### PR TITLE
Fixed wrapping of command descriptions

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/Main.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/Main.java
@@ -13,7 +13,7 @@ public class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     private static final String PROGRAM_NAME = "./bin/new-tool";
-    private static final int COLUMN_SIZE = 200;
+    private static final int COLUMN_SIZE = 120;
 
     private final String[] args;
     private final JCommander commander;

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/SummaryUsageFormatter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/SummaryUsageFormatter.java
@@ -24,14 +24,16 @@ class SummaryUsageFormatter extends DefaultUsageFormatter {
     public void appendCommands(StringBuilder out, int indentCount, int descriptionIndent, String indent) {
         out.append(indent + "  Commands:\n");
         final int longestNameLength = getLengthOfLongestCommandName();
+        final int descriptionNewlineIndent = indentCount + descriptionIndent + longestNameLength;
         for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
             Object arg = commands.getValue().getObjects().get(0);
             Parameters p = arg.getClass().getAnnotation(Parameters.class);
             if (p == null || !p.hidden()) {
                 JCommander.ProgramName programName = commands.getKey();
                 String displayName = StringUtils.rightPad(programName.getDisplayName(), longestNameLength);
-                String description = indent + s(4) + displayName + s(6) + getCommandDescription(programName.getName());
-                wrapDescription(out, indentCount + descriptionIndent, description);
+                String commandDescription = getCommandDescription(programName.getName());
+                String description = s(indentCount) + displayName + s(descriptionIndent) + commandDescription;
+                wrapDescription(out, descriptionNewlineIndent, description);
                 out.append("\n");
             }
         }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportDelimitedFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportDelimitedFilesCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 @Parameters(commandDescription = "Read delimited text files from local, HDFS, and S3 locations using Spark's support " +
-    "defined at https://spark.apache.org/docs/latest/sql-data-sources-csv.html , with each row being written " +
+    "defined at https://spark.apache.org/docs/latest/sql-data-sources-csv.html, with each row being written " +
     "to MarkLogic.")
 public class ImportDelimitedFilesCommand extends AbstractCommand {
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/HelpTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/HelpTest.java
@@ -9,9 +9,19 @@ class HelpTest extends AbstractTest {
     @Test
     void summaryUsage() {
         String stdout = runAndReturnStdout(() -> run());
+
         assertTrue(stdout.contains("View details for the named command."),
-            "Summary usage is expected to show each command its description, but no parameters.");
-        assertFalse(stdout.contains("-host"), "No parameters should be shown with summary usage.");
+            "Summary usage is expected to show each command its description, but no parameters; stdout: " + stdout);
+
+        assertFalse(stdout.contains("-host"), "No parameters should be shown with summary usage; stdout: " + stdout);
+
+        assertTrue(
+            stdout.contains("Read delimited text files from local, HDFS, and S3 locations using Spark's support \n"),
+            "Each command description is expected to wrap at 120 characters. This test may break if/when new commands " +
+                "commands are introduced with long names, or if the import_delimited_files description changes. If " +
+                "so, just update this assertion to capture the description text that occurs before the first newline " +
+                "symbol. stdout: " + stdout
+        );
     }
 
     @Test


### PR DESCRIPTION
120 is a more realistic command size. Manual inspection is ultimately needed to make sure this looks "nice", but all the descriptions are 
wrapping nicely right now. 