### PR TITLE
Renamed `AbstractExportRowsToFilesCommand`

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/AbstractExportRowsToFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/AbstractExportRowsToFilesCommand.java
@@ -8,7 +8,11 @@ import org.apache.spark.sql.*;
 
 import java.util.Map;
 
-public abstract class AbstractExportFilesCommand extends AbstractCommand {
+/**
+ * Support class for concrete commands that want to run an Optic DSL query to read rows and then write them to one or
+ * more files.
+ */
+abstract class AbstractExportRowsToFilesCommand extends AbstractCommand {
 
     @Parameter(required = true, names = "--path", description = "Path expression for where files should be written.")
     private String path;
@@ -24,8 +28,15 @@ public abstract class AbstractExportFilesCommand extends AbstractCommand {
     @ParametersDelegate
     private S3Params s3Params = new S3Params();
 
+    /**
+     * @return subclass must return the Spark data format for the desired output file.
+     */
     protected abstract String getWriteFormat();
 
+    /**
+     * Allows subclass a chance to provide their own output-specific write options.
+     * @return
+     */
     protected abstract Map<String, String> makeWriteOptions();
 
     @Override

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportAvroFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportAvroFilesCommand.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Parameters(commandDescription = "Read rows via Optic from MarkLogic and write them to Avro files on a local filesystem, HDFS, or S3.")
-public class ExportAvroFilesCommand extends AbstractExportFilesCommand {
+public class ExportAvroFilesCommand extends AbstractExportRowsToFilesCommand {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportOrcFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportOrcFilesCommand.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Parameters(commandDescription = "Read rows via Optic from MarkLogic and write them to ORC files on a local filesystem, HDFS, or S3.")
-public class ExportOrcFilesCommand extends AbstractExportFilesCommand {
+public class ExportOrcFilesCommand extends AbstractExportRowsToFilesCommand {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportParquetFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/export/ExportParquetFilesCommand.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Parameters(commandDescription = "Read rows via Optic from MarkLogic and write them to Parquet files on a local filesystem, HDFS, or S3.")
-public class ExportParquetFilesCommand extends AbstractExportFilesCommand {
+public class ExportParquetFilesCommand extends AbstractExportRowsToFilesCommand {
 
     @DynamicParameter(
         names = "-P",


### PR DESCRIPTION
Wanted to make it more clear that it's strictly for commands that read rows instead of documents, and then write them to files.  No functional change. 