### PR TITLE
Added validation of connection parameters

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/HelpCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/HelpCommand.java
@@ -18,6 +18,8 @@ class HelpCommand {
         this.columnSize = columnSize;
     }
 
+    // Sonar's not happy about stderr/stdout usage; will revisit this, ignoring warnings for now.
+    @SuppressWarnings("java:S106")
     void printUsageForCommand(JCommander commander, String commandName) {
         JCommander parsedCommander = commander.getCommands().get(commandName);
         if (parsedCommander == null) {

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/Main.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/Main.java
@@ -27,6 +27,8 @@ public class Main {
     // Only used for logging
     private String selectedCommandName;
 
+    // Sonar's not happy about stderr/stdout usage; will revisit this, ignoring warnings for now.
+    @SuppressWarnings({"java:S106", "java:S4507"})
     public static void main(String[] args) {
         try {
             Main main = new Main(args);
@@ -45,9 +47,9 @@ public class Main {
             }
             if (ex instanceof SparkException && ex.getCause() != null) {
                 // The SparkException message typically has a stacktrace in it that is not likely to be helpful.
-                System.err.println(String.format("\nCommand failed, cause: %s", ex.getCause().getMessage()));
+                System.err.println(String.format("%nCommand failed, cause: %s", ex.getCause().getMessage()));
             } else {
-                System.err.println(String.format("\nCommand failed, cause: %s", ex.getMessage()));
+                System.err.println(String.format("%nCommand failed, cause: %s", ex.getMessage()));
             }
         }
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionInputs.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionInputs.java
@@ -34,7 +34,7 @@ public abstract class ConnectionInputs {
     protected String database;
     protected DatabaseClient.ConnectionType connectionType;
     protected Boolean disableGzippedResponses;
-    protected ConnectionParams.AuthenticationType authType;
+    protected AuthenticationType authType;
     protected String username;
     protected String password;
     protected String certificateFile;

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionParams.java
@@ -1,9 +1,33 @@
 package com.marklogic.newtool.command;
 
+import com.beust.jcommander.IParametersValidator;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
 import com.marklogic.client.DatabaseClient;
 
-public class ConnectionParams extends ConnectionInputs {
+import java.util.Map;
+
+@Parameters(parametersValidators = ConnectionParams.class)
+public class ConnectionParams extends ConnectionInputs implements IParametersValidator {
+
+    @Override
+    public void validate(Map<String, Object> parameters) throws ParameterException {
+        if (parameters.get("--clientUri") == null && parameters.get("--preview") == null) {
+            if (parameters.get("--host") == null) {
+                throw new ParameterException("Must specify a MarkLogic host via --host or --clientUri.");
+            }
+            if (parameters.get("--port") == null) {
+                throw new ParameterException("Must specify a MarkLogic app server port via --port or --clientUri.");
+            }
+
+            String authType = (String) parameters.get("--authType");
+            boolean isDigestOrBasicAuth = authType == null || ("digest".equalsIgnoreCase(authType) || "basic".equalsIgnoreCase(authType));
+            if (isDigestOrBasicAuth && parameters.get("--username") == null) {
+                throw new ParameterException("Must specify a MarkLogic user via --username when using 'BASIC' or 'DIGEST' authentication.");
+            }
+        }
+    }
 
     @Parameter(
         names = {"--clientUri"},
@@ -65,7 +89,7 @@ public class ConnectionParams extends ConnectionInputs {
         names = "--authType",
         description = "Type of authentication to use."
     )
-    public void setAuthType(ConnectionParams.AuthenticationType authType) {
+    public void setAuthType(AuthenticationType authType) {
         this.authType = authType;
     }
 

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/OutputConnectionParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/OutputConnectionParams.java
@@ -63,7 +63,7 @@ public class OutputConnectionParams extends ConnectionInputs {
         names = "--outputAuthType",
         description = "Type of authentication to use."
     )
-    public void setAuthType(ConnectionParams.AuthenticationType authType) {
+    public void setAuthType(AuthenticationType authType) {
         this.authType = authType;
     }
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/HandleErrorTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/HandleErrorTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
  * when running on Spark on Java 9 or higher. Our ETL tool prevents this, so you can ignore it when analyzing the
  * logging in these tests.
  */
+// Suppressing Sonar warnings about tests not having assertions as that is not yet possible with this test.
+@SuppressWarnings("java:S2699")
 class HandleErrorTest extends AbstractTest {
 
     @Test

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/CopyOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/CopyOptionsTest.java
@@ -39,6 +39,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
     @Test
     void allWriteParams() {
         CopyCommand command = (CopyCommand) getCommand("copy",
+            "--clientUri", "someone:word@somehost:7000",
             "--outputAbortOnFailure", "false",
             "--outputBatchSize", "123",
             "--outputCollections", "c1,c2",
@@ -75,6 +76,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
     void allOutputConnectionParams() {
         CopyCommand command = (CopyCommand) getCommand(
             "copy",
+            "--clientUri", "someone:word@somehost:7000",
             "--outputClientUri", "user:password@host:8000",
             "--outputHost", "localhost",
             "--outputPort", "8123",

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ReprocessOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ReprocessOptionsTest.java
@@ -13,6 +13,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readInvoke() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readInvoke", "/my/invoke.sjs",
             "--readPartitionsInvoke", "/my/other-invoke.sjs",
             "--readVar", "param1=value1",
@@ -31,6 +32,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeInvoke() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readInvoke", "/my/invoke.sjs",
             "--writeInvoke", "/my/invoke.sjs",
             "--externalVariableName", "MY_VAR",
@@ -55,6 +57,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readJavascript() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readJavascript", "fn.currentDate()",
             "--readPartitionsJavascript", "console.log('')",
             "--writeJavascript", "fn.currentDate()"
@@ -69,6 +72,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeJavascript() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readJavascript", "fn.currentDate()",
             "--writeJavascript", "fn.currentDate()"
         );
@@ -81,6 +85,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readXquery() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readXquery", "fn:current-date()",
             "--readPartitionsXquery", "xdmp:log('')",
             "--writeXquery", "fn:current-date()"
@@ -95,6 +100,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeXquery() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
+            "--clientUri", "user:password@host:8000",
             "--readXquery", "fn:current-date()",
             "--writeXquery", "fn:current-date()"
         );

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ValidateMarkLogicConnectionTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ValidateMarkLogicConnectionTest.java
@@ -1,0 +1,63 @@
+package com.marklogic.newtool.command;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates that the essentials for a MarkLogic connection are available.
+ */
+class ValidateMarkLogicConnectionTest extends AbstractTest {
+
+    @Test
+    void noHost() {
+        String output = runAndReturnStderr(() -> run(
+            "import_files",
+            "--path", "src/test/resources/mixed-files"
+        ));
+
+        assertTrue(output.contains("Must specify a MarkLogic host via --host or --clientUri."),
+            "Unexpected stderr: " + output);
+    }
+
+    @Test
+    void noPort() {
+        String output = runAndReturnStderr(() -> run(
+            "import_files",
+            "--path", "src/test/resources/mixed-files",
+            "--host", getDatabaseClient().getHost()
+        ));
+
+        assertTrue(output.contains("Must specify a MarkLogic app server port via --port or --clientUri."),
+            "Unexpected stderr: " + output);
+    }
+
+    @Test
+    void noUsername() {
+        String output = runAndReturnStderr(() -> run(
+            "import_files",
+            "--path", "src/test/resources/mixed-files",
+            "--host", getDatabaseClient().getHost(),
+            "--port", Integer.toString(getDatabaseClient().getPort())
+        ));
+
+        assertTrue(output.contains("Must specify a MarkLogic user via --username when using 'BASIC' or 'DIGEST' authentication."),
+            "Unexpected stderr: " + output);
+    }
+
+    /**
+     * This shows a gap where errors from the Spark connector can reference Spark option names that don't make any sense
+     * to an ETL user. MLE-12333 will improve this.
+     */
+    @Test
+    void badClientUri() {
+        String output = runAndReturnStderr(() -> run(
+            "import_files",
+            "--path", "src/test/resources/mixed-files",
+            "--clientUri", "admin-missing-password@localhost:8003"
+        ));
+
+        assertTrue(output.contains("Invalid value for spark.marklogic.client.uri"), "Unexpected output: " + output);
+    }
+}


### PR DESCRIPTION
There's more we can do here later on, like validating that a Kerberos principal is set when choosing Kerberos authentication. But this captures the basic, common stuff that users may run into. 

Addressed some Sonar issues as well; going to have to revisit stderr/stdout usage. 