### PR TITLE
MLE-12632 Added abortOnReadFailure for commands using Spark readers

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ReadFilesParams.java
@@ -34,10 +34,11 @@ public class ReadFilesParams {
     public Map<String, String> makeOptions() {
         Map<String, String> options = new HashMap<>();
         if (abortOnReadFailure != null && abortOnReadFailure) {
-            options.put(Options.READ_FILES_ABORT_ON_FAILURE, "true");
+            addOptionsToFailOnReadError(options);
         } else {
-            options.put(Options.READ_FILES_ABORT_ON_FAILURE, "false");
+            addOptionsToNotFailOnReadError(options);
         }
+
         if (filter != null) {
             options.put("pathGlobFilter", filter);
         }
@@ -45,6 +46,34 @@ public class ReadFilesParams {
             options.put("recursiveFileLookup", recursiveFileLookup.toString());
         }
         return options;
+    }
+
+    /**
+     * For the Spark data sources, we don't get the ideal user experience here, as we haven't figured out if it's
+     * possible to configure Spark to log something about failed files/rows, which we're able to do with our own
+     * connector. So the Spark reader will skip over invalid data without any logging for the user to see. This will
+     * likely be fine for a scenario such as trying to read Avro files with a Parquet reader, where the user shouldn't
+     * have an expectation that the Avro files are processed correctly.
+     *
+     * @param options
+     */
+    private void addOptionsToNotFailOnReadError(Map<String, String> options) {
+        // For commands that use the MarkLogic connector to read files.
+        options.put(Options.READ_FILES_ABORT_ON_FAILURE, "false");
+        // For commands that use Spark JSON / CSV.
+        options.put("mode", "DROPMALFORMED");
+        // For commands that use Spark Parquet / Avro / ORC. This does not appear to affect Spark JSON / CSV, as
+        // those use the 'mode' option to determine what to do with corrupt data.
+        options.put("ignoreCorruptFiles", "true");
+    }
+
+    private void addOptionsToFailOnReadError(Map<String, String> options) {
+        // For commands that use the MarkLogic connector to read files.
+        options.put(Options.READ_FILES_ABORT_ON_FAILURE, "true");
+        // For commands that use Spark JSON / CSV to read files.
+        options.put("mode", "FAILFAST");
+        // For commands that use Spark Parquet / Avro / ORC.
+        options.put("ignoreCorruptFiles", "false");
     }
 
     public List<String> getPaths() {

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportAvroFilesTest.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ImportAvroFilesTest extends AbstractTest {
 
@@ -78,6 +77,36 @@ class ImportAvroFilesTest extends AbstractTest {
         assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
             "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
                 "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
+    }
+
+    @Test
+    void dontAbortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_avro_files",
+            "--path", "src/test/resources/avro/colors.avro",
+            "--path", "src/test/resources/json-files/array-of-objects.json",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "avro-data"
+        ));
+
+        assertCollectionSize("The colors.avro file should have been processed correctly", "avro-data", 3);
+        assertFalse(stderr.contains("Command failed"), "The command should default to ignoreCorruptFiles=true for " +
+            "reading Avro files so that invalid files do not cause the command to fail; stderr: " + stderr);
+    }
+
+    @Test
+    void abortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_avro_files",
+            "--path", "src/test/resources/json-files/array-of-objects.json",
+            "--abortOnReadFailure",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS
+        ));
+
+        System.out.println(stderr);
+        assertTrue(stderr.contains("Command failed, cause: Not an Avro data file"), "Actual stderr: " + stderr);
     }
 
     private void verifyColorDoc(String uri, String expectedNumber, String expectedColor, boolean expectedFlag) {

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportDelimitedFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportDelimitedFilesTest.java
@@ -2,6 +2,9 @@ package com.marklogic.newtool.command;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.marklogic.client.io.JacksonHandle;
+import com.marklogic.client.query.QueryManager;
+import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -140,6 +143,57 @@ class ImportDelimitedFilesTest extends AbstractTest {
         String message = "Unexpected stdout: " + stdout;
         assertTrue(stdout.contains("number | 1"), message);
         assertFalse(stdout.contains("number | 2"), message);
+    }
+
+    @Test
+    void dontAbortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_delimited_files",
+            "--path", "src/test/resources/delimited-files/three-rows.csv",
+            "--path", "src/test/resources/xml-file/single-xml.zip",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "delimited-test"
+        ));
+
+        // Must use this technique to get URIs, as the helper method in marklogic-junit fetches documents and the
+        // documents have some encoding issues in them.
+        QueryManager queryManager = getDatabaseClient().newQueryManager();
+        StructuredQueryDefinition query = queryManager.newStructuredQueryBuilder().collection("delimited-test");
+        queryManager.setView(QueryManager.QueryView.METADATA);
+        JsonNode results = queryManager.search(query, new JacksonHandle()).get();
+        int uriCount = results.get("total").asInt();
+        assertTrue(
+            uriCount > 0,
+            "Spark CSV is very liberal in terms of what it allows. It will extract lines from " +
+            "binary files like single-xml.zip. What's not clear is how Spark chooses a schema when it gets a " +
+            "non-delimited file like single-xml.zip. In this test, it consistently chooses single-xml.zip to use " +
+            "as the source of a schema, which results in a gibberish column name and only one row being created. " +
+            "It's not clear if this process is indeterminate and thus Spark CSV may choose three-rows.csv sometimes " +
+            "too. So we expect at least one URI to be written, as the command should default to not failing. " +
+            "Actual URI count: " + uriCount
+        );
+
+        assertFalse(stderr.contains("Command failed"), "The command should not have failed because it defaults to " +
+            "mode=DROPMALFORMED (mode=PERMISSIVE would also result in the command not failing); stderr: " + stderr);
+    }
+
+    @Test
+    void abortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_delimited_files",
+            "--path", "src/test/resources/delimited-files/three-rows.csv",
+            "--path", "src/test/resources/xml-file/single-xml.zip",
+            "--abortOnReadFailure",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "delimited-test"
+        ));
+
+        assertCollectionSize("delimited-test", 0);
+        assertTrue(stderr.contains("Command failed, cause: [MALFORMED_RECORD_IN_PARSING]"), "The command should " +
+            "have failed due to --abortOnReadFailure being included. This should result in the 'mode' option being " +
+            "set to FAILFAST.");
     }
 
     private void verifyDoc(String uri, int expectedNumber, String expectedColor, boolean expectedFlag) {

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ImportOrcFilesTest.java
@@ -6,8 +6,7 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 class ImportOrcFilesTest extends AbstractTest {
@@ -82,6 +81,37 @@ class ImportOrcFilesTest extends AbstractTest {
         assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
             "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
                 "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
+    }
+
+    @Test
+    void dontAbortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_orc_files",
+            "--path", "src/test/resources/orc-files/authors.orc",
+            "--path", "src/test/resources/avro/colors.avro",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "orc-data"
+        ));
+
+        assertCollectionSize("The authors.orc file should have been processed correctly", "orc-data", 15);
+        assertFalse(stderr.contains("Command failed"), "The command should default to ignoreCorruptFiles=true for " +
+            "reading ORC files so that invalid files do not cause the command to fail; stderr: " + stderr);
+    }
+
+    @Test
+    void abortOnReadFailure() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_parquet_files",
+            "--path", "src/test/resources/avro/colors.avro",
+            "--abortOnReadFailure",
+            "--clientUri", makeClientUri(),
+            "--permissions", DEFAULT_PERMISSIONS
+        ));
+
+        assertTrue(stderr.contains("Command failed") && stderr.contains("Could not read footer for file"),
+            "The command should have failed because Spark could not read the footer of the invalid Avro file; " +
+                "stderr: " + stderr);
     }
 
     private void verifyDocContent(String uri) {


### PR DESCRIPTION
The tests primarily capture the behavior of various Spark configuration options. 