### PR TITLE
MLE-12632 Added abortOnReadFailure for import files using our connector

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportAggregateXmlCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ImportAggregateXmlCommand.java
@@ -11,21 +11,28 @@ import java.util.Map;
 public class ImportAggregateXmlCommand extends AbstractImportFilesCommand {
 
     @Parameter(required = true, names = "--element",
-        description = "Specifies the local name of the element to use as the root of each document.")
+        description = "Specifies the local name of the element to use as the root of each document."
+    )
     private String element;
 
-    @Parameter(required = false, names = "--namespace", description = "Specifies namespace where the input data resides.")
+    @Parameter(names = "--namespace",
+        description = "Specifies the namespace of the element to use as the root of each document."
+    )
     private String namespace;
 
-    @Parameter(required = false, names = "--uriElement",
-        description = "Specifies the local name of the element used for creating uris of docs inserted into MarkLogic.")
+    @Parameter(names = "--uriElement",
+        description = "Specifies the local name of the element used for creating URIs."
+    )
     private String uriElement;
 
-    @Parameter(required = false, names = "--uriNamespace",
-        description = "Specifies namespace where the input data resides.")
+    @Parameter(names = "--uriNamespace",
+        description = "Specifies the namespace of the element used for creating URIs."
+    )
     private String uriNamespace;
 
-    @Parameter(names = "--compression", description = "When importing compressed files, specify the type of compression used.")
+    @Parameter(names = "--compression",
+        description = "When importing compressed files, specify the type of compression used."
+    )
     private CompressionType compression;
 
     @Override
@@ -35,14 +42,13 @@ public class ImportAggregateXmlCommand extends AbstractImportFilesCommand {
 
     @Override
     protected Map<String, String> makeReadOptions() {
-        Map<String, String> options = super.makeReadOptions();
-        options.put(Options.READ_AGGREGATES_XML_ELEMENT, element);
-        options.put(Options.READ_AGGREGATES_XML_NAMESPACE, namespace);
-        options.put(Options.READ_AGGREGATES_XML_URI_ELEMENT, uriElement);
-        options.put(Options.READ_AGGREGATES_XML_URI_NAMESPACE, uriNamespace);
-        if (compression != null) {
-            options.put(Options.READ_FILES_COMPRESSION, compression.name());
-        }
-        return options;
+        return OptionsUtil.addOptions(
+            super.makeReadOptions(),
+            Options.READ_AGGREGATES_XML_ELEMENT, element,
+            Options.READ_AGGREGATES_XML_NAMESPACE, namespace,
+            Options.READ_AGGREGATES_XML_URI_ELEMENT, uriElement,
+            Options.READ_AGGREGATES_XML_URI_NAMESPACE, uriNamespace,
+            Options.READ_FILES_COMPRESSION, compression != null ? compression.name() : null
+        );
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import com.marklogic.spark.Options;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,6 +17,11 @@ public class ReadFilesParams {
     @Parameter(required = true, names = "--path", description = "Specify one or more path expressions for selecting files to import.")
     private List<String> paths = new ArrayList<>();
 
+    @Parameter(names = "--abortOnReadFailure",
+        description = "Causes the command to abort when it fails to read a file."
+    )
+    private Boolean abortOnReadFailure = false;
+
     @Parameter(names = "--filter", description = "A glob filter for selecting only files with file names matching the pattern.")
     private String filter;
 
@@ -27,6 +33,11 @@ public class ReadFilesParams {
 
     public Map<String, String> makeOptions() {
         Map<String, String> options = new HashMap<>();
+        if (abortOnReadFailure != null && abortOnReadFailure) {
+            options.put(Options.READ_FILES_ABORT_ON_FAILURE, "true");
+        } else {
+            options.put(Options.READ_FILES_ABORT_ON_FAILURE, "false");
+        }
         if (filter != null) {
             options.put("pathGlobFilter", filter);
         }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportRdfFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportRdfFilesTest.java
@@ -123,4 +123,34 @@ class ImportRdfFilesTest extends AbstractTest {
                 "have any meaningful use case since we default to '/triplestore/uuid.xml' for managed triples " +
                 "documents. Unexpected stderr: " + stderr);
     }
+
+    @Test
+    void invalidFileDontAbort() {
+        run(
+            "import_rdf_files",
+            "--path", "src/test/resources/mixed-files/hello2.txt.gz",
+            "--path", "src/test/resources/rdf/englishlocale.ttl",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "my-triples"
+        );
+
+        assertCollectionSize("An error should have been logged for the non-RDF hello2.txt.gz file but it should not " +
+            "have caused the command to fail, which defaults to not aborting on read failure.", "my-triples", 1);
+    }
+
+    @Test
+    void invalidFileAbort() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_rdf_files",
+            "--path", "src/test/resources/mixed-files/hello2.txt.gz",
+            "--abortOnReadFailure",
+            "--clientUri", makeClientUri(),
+            "--collections", "my-triples"
+        ));
+
+        assertTrue(stderr.contains("Command failed, cause: Unable to read file at"),
+            "Unexpected stderr: " + stderr);
+        assertCollectionSize("my-triples", 0);
+    }
 }


### PR DESCRIPTION
Halfway done. Still need to account for the commands that import files that use a Spark data source. But some incremental progress here. 

One rename - `ImportXmlAggregateTest` to `ImportAggregateXmlFilesTest`.