### PR TITLE
More docs for 0.2 release

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -128,7 +128,17 @@ The following shows an example of only importing the first 10 rows from a delimi
 
 ## Repartitioning
 
-TODO - `--repartition`.
+When NT reads data from a data source, it does so via one or more "partitions" that allows for data to be read in 
+parallel. The number of partitions depends on the type of data source and may be configurable depending on which 
+command you are running. 
+
+When NT writes the data it has read, a separate worker is created for each partition, thereby allowing for data to be
+written in parallel. 
+
+You can adjust the number of partitions and thus the number of workers used for writing data via the `--repartition` 
+input, which accepts a number greater than zero. You may find better performance by increasing the number of partitions
+for writing data to MarkLogic. In other cases, such as exporting data to ZIP files, you can control how many ZIP files
+are written via `--repartition`. 
 
 ## Viewing a stacktrace
 

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -4,4 +4,63 @@ title: Copying Data
 nav_order: 6
 ---
 
-This will eventually document the command for copying data in MarkLogic.
+NT supports copying documents and their associated metadata from one database to another.
+
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+## Usage
+
+Similar to the commands for [exporting documents](export/export-documents.md), the `copy` command requires that you 
+specify the documents you wish to copy, along with connection information for the MarkLogic database to wish to read
+from.
+
+The following options control which documents are read from MarkLogic:
+
+| Option | Description | 
+| --- |--- |
+| --stringQuery | A string query utilizing MarkLogic's search grammar. |
+| --query | A structured, serialized CTS, or combined query expressed as JSON or XML. |
+| --options | Name of a REST API search options document; typically used with a string query. |
+| --collections | Comma-delimited sequence of collection names. |
+| --directory | A database directory for constraining on URIs. |
+
+You must specify at least one of `--stringQuery`, `--query`, `--collections`, or `--directory`. You may specify any
+combination of those options as well.
+
+The `copy` command then requires that you specify connection information via for the target database that the documents
+will be copied into. Each of the [connection options](common-options.md) can be used for this target database, but with
+`output` as a prefix so that they are distinguished from the connections used for the source database. For example, 
+`--outputClientUri` is used to specify a connection string for the target database. If you are copying the documents
+to the same database that they were read from, you can omit output connection options.
+
+The following shows an example of copying documents from a collection to a different database in the same MarkLogic 
+cluster:
+
+```
+./bin/nt copy \
+  --clientUri "user:password@localhost:8000" \
+  --collections "example" \
+  --outputClientUri "user:password@localhost:8000" \
+  --outputDatabase "target-database"
+```
+
+## Controlling what metadata is read
+
+The `--categories` option controls what metadata is read from the source database. The option defaults to a value of 
+`content,metadata`, resulting in the document content and all of its metadata being read for each matching URI. 
+In addition to `content` and `metadata`, valid choices include `collections`, `permissions`, `quality`, `properties`, 
+and `metadatavalues`. Choices should be concatenated together into a comma-delimited string. For example, the 
+following will only read documents and their collections and permissions:
+
+    --categories content,collections,permissions
+
+## Controlling how documents are written
+
+The `copy` command supports many of the same options as the [import commands](import/common-import-features.md) for 
+writing documents. But similar to the output connection options, each option for controlling how documents are written
+is prefixed with `output`. For example, to specify collections for the documents, `--outputCollections` is used instead
+of `--collections`.

--- a/docs/import/import-files/archives.md
+++ b/docs/import/import-files/archives.md
@@ -7,7 +7,7 @@ nav_order: 7
 ---
 
 NT can import archive files containing documents and their associated metadata. This includes archives written via 
-the `export_archives` command (TODO add link) as well as archives written by 
+the [`export_archives` command](../../export/export-archives.md) as well as archives written by 
 [MarkLogic Content Pump](https://docs.marklogic.com/11.0/guide/mlcp-guide/en/importing-content-into-marklogic-server/loading-content-and-metadata-from-an-archive.html), 
 which are hereafter referred to as "MLCP archives".
 

--- a/docs/import/tuning-performance.md
+++ b/docs/import/tuning-performance.md
@@ -39,4 +39,6 @@ The rule of thumb can thus be expressed as:
 
 ### Direct connections to each host
 
-TODO `--connectionType direct` (which then enables the underlying DMSDK support for direct connections to hosts).
+In a scenario where NT can connect directly to each host in your MarkLogic cluster without a load balancer being 
+present, you can set the `--connectionType` option to a value of `direct`. NT will then effectively act as a load 
+balancer by distributing work across each host in the cluster. 


### PR DESCRIPTION
I think `copy` needs more info, like a list of all the "output" options. But this will do for now. 