### PR TITLE
MLE-12335 Support config options for Avro and ORC

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportAvroFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportAvroFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import org.apache.spark.sql.SparkSession;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,8 +14,9 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand {
 
     @DynamicParameter(
         names = "-P",
-        description = "Specify any Spark Avro option defined at " +
-            "https://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true."
+        description = "Specify any Spark Avro option or configuration item defined at" +
+            "https://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true or " +
+            "-Pspark.sql.avro.filterPushdown.enabled=false."
     )
     private Map<String, String> avroParams = new HashMap<>();
 
@@ -24,9 +26,18 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand {
     }
 
     @Override
+    protected void modifySparkSession(SparkSession session) {
+        avroParams.entrySet().stream()
+            .filter(OptionsUtil::isSparkConfigurationOption)
+            .forEach(entry -> session.conf().set(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
     protected Map<String, String> makeReadOptions() {
         Map<String, String> options = super.makeReadOptions();
-        options.putAll(avroParams);
+        avroParams.entrySet().stream()
+            .filter(OptionsUtil::isSparkDataSourceOption)
+            .forEach(entry -> options.put(entry.getKey(), entry.getValue()));
         return options;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportOrcFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportOrcFilesCommand.java
@@ -2,17 +2,21 @@ package com.marklogic.newtool.command;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import org.apache.spark.sql.SparkSession;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Parameters(commandDescription = "Read ORC files from local, HDFS, and S3 locations using Spark's support " +
-    "with each row being written to MarkLogic.")
-public class ImportOrcFilesCommand extends AbstractImportFilesCommand{
+    "defined at https://spark.apache.org/docs/latest/sql-data-sources-orc.html, with each row being " +
+    "written to MarkLogic.")
+public class ImportOrcFilesCommand extends AbstractImportFilesCommand {
+
     @DynamicParameter(
         names = "-P",
-        description = "Specify any Spark ORC option defined at "  +
-                      "https://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -Pspark.sql.orc.filterPushdown=true."
+        description = "Specify any Spark ORC option or configuration item defined at " +
+            "https://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -PmergeSchema=true or " +
+            "-Pspark.sql.orc.filterPushdown=false."
     )
     private Map<String, String> orcParams = new HashMap<>();
 
@@ -22,9 +26,18 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand{
     }
 
     @Override
+    protected void modifySparkSession(SparkSession session) {
+        orcParams.entrySet().stream()
+            .filter(OptionsUtil::isSparkConfigurationOption)
+            .forEach(entry -> session.conf().set(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
     protected Map<String, String> makeReadOptions() {
         Map<String, String> options = super.makeReadOptions();
-        options.putAll(orcParams);
+        orcParams.entrySet().stream()
+            .filter(OptionsUtil::isSparkDataSourceOption)
+            .forEach(entry -> options.put(entry.getKey(), entry.getValue()));
         return options;
     }
 }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesOptionsTest.java
@@ -1,0 +1,30 @@
+package com.marklogic.newtool.command;
+
+import com.marklogic.newtool.AbstractOptionsTest;
+import com.marklogic.newtool.command.ImportAvroFilesCommand;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ImportAvroFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        ImportAvroFilesCommand command = (ImportAvroFilesCommand) getCommand(
+            "import_avro_files",
+            "--path", "/doesnt/matter",
+            "-PdatetimeRebaseMode=CORRECTED",
+            "-Pspark.sql.parquet.filterPushdown=false",
+            "--preview", "10"
+        );
+
+        Map<String, String> options = command.makeReadOptions();
+        assertOptions(options, "datetimeRebaseMode", "CORRECTED");
+        assertFalse(options.containsKey("spark.sql.parquet.filterPushdown"),
+            "Dynamic params starting with 'spark.sql' should not be added to the 'read' options. They should " +
+                "instead be added to the SparkConf object, per the documentation at " +
+                "https://spark.apache.org/docs/latest/sql-data-sources-avro.html.");
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesTest.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ImportAvroFilesTest extends AbstractTest {
 
@@ -46,6 +45,23 @@ class ImportAvroFilesTest extends AbstractTest {
         verifyColorDoc("/avro/blue.json", "1", "blue", true);
         verifyColorDoc("/avro/red.json", "2", "red", false);
         verifyColorDoc("/avro/green.json", "3", "green", true);
+    }
+
+    @Test
+    void badConfigurationItem() {
+        String stderr = runAndReturnStderr(() ->
+            run(
+                "import_avro_files",
+                "--path", "src/test/resources/avro/*",
+                "--clientUri", makeClientUri(),
+                "--permissions", DEFAULT_PERMISSIONS,
+                "-Pspark.sql.parquet.filterPushdown=invalid-value"
+            )
+        );
+
+        assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
+            "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
+                "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
     }
 
     private void verifyColorDoc(String uri, String expectedNumber, String expectedColor, boolean expectedFlag) {

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesOptionsTest.java
@@ -1,0 +1,29 @@
+package com.marklogic.newtool.command;
+
+import com.marklogic.newtool.AbstractOptionsTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ImportOrcFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        ImportOrcFilesCommand command = (ImportOrcFilesCommand) getCommand(
+            "import_orc_files",
+            "--path", "/doesnt/matter",
+            "-PmergeSchema=true",
+            "-Pspark.sql.parquet.filterPushdown=false",
+            "--preview", "10"
+        );
+
+        Map<String, String> options = command.makeReadOptions();
+        assertOptions(options, "mergeSchema", "true");
+        assertFalse(options.containsKey("spark.sql.parquet.filterPushdown"),
+            "Dynamic params starting with 'spark.sql' should not be added to the 'read' options. They should " +
+                "instead be added to the SparkConf object, per the documentation at " +
+                "https://spark.apache.org/docs/latest/sql-data-sources-orc.html.");
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesTest.java
@@ -49,6 +49,23 @@ class ImportOrcFilesTest extends AbstractTest {
         verifyDocContent("/orc-compressed-test/author/author9.json");
     }
 
+    @Test
+    void badConfigurationItem() {
+        String stderr = runAndReturnStderr(() ->
+            run(
+                "import_orc_files",
+                "--path", "src/test/resources/orc-files",
+                "--clientUri", makeClientUri(),
+                "--permissions", DEFAULT_PERMISSIONS,
+                "-Pspark.sql.parquet.filterPushdown=invalid-value"
+            )
+        );
+
+        assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
+            "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
+                "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
+    }
+
     private void verifyDocContent(String uri) {
         JSONDocumentManager documentManager = getDatabaseClient().newJSONDocumentManager();
         String docContent = documentManager.read(uri).next().getContent(new StringHandle()).toString();


### PR DESCRIPTION
Same as what was done for Parquet. 