### PR TITLE
MLE-12866 uriTemplate no longer appears for import_rdf_files

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportJdbcCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportJdbcCommand.java
@@ -12,7 +12,7 @@ import java.util.*;
 public class ImportJdbcCommand extends AbstractCommand {
 
     @ParametersDelegate
-    private WriteDocumentParams writeDocumentParams = new WriteDocumentParams();
+    private WriteDocumentWithTemplateParams writeDocumentParams = new WriteDocumentWithTemplateParams();
 
     @ParametersDelegate
     private JdbcParams jdbcParams = new JdbcParams();

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
@@ -1,0 +1,46 @@
+package com.marklogic.newtool.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines common parameters for any import command that reads from files.
+ */
+public class ReadFilesParams {
+
+    @Parameter(required = true, names = "--path", description = "Specify one or more path expressions for selecting files to import.")
+    private List<String> paths = new ArrayList<>();
+
+    @Parameter(names = "--filter", description = "A glob filter for selecting only files with file names matching the pattern.")
+    private String filter;
+
+    @Parameter(names = "--recursiveFileLookup", arity = 1, description = "If true, files will be loaded recursively from child directories and partition inferring is disabled.")
+    private Boolean recursiveFileLookup = true;
+
+    @ParametersDelegate
+    private S3Params s3Params = new S3Params();
+
+    public Map<String, String> makeOptions() {
+        Map<String, String> options = new HashMap<>();
+        if (filter != null) {
+            options.put("pathGlobFilter", filter);
+        }
+        if (recursiveFileLookup != null) {
+            options.put("recursiveFileLookup", recursiveFileLookup.toString());
+        }
+        return options;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public S3Params getS3Params() {
+        return s3Params;
+    }
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/WriteDocumentParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/WriteDocumentParams.java
@@ -5,6 +5,10 @@ import com.marklogic.spark.Options;
 
 import java.util.Map;
 
+/**
+ * Defines all basic params for writing documents. Does not include support for a URI template, as that is not always
+ * relevant nor possible depending on what kind of data is being imported.
+ */
 public class WriteDocumentParams {
 
     // See https://jcommander.org/#_boolean for a description of the 'arity' field.
@@ -81,13 +85,6 @@ public class WriteDocumentParams {
     )
     private String uriSuffix;
 
-    @Parameter(
-        names = "--uriTemplate",
-        description = "String defining a template for constructing each document URI. " +
-            "See https://marklogic.github.io/marklogic-spark-connector/writing.html for more information."
-    )
-    private String uriTemplate;
-
     public Map<String, String> makeOptions() {
         return OptionsUtil.makeOptions(
             Options.WRITE_ABORT_ON_FAILURE, Boolean.toString(abortOnFailure),
@@ -101,8 +98,7 @@ public class WriteDocumentParams {
             Options.WRITE_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
             Options.WRITE_URI_PREFIX, uriPrefix,
             Options.WRITE_URI_REPLACE, uriReplace,
-            Options.WRITE_URI_SUFFIX, uriSuffix,
-            Options.WRITE_URI_TEMPLATE, uriTemplate
+            Options.WRITE_URI_SUFFIX, uriSuffix
         );
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/WriteDocumentWithTemplateParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/WriteDocumentWithTemplateParams.java
@@ -1,0 +1,27 @@
+package com.marklogic.newtool.command;
+
+import com.beust.jcommander.Parameter;
+import com.marklogic.spark.Options;
+
+import java.util.Map;
+
+/**
+ * For commands where defining URIs via a template makes sense.
+ */
+public class WriteDocumentWithTemplateParams extends WriteDocumentParams {
+
+    @Parameter(
+        names = "--uriTemplate",
+        description = "String defining a template for constructing each document URI. " +
+            "See https://marklogic.github.io/marklogic-spark-connector/writing.html for more information."
+    )
+    private String uriTemplate;
+
+    @Override
+    public Map<String, String> makeOptions() {
+        return OptionsUtil.addOptions(
+            super.makeOptions(),
+            Options.WRITE_URI_TEMPLATE, uriTemplate
+        );
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/CopyOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/CopyOptionsTest.java
@@ -137,8 +137,11 @@ class CopyOptionsTest extends AbstractOptionsTest {
 
     @Test
     void testOutputParameterCount() {
-        int copyCommandCount = getOutputParameterCountInCopyCommand();
-        int writeDocumentParamsCount = getParameterCount(WriteDocumentParams.class);
+        final int copyCommandCount = getOutputParameterCountInCopyCommand();
+
+        // Can't find a way to get the count from the subclass, so gotta get counts from both subclass and parent class.
+        final int writeDocumentParamsCount =
+            getParameterCount(WriteDocumentWithTemplateParams.class) + getParameterCount(WriteDocumentParams.class);
 
         assertEquals(copyCommandCount, writeDocumentParamsCount,
             "Expecting the CopyCommand to declare one Parameter field for each Parameter field found in " +

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportRdfFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportRdfFilesTest.java
@@ -3,6 +3,8 @@ package com.marklogic.newtool.command;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class ImportRdfFilesTest extends AbstractTest {
 
     private static final String DEFAULT_MARKLOGIC_GRAPH = "http://marklogic.com/semantics#default-graph";
@@ -102,5 +104,23 @@ class ImportRdfFilesTest extends AbstractTest {
                 "graph collections",
             "all-my-rdf", 7
         );
+    }
+
+    @Test
+    void uriTemplateOptionShouldNotWork() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_rdf_files",
+            "--path", "src/test/resources/rdf/englishlocale.ttl",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "my-triples",
+            "--uriTemplate", "/test/{uri}"
+        ));
+
+        // We may want to eventually modify this JCommander error, as it's not intuitive as to what it means.
+        assertTrue(stderr.contains("Was passed main parameter '--uriTemplate'"),
+            "Was expecting an error due to --uriTemplate not being supported for importing RDF files, as it doesn't " +
+                "have any meaningful use case since we default to '/triplestore/uuid.xml' for managed triples " +
+                "documents. Unexpected stderr: " + stderr);
     }
 }


### PR DESCRIPTION
This was a bit awkward to do, as it required removing `uriTemplate` from `WriteDocumentParams`. So I made a subclass - `WriteDocumentWithTemplateParams` - whose name I'm not crazy about yet. 

Also made `ReadFilesParams` so that the command for importing RDF files and the abstract command for importing any kind of files don't have any duplication. 