### PR TITLE
Renaming --clientUri to --connectionString

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ You can cause a failure with MarkLogic that caused the command to stop:
 
 ```
 ./nt/bin/nt import_files --path "new-tool-cli/src/test/resources/mixed-files/*" \
-  --clientUri "new-tool-user:password@localhost:8000" \
+  --connectionString "new-tool-user:password@localhost:8000" \
   --repartition 1 \
   --abortOnWriteFailure \
   --permissions "invalid-role,read,new-tool-role,update" \
@@ -151,7 +151,7 @@ You can cause a failure and ask to see the full stacktrace (often noisy and not 
 
 ```
 ./nt/bin/nt import_files --path "new-tool-cli/src/test/resources/mixed-files/*" \
-  --clientUri "new-tool-user:password@localhost:8000" \
+  --connectionString "new-tool-user:password@localhost:8000" \
   --repartition 1 \
   --permissions "invalid-role,read,new-tool-role,update" \
   --uriReplace ".*/mixed-files,'/test'" \
@@ -163,7 +163,7 @@ You can cause a failure and tell the command to keep executing by not including 
 
 ```
 ./nt/bin/nt import_files --path "new-tool-cli/src/test/resources/mixed-files/*" \
-  --clientUri "new-tool-user:password@localhost:8000" \
+  --connectionString "new-tool-user:password@localhost:8000" \
   --permissions "invalid-role,read,new-tool-role,update" \
   --uriReplace ".*/mixed-files,'/test'"
 ```
@@ -181,12 +181,12 @@ owned by the performance team. Feel free to adjust this config locally as needed
 Example of using the existing config to copy from port 8015 to port 8016 in the performance cluster:
 
 ```
-./nt/bin/nt copy --clientUri "admin:admin@localhost:8006" \
+./nt/bin/nt copy --connectionString "admin:admin@localhost:8006" \
   --collections "address_small" \
   --batchSize 500 \
   --limit 10000 \
   --categories content,metadata \
-  --outputClientUri "admin:admin@localhost:8007" \
+  --outputConnectionString "admin:admin@localhost:8007" \
   --outputThreadCount 3 --partitionsPerForest 1 --outputBatchSize 200
 ```
 

--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -22,9 +22,9 @@ Generally, you must include at least the following information for each command:
 - Authentication information.
 
 For the common use case of using digest or basic authentication with a MarkLogic app server, you can use the 
-`--clientUri` option to specify the host, port, username, and password in a single concise option:
+`--connectionString` option to specify the host, port, username, and password in a single concise option:
 
-    --clientUri user:password@host:port
+    --connectionString user:password@host:port
 
 For other authentication mechanisms, you must use the `--host` and `--port` options to define the host and port for 
 your MarkLogic app server. 
@@ -37,7 +37,7 @@ All available connection options are shown in the table below:
 | --basePath | Path to prepend to each call to a MarkLogic REST API app server. |
 | --certificateFile | File path for a key store to be used for 'CERTIFICATE' authentication. |
 | --certificatePassword | Password for the key store referenced by '--certificateFile'. |
-| --clientUri |  Defines a connection string as user:password@host:port; only usable when using `DIGEST` or `BASIC` authentication. |
+| --connectionString |  Defines a connection string as user:password@host:port; only usable when using `DIGEST` or `BASIC` authentication. |
 | --cloudApiKey | API key for authenticating with a MarkLogic Cloud cluster. |
 | --connectionType |  Defines whether connections can be made directly to each host in the MarkLogic cluster. Possible values are `DIRECT` and `GATEWAY`. |
 | --database | Name of a database to connect if it differs from the one associated with the app server identified by '--port'. |
@@ -98,7 +98,7 @@ instead of in a table:
 
 ```
 ./bin/nt import_parquet_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --path export/parquet \
     --preview 10 \
     --previewDrop job_title,department
@@ -119,7 +119,7 @@ The following shows an example of only importing the first 10 rows from a delimi
 ```
 ./bin/nt import_delimited_files \
     --path ../data/employees.csv.gz \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --permissions nt-role,read,nt-role,update \
     --collections employee \
     --uriTemplate "/employee/{id}.json" \

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -34,7 +34,7 @@ combination of those options as well.
 The `copy` command then requires that you specify connection information via for the target database that the documents
 will be copied into. Each of the [connection options](common-options.md) can be used for this target database, but with
 `output` as a prefix so that they are distinguished from the connections used for the source database. For example, 
-`--outputClientUri` is used to specify a connection string for the target database. If you are copying the documents
+`--outputConnectionString` is used to specify a connection string for the target database. If you are copying the documents
 to the same database that they were read from, you can omit output connection options.
 
 The following shows an example of copying documents from a collection to a different database in the same MarkLogic 
@@ -42,9 +42,9 @@ cluster:
 
 ```
 ./bin/nt copy \
-  --clientUri "user:password@localhost:8000" \
+  --connectionString "user:password@localhost:8000" \
   --collections "example" \
-  --outputClientUri "user:password@localhost:8000" \
+  --outputConnectionString "user:password@localhost:8000" \
   --outputDatabase "target-database"
 ```
 

--- a/docs/export/export-documents.md
+++ b/docs/export/export-documents.md
@@ -19,7 +19,7 @@ The `export_files` command is used to select documents in a MarkLogic database a
 You must specify a `--path` option for where files should be written along with connection information for the
 MarkLogic database you wish to write to:
 
-    ./bin/nt export_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt export_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 The following options then control which documents are selected to be exported:
 
@@ -67,7 +67,7 @@ the following command below from the [Getting Started guide](getting-started.md)
 
 ```
 rm export/*.zip
-./bin/nt export_files --clientUri nt-user:password@localhost:8004 \
+./bin/nt export_files --connectionString nt-user:password@localhost:8004 \
     --collections employee \
     --path export --compression zip
 ```
@@ -81,7 +81,7 @@ from each forest in your database:
 
 ```
 rm export/*.zip
-./bin/nt export_files --clientUri nt-user:password@localhost:8004 \
+./bin/nt export_files --connectionString nt-user:password@localhost:8004 \
     --collections employee \
     --path export --compression zip \
     --partitionsPerForest 1
@@ -94,7 +94,7 @@ writing data, regardless of how many were used to read the data:
 
 ```
 rm export/*.zip
-./bin/nt export_files --clientUri nt-user:password@localhost:8004 \
+./bin/nt export_files --connectionString nt-user:password@localhost:8004 \
     --collections employee \
     --path export --compression zip \
     --repartition 1

--- a/docs/export/export-rows.md
+++ b/docs/export/export-rows.md
@@ -65,7 +65,7 @@ Once you have installed your database's JDBC driver and determined your JDBC con
 a notional example of doing so:
 
 ```
-./bin/nt export_jdbc --clientUri user:password@localhost:8000 \
+./bin/nt export_jdbc --connectionString user:password@localhost:8000 \
   --query "op.fromView('example', 'employee', '')" \
   --jdbcUrl "jdbc:postgresql://localhost/example?user=postgres&password=postgres" \
   --jdbcDriver "org.postgresql.Driver" \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,14 +57,14 @@ command. To see the usage for a particular command, such as `import_files`, run:
 
     ./bin/nt help import_files
 
-Required options are marked with an asterisk - "*". Additionally, every command requires that either `--clientUri`
+Required options are marked with an asterisk - "*". Additionally, every command requires that either `--connectionString`
 or `--host` and `--port` be specified so that the tool knows which MarkLogic cluster to connect to. 
 
-The `--clientUri` option provides a succinct way of defining the host, port, username, and password when the MarkLogic
+The `--connectionString` option provides a succinct way of defining the host, port, username, and password when the MarkLogic
 app server you connect to requires basic or digest authentication. Its value is of the form 
 `(user):(password)@(host):(port)`. For example:
 
-    ./bin/nt import_files --clientUri "my-user:my-secret@localhost:8000" ...
+    ./bin/nt import_files --connectionString "my-user:my-secret@localhost:8000" ...
 
 Options can be read from a file; see the [Common Options](common-options.md) guide for more information.
 
@@ -83,7 +83,7 @@ demonstrated:
 ```
 ./bin/nt import_delimited_files \
     --path ../data/employees.csv.gz \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --permissions nt-role,read,nt-role,update \
     --collections employee \
     --uriTemplate "/employee/{id}.json"
@@ -106,7 +106,7 @@ requires a separate Postgres database; it is only included for reference):
     --jdbcUrl "jdbc:postgresql://localhost/dvdrental?user=postgres&password=postgres" \
     --jdbcDriver "org.postgresql.Driver" \
     --query "select * from customer" \
-    --clientUri "new-tool-user:password@localhost:8004" \
+    --connectionString "new-tool-user:password@localhost:8004" \
     --permissions nt-role,read,nt-role,update \
     --collections customer
 ```
@@ -123,7 +123,7 @@ to select rows. The following shows an example of exporting the 1000 employee do
 ```
 mkdir export
 ./bin/nt export_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --collections employee \
     --path export \
     --compression zip \
@@ -141,7 +141,7 @@ in 4 JSON documents being written to `./export/employee`:
 
 ```
 ./bin/nt export_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --collections employee \
     --stringQuery Engineering \
     --query '{"query": {"value-query": {"json-property": "job_title", "text": "Junior Executive"}}}' \
@@ -162,7 +162,7 @@ bucket, ensuring that your AWS credentials give you access to writing to the buc
 
 ```
 ./bin/nt export_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --collections employee \
     --compression zip \
     --repartition 1 \
@@ -178,7 +178,7 @@ destinations, such as Parquet files or an RDBMS. The following demonstrates writ
 ```
 mkdir export/parquet
 ./bin/nt export_parquet_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --path export/parquet \
     --query "op.fromView('Example', 'Employees', '')" 
 ```
@@ -189,7 +189,7 @@ Change the details in it to match your database and JDBC driver, ensuring that t
 
 ```
 ./bin/nt export_jdbc \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --query "op.fromView('Example', 'Employees', '')" \
     --jdbcUrl "jdbc:postgresql://localhost/postgres?user=postgres&password=postgres" \
     --jdbcDriver "org.postgresql.Driver" \
@@ -206,7 +206,7 @@ command can preview 10 rows read from MarkLogic without writing any data to file
 
 ```
 ./bin/nt export_parquet_files \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --query "op.fromView('Example', 'Employees', '')" \
     --path export/parquet \
     --preview 10
@@ -222,7 +222,7 @@ documents:
 
 ```
 ./bin/nt reprocess \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --readJavascript "cts.uris(null, null, cts.collectionQuery('employee'))" \
     --writeJavascript "declareUpdate(); xdmp.documentAddCollections(URI, 'reprocessed')" 
 ```
@@ -243,10 +243,10 @@ MarkLogic instance:
 
 ```
 ./bin/nt copy \
-    --clientUri "nt-user:password@localhost:8004" \
+    --connectionString "nt-user:password@localhost:8004" \
     --collections employee \
     --categories content,metadata \
-    --outputClientUri "nt-user:password@localhost:8000"
+    --outputConnectionString "nt-user:password@localhost:8000"
 ```
 
 For more information, please see the [Copying guide](copy.md).

--- a/docs/import/import-files/aggregate-xml.md
+++ b/docs/import/import-files/aggregate-xml.md
@@ -24,7 +24,7 @@ will be used as the root of an XML document written to MarkLogic. The `--namespa
 has an associated namespace:
 
 ```
-./bin/nt import_aggregate_xml_files --path /path/to/files --clientUri user:password@localhost:8000 \
+./bin/nt import_aggregate_xml_files --path /path/to/files --connectionString user:password@localhost:8000 \
     --element employee --namespace org:example
 ```
 
@@ -35,7 +35,7 @@ you can use the `--uriElement` and `--uriNamespace` options to identify an eleme
 be included in the URI:
 
 ```
-./bin/nt import_aggregate_xml_files --path /path/to/files --clientUri user:password@localhost:8000 \
+./bin/nt import_aggregate_xml_files --path /path/to/files --connectionString user:password@localhost:8000 \
     --element employee --namespace org:example \
     --uriElement employee ID --namespace org:example
 ```

--- a/docs/import/import-files/archives.md
+++ b/docs/import/import-files/archives.md
@@ -23,7 +23,7 @@ The `import_archives` command will import the documents and metadata files in a 
 `export_archives` command. You must specify at least one `--path` option along with connection information for the
 MarkLogic database you wish to write to:
 
-    ./bin/nt import_archives --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_archives --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Importing MLCP archives
 
@@ -32,7 +32,7 @@ You can also import
 that were produced via the `EXPORT` command in MLCP. The `import_mlcp_archives` command is used instead, and it also
 requires at least one `--path` option along with connection information for the MarkLogic database you wish to write to:
 
-    ./bin/nt import_mlcp_archives --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_mlcp_archives --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Restricting metadata
 

--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -20,7 +20,7 @@ The `import_avro_files` command is used to read Avro files and write the content
 documents in MarkLogic. You must specify at least one `--path` option along with connection information for the
 MarkLogic database you wish to write to:
 
-    ./bin/nt import_avro_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_avro_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Specifying a JSON root name
 

--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -20,7 +20,7 @@ The `import_delimited_files` command is used to read delimited text files. The c
 the delimiter for each row value. You must specify at least one `--path` option along with connection information 
 for the MarkLogic database you wish to write to:
 
-    ./bin/nt import_delimited_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_delimited_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Specifying a JSON root name
 

--- a/docs/import/import-files/json.md
+++ b/docs/import/import-files/json.md
@@ -24,7 +24,7 @@ this behavior for an array of JSON objects, use the `import_files` command inste
 
 You must specify at least one `--path` option along with connection information for the MarkLogic database you wish to write to:
 
-    ./bin/nt import_json_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_json_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Importing JSON Lines files
 

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -20,7 +20,7 @@ The `import_orc_files` command is used to read ORC files and write the contents 
 documents in MarkLogic. You must specify at least one `--path` option along with connection information for the
 MarkLogic database you wish to write to:
 
-    ./bin/nt import_orc_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_orc_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Specifying a JSON root name
 

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -20,7 +20,7 @@ The `import_parquet_files` command is used to read Parquet files and write the c
 documents in MarkLogic. You must specify at least one `--path` option along with connection information for the 
 MarkLogic database you wish to write to:
 
-    ./bin/nt import_parquet_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_parquet_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Specifying a JSON root name
 

--- a/docs/import/import-files/rdf.md
+++ b/docs/import/import-files/rdf.md
@@ -24,7 +24,7 @@ document is an XML document containing up to 100 semantic triples.
 To import RDF files, you must specify at least one `--path` option along with connection information for the MarkLogic 
 database you wish to write to:
 
-    ./bin/nt import_rdf_files --path /path/to/files --clientUri "user:password@localhost:8000"
+    ./bin/nt import_rdf_files --path /path/to/files --connectionString "user:password@localhost:8000"
 
 ## Supported files types
 

--- a/docs/import/import-files/regular-files.md
+++ b/docs/import/import-files/regular-files.md
@@ -22,7 +22,7 @@ The `import_files` command is used to import a set of files into MarkLogic, with
 document. You must specify at least one `--path` option along with connection information for the MarkLogic database
 you wish to write to. For example:
 
-    ./bin/nt import_files --path /path/to/files --clientUri user:password@localhost:8000
+    ./bin/nt import_files --path /path/to/files --connectionString user:password@localhost:8000
 
 ## Controlling document URIs
 

--- a/docs/reprocess.md
+++ b/docs/reprocess.md
@@ -48,7 +48,7 @@ you wish to reprocess.
 The following shows a simple example of querying a collection for its URIs and logging each one:
 
 ```
-./bin/nt reprocess --clientUri user:password@localhost:8000 \
+./bin/nt reprocess --connectionString user:password@localhost:8000 \
   --readJavascript "cts.uris(null, null, cts.collectionQuery('example'))"
   --writeJavascript "var URI; console.log(URI)"
 ```
@@ -65,7 +65,7 @@ with each value being of the same form.
 The following shows a simple example of including a variable in both the reader and writer:
 
 ```
-./bin/nt reprocess --clientUri user:password@localhost:8000 \
+./bin/nt reprocess --connectionString user:password@localhost:8000 \
   --readJavascript "var collection; cts.uris(null, null, cts.collectionQuery(collection))"
   --readVar "collection=example"
   --writeJavascript "var URI; var exampleVariable; console.log([URI, exampleVariable])"
@@ -91,7 +91,7 @@ Partition values can thus be anything you want. A common use case is to partitio
 MarkLogic database. The following shows an example of partitions based on forests:
 
 ```
-./bin/nt reprocess --clientUri user:password@localhost:8000 \
+./bin/nt reprocess --connectionString user:password@localhost:8000 \
   --readPartitionsJavascript "xdmp.databaseForests(xdmp.database())"
   --readJavascript "cts.uris(null, null, cts.collectionQuery('example'), 0, [PARTITION])"
   --writeJavascript "var URI; console.log(URI)"

--- a/mlcp-testing/build.gradle
+++ b/mlcp-testing/build.gradle
@@ -70,7 +70,7 @@ task ntImportRdf(type: Exec) {
   description = "Intended to run against a local Caddy load balancer."
   workingDir = "../nt/"
   commandLine "./bin/nt", "import_rdf_files",
-    "--clientUri", "${mlUsername}:${mlPassword}@${lbHost}:${lbPort}",
+    "--connectionString", "${mlUsername}:${mlPassword}@${lbHost}:${lbPort}",
     "--path", rdfFile,
     "--permissions", "rest-reader,read,rest-writer,update",
     "--connectionType", "gateway",
@@ -82,7 +82,7 @@ task ntDirectImportRdf(type: Exec) {
   description = "For testing without a load balancer."
   workingDir = "../nt/"
   commandLine "./bin/nt", "import_rdf_files",
-    "--clientUri", "${mlUsername}:${mlPassword}@${mlHost}:${mlRestPort}",
+    "--connectionString", "${mlUsername}:${mlPassword}@${mlHost}:${mlRestPort}",
     "--path", rdfFile,
     "--permissions", "rest-reader,read,rest-writer,update",
     "--connectionType", "direct",
@@ -93,14 +93,14 @@ task ntDirectImportRdf(type: Exec) {
 task ntCopy(type: Exec) {
   workingDir = "../nt/"
   commandLine "./bin/nt", "copy",
-    "--clientUri", "${mlUsername}:${mlPassword}@${mlHost}:${mlRestPort}",
+    "--connectionString", "${mlUsername}:${mlPassword}@${mlHost}:${mlRestPort}",
     "--collections", "address_small",
     "--batchSize", "500",
     // results in 24 threads total, assuming 3 forests and 4 partitions per forests, which means 12 partitions.
     "--outputThreadCount", "2",
     "--outputBatchSize", "500",
     "--outputPermissions", "rest-reader,read,rest-writer,update",
-    "--outputClientUri", "${outputUsername}:${outputPassword}@${outputHost}:${outputPort}"
+    "--outputConnectionString", "${outputUsername}:${outputPassword}@${outputHost}:${outputPort}"
 }
 
 task mlcpCopy(type: JavaExec) {
@@ -145,7 +145,7 @@ task ntTwoWaySSL(type: Exec) {
     "then run this task to ensure that two-way SSL works."
   workingDir = "../nt/"
   commandLine "./bin/nt", "copy",
-    "--clientUri", "rest-writer:x@localhost:8012",
+    "--connectionString", "rest-writer:x@localhost:8012",
     "--collections", "zipcode",
     "--keyStorePath", "../mlcp-testing/keyStore.jks",
     "--keyStorePassword", "password",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionInputs.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionInputs.java
@@ -27,7 +27,7 @@ public abstract class ConnectionInputs {
         STRICT
     }
 
-    protected String clientUri;
+    protected String connectionString;
     protected String host;
     protected Integer port;
     protected String basePath;
@@ -54,9 +54,9 @@ public abstract class ConnectionInputs {
     protected String trustStoreAlgorithm;
 
     public String getSelectedHost() {
-        if (clientUri != null) {
+        if (connectionString != null) {
             // TBD Ideally reuse this logic from the connector.
-            String[] parts = clientUri.split("@");
+            String[] parts = connectionString.split("@");
             return parts[1].split(":")[0];
         }
         return host;
@@ -64,7 +64,7 @@ public abstract class ConnectionInputs {
 
     public Map<String, String> makeOptions() {
         return OptionsUtil.makeOptions(
-            Options.CLIENT_URI, clientUri,
+            Options.CLIENT_URI, connectionString,
             Options.CLIENT_HOST, host,
             Options.CLIENT_PORT, port != null ? port.toString() : null,
             "spark.marklogic.client.disableGzippedResponses", disableGzippedResponses != null ? Boolean.toString(disableGzippedResponses) : null,

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/ConnectionParams.java
@@ -13,12 +13,12 @@ public class ConnectionParams extends ConnectionInputs implements IParametersVal
 
     @Override
     public void validate(Map<String, Object> parameters) throws ParameterException {
-        if (parameters.get("--clientUri") == null && parameters.get("--preview") == null) {
+        if (parameters.get("--connectionString") == null && parameters.get("--preview") == null) {
             if (parameters.get("--host") == null) {
-                throw new ParameterException("Must specify a MarkLogic host via --host or --clientUri.");
+                throw new ParameterException("Must specify a MarkLogic host via --host or --connectionString.");
             }
             if (parameters.get("--port") == null) {
-                throw new ParameterException("Must specify a MarkLogic app server port via --port or --clientUri.");
+                throw new ParameterException("Must specify a MarkLogic app server port via --port or --connectionString.");
             }
 
             String authType = (String) parameters.get("--authType");
@@ -30,11 +30,11 @@ public class ConnectionParams extends ConnectionInputs implements IParametersVal
     }
 
     @Parameter(
-        names = {"--clientUri"},
+        names = {"--connectionString"},
         description = "Defines a connection string as user:password@host:port; only usable when using 'DIGEST' or 'BASIC' authentication."
     )
-    public void setClientUri(String clientUri) {
-        this.clientUri = clientUri;
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
     }
 
     @Parameter(

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/copy/OutputConnectionParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/copy/OutputConnectionParams.java
@@ -11,11 +11,11 @@ import com.marklogic.newtool.command.ConnectionInputs;
 public class OutputConnectionParams extends ConnectionInputs {
 
     @Parameter(
-        names = {"--outputClientUri"},
+        names = {"--outputConnectionString"},
         description = "Defines a connection string as user:password@host:port; only usable when using 'DIGEST' or 'BASIC' authentication."
     )
-    public void setClientUri(String clientUri) {
-        this.clientUri = clientUri;
+    public void setConnectionString(String connectionString) {
+        this.connectionString = connectionString;
     }
 
     @Parameter(

--- a/new-tool-cli/src/main/resources/marklogic-spark-messages_en.properties
+++ b/new-tool-cli/src/main/resources/marklogic-spark-messages_en.properties
@@ -2,7 +2,7 @@
 # Overridden here so that the user sees meaningful CLI option names instead of meaningless connector option names.
 # The use of "_en" allows this to take precedence over the marklogic-spark-messages.properties file in the connector,
 # while still inheriting anything from that file that is not overridden.
-spark.marklogic.client.uri=--clientUri
+spark.marklogic.client.uri=--connectionString
 spark.marklogic.read.batchSize=--batchSize
 spark.marklogic.read.documents.partitionsPerForest=--partitionsPerForest
 spark.marklogic.read.numPartitions=--partitions

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/AbstractTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/AbstractTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractTest extends AbstractMarkLogicTest {
             "{xdmp.documentDelete(uri)}";
     }
 
-    protected final String makeClientUri() {
+    protected final String makeConnectionString() {
         // new-tool-user is expected to have the minimum set of privileges for running all the tests.
         return String.format("%s:%s@%s:%d", "new-tool-user", "password", databaseClient.getHost(), databaseClient.getPort());
     }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/ErrorMessagesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/ErrorMessagesTest.java
@@ -16,7 +16,7 @@ class ErrorMessagesTest {
             "Expecting 13 keys as of the upcoming 2.3.0 release. Bump this up as more keys are added. Each key should " +
                 "also be verified in an assertion below.");
 
-        assertEquals("--clientUri", bundle.getString(Options.CLIENT_URI));
+        assertEquals("--connectionString", bundle.getString(Options.CLIENT_URI));
         assertEquals("--batchSize", bundle.getString(Options.READ_BATCH_SIZE));
         assertEquals("--partitionsPerForest", bundle.getString(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST));
         assertEquals("--partitions", bundle.getString(Options.READ_NUM_PARTITIONS));

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/HandleErrorTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/HandleErrorTest.java
@@ -18,7 +18,7 @@ class HandleErrorTest extends AbstractTest {
     void invalidCommand() {
         run(
             "not_a_real_command",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
     }
 
@@ -26,7 +26,7 @@ class HandleErrorTest extends AbstractTest {
     void missingRequiredParam() {
         run(
             "import_files",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
     }
 
@@ -38,7 +38,7 @@ class HandleErrorTest extends AbstractTest {
         run(
             "import_files",
             "--path", "/not/valid",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
     }
 
@@ -51,7 +51,7 @@ class HandleErrorTest extends AbstractTest {
             "import_files",
             "--path", "src/test/resources/mixed-files/hello*",
             "--repartition", "2",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", "invalid-role,read,rest-writer,update",
             "--abortOnWriteFailure"
         );
@@ -63,7 +63,7 @@ class HandleErrorTest extends AbstractTest {
             "import_files",
             "--path", "src/test/resources/mixed-files/hello*",
             "--repartition", "2",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", "invalid-role,read,rest-writer,update",
             "--stacktrace",
             "--abortOnWriteFailure"
@@ -77,7 +77,7 @@ class HandleErrorTest extends AbstractTest {
             "--path", "src/test/resources/mixed-files/hello*",
             // Using two partitions to verify that both partition writers log an error.
             "--repartition", "2",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", "invalid-role,read,rest-writer,update"
         );
     }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ConnectionParamsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ConnectionParamsTest.java
@@ -14,7 +14,7 @@ class ConnectionParamsTest extends AbstractOptionsTest {
         ImportFilesCommand command = (ImportFilesCommand) getCommand(
             "import_files",
             "--path", "/doesnt/matter/for-this-test",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--host", "localhost",
             "--port", "8123",
             "--disableGzippedResponses",

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/LimitTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/LimitTest.java
@@ -28,7 +28,7 @@ class LimitTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/hello*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", COLLECTION,
             "--limit", Integer.toString(limit)

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/ValidateMarkLogicConnectionTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/ValidateMarkLogicConnectionTest.java
@@ -17,7 +17,7 @@ class ValidateMarkLogicConnectionTest extends AbstractTest {
             "--path", "src/test/resources/mixed-files"
         ));
 
-        assertTrue(output.contains("Must specify a MarkLogic host via --host or --clientUri."),
+        assertTrue(output.contains("Must specify a MarkLogic host via --host or --connectionString."),
             "Unexpected stderr: " + output);
     }
 
@@ -29,7 +29,7 @@ class ValidateMarkLogicConnectionTest extends AbstractTest {
             "--host", getDatabaseClient().getHost()
         ));
 
-        assertTrue(output.contains("Must specify a MarkLogic app server port via --port or --clientUri."),
+        assertTrue(output.contains("Must specify a MarkLogic app server port via --port or --connectionString."),
             "Unexpected stderr: " + output);
     }
 
@@ -55,10 +55,10 @@ class ValidateMarkLogicConnectionTest extends AbstractTest {
         String output = runAndReturnStderr(() -> run(
             "import_files",
             "--path", "src/test/resources/mixed-files",
-            "--clientUri", "admin-missing-password@localhost:8003"
+            "--connectionString", "admin-missing-password@localhost:8003"
         ));
 
-        assertTrue(output.contains("Invalid value for --clientUri"),
+        assertTrue(output.contains("Invalid value for --connectionString"),
             "Unexpected output: " + output + "; this test also confirms that the ETL tool is overriding " +
                 "error messages from the connector so that CLI option names appear instead of connector " +
                 "option names. This is also confirmed by ErrorMessagesTest.");

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/copy/CopyOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/copy/CopyOptionsTest.java
@@ -16,8 +16,8 @@ class CopyOptionsTest extends AbstractOptionsTest {
     @Test
     void useOutputParamsForConnection() {
         CopyCommand command = (CopyCommand) getCommand("copy",
-            "--clientUri", "test:test@test:8000",
-            "--outputClientUri", "user:password@host:8000",
+            "--connectionString", "test:test@test:8000",
+            "--outputConnectionString", "user:password@host:8000",
             "--collections", "anything"
         );
 
@@ -30,7 +30,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
     @Test
     void useRegularConnectionParamsIfNoOutputConnectionParams() {
         CopyCommand command = (CopyCommand) getCommand("copy",
-            "--clientUri", "test:test@test:8000",
+            "--connectionString", "test:test@test:8000",
             "--collections", "anything"
         );
 
@@ -43,7 +43,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
     @Test
     void allWriteParams() {
         CopyCommand command = (CopyCommand) getCommand("copy",
-            "--clientUri", "someone:word@somehost:7000",
+            "--connectionString", "someone:word@somehost:7000",
             "--collections", "anything",
             "--outputAbortOnWriteFailure",
             "--outputBatchSize", "123",
@@ -83,9 +83,9 @@ class CopyOptionsTest extends AbstractOptionsTest {
     void allOutputConnectionParams() {
         CopyCommand command = (CopyCommand) getCommand(
             "copy",
-            "--clientUri", "someone:word@somehost:7000",
+            "--connectionString", "someone:word@somehost:7000",
             "--collections", "anything",
-            "--outputClientUri", "user:password@host:8000",
+            "--outputConnectionString", "user:password@host:8000",
             "--outputHost", "localhost",
             "--outputPort", "8123",
             "--outputBasePath", "/path",

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/copy/CopyTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/copy/CopyTest.java
@@ -16,7 +16,7 @@ class CopyTest extends AbstractTest {
             "copy",
             "--categories", "content",
             "--collections", "author",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--outputCollections", "author-copies",
             "--outputUriPrefix", "/copied",
             "--outputPermissions", DEFAULT_PERMISSIONS
@@ -33,7 +33,7 @@ class CopyTest extends AbstractTest {
             "copy",
             "--categories", "content",
             "--uris", "/author/author1.json\n/author/author2.json",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--outputCollections", "author-copies",
             "--outputUriPrefix", "/copied",
             "--outputPermissions", DEFAULT_PERMISSIONS
@@ -51,8 +51,8 @@ class CopyTest extends AbstractTest {
             "--collections", "author",
             "--partitionsPerForest", "1",
             "--categories", "content,metadata",
-            "--clientUri", makeClientUri(),
-            "--outputClientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
+            "--outputConnectionString", makeConnectionString(),
             // No need to specify permissions since they are included via "--categories".
             "--outputCollections", "author-copies",
             "--outputUriPrefix", "/copied"

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportArchivesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportArchivesTest.java
@@ -15,7 +15,7 @@ class ExportArchivesTest extends AbstractTest {
     void test(@TempDir Path tempDir) {
         run(
             "export_archives",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author",
             "--fileCount", "1",
             "--path", tempDir.toFile().getAbsolutePath()
@@ -29,7 +29,7 @@ class ExportArchivesTest extends AbstractTest {
         run(
             "import_archives",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "imported-author"
         );
 
@@ -45,7 +45,7 @@ class ExportArchivesTest extends AbstractTest {
     void contentShouldAlwaysBeIncluded(@TempDir Path tempDir) {
         String stderr = runAndReturnStderr(() -> run(
             "export_archives",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author",
             "--path", tempDir.toFile().getAbsolutePath(),
             "--categories", "collections,permissions"
@@ -57,7 +57,7 @@ class ExportArchivesTest extends AbstractTest {
         run(
             "import_archives",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "imported-author"
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportAvroFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportAvroFilesTest.java
@@ -15,7 +15,7 @@ class ExportAvroFilesTest extends AbstractTest {
     void test(@TempDir Path tempDir) {
         run(
             "export_avro_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--partitions", "4",
             "--path", tempDir.toFile().getAbsolutePath()
@@ -29,7 +29,7 @@ class ExportAvroFilesTest extends AbstractTest {
         run(
             "import_avro_files",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-test"
         );
@@ -48,7 +48,7 @@ class ExportAvroFilesTest extends AbstractTest {
     void dynamicParameter(@TempDir Path tempDir) {
         String stderr = runAndReturnStderr(() -> run(
             "export_avro_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--partitions", "2",
             "--path", tempDir.toFile().getAbsolutePath(),

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportFilesOptionsTest.java
@@ -15,7 +15,7 @@ class ExportFilesOptionsTest extends AbstractOptionsTest {
     void prettyPrint() {
         ExportFilesCommand command = (ExportFilesCommand) getCommand(
             "export_files",
-            "--clientUri", "test:test@host:8000",
+            "--connectionString", "test:test@host:8000",
             "--collections", "anything",
             "--path", "anywhere",
             "--prettyPrint",
@@ -31,7 +31,7 @@ class ExportFilesOptionsTest extends AbstractOptionsTest {
     void dontPrettyPrint() {
         ExportFilesCommand command = (ExportFilesCommand) getCommand(
             "export_files",
-            "--clientUri", "test:test@host:8000",
+            "--connectionString", "test:test@host:8000",
             "--collections", "anything",
             "--path", "anywhere",
             "--compression", "zip"

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportFilesTest.java
@@ -25,7 +25,7 @@ class ExportFilesTest extends AbstractTest {
         run(
             "export_files",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author",
             // Including this simply to verify that it doesn't cause an error. Its impact is only going to be seen
             // in performance tests.
@@ -53,7 +53,7 @@ class ExportFilesTest extends AbstractTest {
         run(
             "export_files",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--uris", "/author/author1.json\n/author/author2.json"
         );
 
@@ -70,7 +70,7 @@ class ExportFilesTest extends AbstractTest {
             "--partitionsPerForest", "1",
             "--path", tempDir.toFile().getAbsolutePath(),
             "--compression", "zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author"
         );
 
@@ -104,7 +104,7 @@ class ExportFilesTest extends AbstractTest {
             "export_files",
             "--path", tempDir.toFile().getAbsolutePath(),
             "--compression", "zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author",
             "--zipFileCount", "5"
         );
@@ -119,7 +119,7 @@ class ExportFilesTest extends AbstractTest {
             "export_files",
             "--path", tempDir.toFile().getAbsolutePath(),
             "--compression", "gzip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "author"
         );
 
@@ -141,7 +141,7 @@ class ExportFilesTest extends AbstractTest {
                 "export_files",
                 "--path", tempDir.toFile().getAbsolutePath(),
                 "--compression", "gzip",
-                "--clientUri", makeClientUri()
+                "--connectionString", makeConnectionString()
             );
         });
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportJdbcTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportJdbcTest.java
@@ -81,7 +81,7 @@ class ExportJdbcTest extends AbstractTest {
     void dynamicParam() {
         run(
             "export_jdbc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--jdbcUrl", PostgresUtil.URL_WITH_AUTH,
             "--jdbcDriver", "this should be overwritten by the dynamic param",
@@ -100,7 +100,7 @@ class ExportJdbcTest extends AbstractTest {
     private void exportFifteenAuthorsWithMode(String saveMode) {
         run(
             "export_jdbc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--jdbcUrl", PostgresUtil.URL_WITH_AUTH,
             "--jdbcDriver", PostgresUtil.DRIVER,

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportOrcFilesTest.java
@@ -16,7 +16,7 @@ class ExportOrcFilesTest extends AbstractTest {
     void test(@TempDir Path tempDir) {
         run(
             "export_orc_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--partitions", "4",
             "--path", tempDir.toFile().getAbsolutePath()
@@ -30,7 +30,7 @@ class ExportOrcFilesTest extends AbstractTest {
         run(
             "import_orc_files",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orc-test"
         );
@@ -42,7 +42,7 @@ class ExportOrcFilesTest extends AbstractTest {
     void dynamicParameter(@TempDir Path tempDir) {
         run(
             "export_orc_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--partitions", "1",
             "--path", tempDir.toFile().getAbsolutePath(),

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportParquetFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/export/ExportParquetFilesTest.java
@@ -17,7 +17,7 @@ class ExportParquetFilesTest extends AbstractTest {
     void test(@TempDir Path tempDir) {
         run(
             "export_parquet_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--path", tempDir.toFile().getAbsolutePath()
         );
@@ -29,7 +29,7 @@ class ExportParquetFilesTest extends AbstractTest {
         run(
             "import_parquet_files",
             "--path", tempDir.toFile().getAbsolutePath(),
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test"
         );
@@ -41,7 +41,7 @@ class ExportParquetFilesTest extends AbstractTest {
     void saveMode(@TempDir Path tempDir) {
         String stderr = runAndReturnStderr(() -> run(
             "export_parquet_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--path", tempDir.toFile().getAbsolutePath(),
             "--mode", SaveMode.ErrorIfExists.name()
@@ -55,7 +55,7 @@ class ExportParquetFilesTest extends AbstractTest {
     void dynamicParameter(@TempDir Path tempDir) {
         run(
             "export_parquet_files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--query", READ_AUTHORS_OPTIC_QUERY,
             "--partitions", "2",
             "--fileCount", "2",

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAggregateXmlFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAggregateXmlFilesTest.java
@@ -20,7 +20,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
         String stderr = runAndReturnStderr(() -> run(
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/people.xml",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         ));
         assertTrue(stderr.contains("The following option is required: [--element]"),
             "Unexpected stderr: " + stderr);
@@ -32,7 +32,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/people.xml",
             "--element", "person",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "withElement-test",
             "--uriReplace", ".*/xml-file,''"
@@ -51,7 +51,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--path", "src/test/resources/xml-file/people-with-namespace.xml",
             "--element", "person",
             "--namespace", "org:example",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "withElementAndNamespace-test",
             "--uriReplace", ".*/xml-file,''"
@@ -72,7 +72,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--namespace", "org:example",
             "--uriElement", "name",
             "--uriNamespace", "org:example",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "withAllOptions-test"
         );
@@ -88,7 +88,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
         run(
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/single-xml.zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "importZippedXml-test",
             "--compression", "zip",
@@ -104,7 +104,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/single-xml.zip",
             "--element", "person",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "importZippedXmlWithElement-test",
             "--uriElement", "name",
@@ -122,7 +122,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/multiple-xmls.zip",
             "--element", "",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "importMultipleZippedXml-test",
             "--compression", "zip",
@@ -140,7 +140,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "import_aggregate_xml_files",
             "--path", "src/test/resources/xml-file/people.xml.gz",
             "--element", "person",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "importGzippedXml-test",
             "--compression", "gzip",
@@ -160,7 +160,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--path", "src/test/resources/xml-file/people.xml",
             "--element", "person",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "agg-xml"
         ));
@@ -177,7 +177,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--abortOnReadFailure",
             "--element", "person",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "agg-xml"
         ));

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportArchivesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportArchivesTest.java
@@ -18,7 +18,7 @@ class ImportArchivesTest extends AbstractTest {
             "import_archives",
             "--path", "src/test/resources/archive-files",
             "--uriReplace", ".*archive.zip,''",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {
@@ -44,7 +44,7 @@ class ImportArchivesTest extends AbstractTest {
             "--path", "src/test/resources/archive-files",
             "--categories", "collections,permissions",
             "--uriReplace", ".*archive.zip,''",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {
@@ -67,7 +67,7 @@ class ImportArchivesTest extends AbstractTest {
             "import_archives",
             "--path", "src/test/resources/archive-files",
             "--path", "src/test/resources/mlcp-archives",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         ));
 
         assertFalse(stderr.contains("Command failed"),
@@ -83,7 +83,7 @@ class ImportArchivesTest extends AbstractTest {
             "--path", "src/test/resources/archive-files",
             "--path", "src/test/resources/mlcp-archives",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         ));
 
         assertTrue(

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesTest.java
@@ -14,7 +14,7 @@ class ImportAvroFilesTest extends AbstractTest {
         run(
             "import_avro_files",
             "--path", "src/test/resources/avro/*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-test",
             "--uriTemplate", "/avro/{color}.json"
@@ -34,7 +34,7 @@ class ImportAvroFilesTest extends AbstractTest {
         run(
             "import_avro_files",
             "--path", "src/test/resources/avro/*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--jsonRootName", "myAvroData",
             "--uriTemplate", "/avro/{/myAvroData/color}.json"
@@ -49,7 +49,7 @@ class ImportAvroFilesTest extends AbstractTest {
         run(
             "import_avro_files",
             "--path", "src/test/resources/avro/*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-test",
             "-PignoreExtension=false",
@@ -68,7 +68,7 @@ class ImportAvroFilesTest extends AbstractTest {
             run(
                 "import_avro_files",
                 "--path", "src/test/resources/avro/*",
-                "--clientUri", makeClientUri(),
+                "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
                 "-Pspark.sql.parquet.filterPushdown=invalid-value"
             )
@@ -85,7 +85,7 @@ class ImportAvroFilesTest extends AbstractTest {
             "import_avro_files",
             "--path", "src/test/resources/avro/colors.avro",
             "--path", "src/test/resources/json-files/array-of-objects.json",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-data"
         ));
@@ -101,7 +101,7 @@ class ImportAvroFilesTest extends AbstractTest {
             "import_avro_files",
             "--path", "src/test/resources/json-files/array-of-objects.json",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS
         ));
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesTest.java
@@ -18,7 +18,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
         run(
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test",
             "--uriTemplate", "/delimited/{number}.json"
@@ -35,7 +35,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
         run(
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--jsonRootName", "myData",
             "--uriTemplate", "/delimited/{/myData/number}.json"
@@ -50,7 +50,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
         run(
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv.gz",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test",
             "--uriTemplate", "/delimited/{number}.json"
@@ -68,7 +68,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/semicolon-delimiter.csv",
             "-Psep=;",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test",
             "--uriTemplate", "/delimited/{number}.json"
@@ -86,7 +86,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/no-header.csv",
             "-Pheader=false",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "no-header",
             "--uriTemplate", "/no-header/{_c0}.json"
@@ -108,7 +108,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv",
             "-PinferSchema=false",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "no-schema-inference",
             "--uriTemplate", "/delimited/{number}.json"
@@ -151,7 +151,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv",
             "--path", "src/test/resources/xml-file/single-xml.zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test"
         ));
@@ -185,7 +185,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "--path", "src/test/resources/delimited-files/three-rows.csv",
             "--path", "src/test/resources/xml-file/single-xml.zip",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test"
         ));

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportFilesTest.java
@@ -23,7 +23,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/hello*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--uriReplace", ".*/mixed-files,''"
@@ -64,8 +64,8 @@ class ImportFilesTest extends AbstractTest {
         File optionsFile = new File(tempDir.toFile(), "options.txt");
         String options = "--path\n" +
             "src/test/resources/mixed-files/hello*\n" +
-            "--clientUri\n" +
-            makeClientUri() + "\n" +
+            "--connectionString\n" +
+            makeConnectionString() + "\n" +
             "--uriReplace\n" +
             ".*/mixed-files,''";
         FileCopyUtils.copy(options.getBytes(), optionsFile);
@@ -85,7 +85,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/goodbye.zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--uriReplace", ".*/mixed-files,''",
@@ -100,7 +100,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/goodbye.zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--uriReplace", ".*/mixed-files,''",
@@ -115,7 +115,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/hello2.txt.gz",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "files",
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriReplace", ".*/mixed-files,''",
@@ -130,7 +130,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files/hello*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--uriReplace", ".*/mixed-files,''",
@@ -145,7 +145,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--filter", "*.json",
@@ -160,7 +160,7 @@ class ImportFilesTest extends AbstractTest {
         run(
             "import_files",
             "--path", "src/test/resources/mixed-files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
             "--filter", "*.json",
@@ -177,7 +177,7 @@ class ImportFilesTest extends AbstractTest {
             "import_files",
             "--path", "src/test/resources/json-files/array-of-objects.json",
             "--path", "src/test/resources/mixed-files/hello2.txt.gz",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "files",
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriReplace", ".*/mixed-files,''",
@@ -195,7 +195,7 @@ class ImportFilesTest extends AbstractTest {
             "import_files",
             "--path", "src/test/resources/json-files/array-of-objects.json",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "files",
             "--permissions", DEFAULT_PERMISSIONS,
             "--compression", "gzip"

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJdbcTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJdbcTest.java
@@ -20,7 +20,7 @@ class ImportJdbcTest extends AbstractTest {
             "--jdbcPassword", PostgresUtil.PASSWORD,
             "--jdbcDriver", PostgresUtil.DRIVER,
             "--query", "select * from customer where customer_id < 11",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/customer/{customer_id}.json",
             "--collections", "customer"
@@ -38,7 +38,7 @@ class ImportJdbcTest extends AbstractTest {
             "--jdbcPassword", PostgresUtil.PASSWORD,
             "--jdbcDriver", PostgresUtil.DRIVER,
             "--query", "select * from customer where customer_id < 11",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--jsonRootName", "customer",
             "--uriTemplate", "/customer/{/customer/customer_id}.json",
@@ -56,7 +56,7 @@ class ImportJdbcTest extends AbstractTest {
             "--jdbcUrl", PostgresUtil.URL_WITH_AUTH,
             "--jdbcDriver", PostgresUtil.DRIVER,
             "--query", "select * from customer where customer_id < 11",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/customer/{customer_id}.json",
             "--collections", "customer"

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJdbcWithAggregatesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJdbcWithAggregatesTest.java
@@ -29,7 +29,7 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
             "--query", query,
             "--groupBy", "customer_id",
             "--aggregate", "payments=payment_id;amount;payment_date",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/customer/{customer_id}.json"
         );
@@ -79,7 +79,7 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
             "--groupBy", "customer_id",
             "--aggregate", "payments=payment_id;amount",
             "--aggregate", "rentals=rental_id;inventory_id",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/customer/{customer_id}.json"
         );
@@ -123,7 +123,7 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
             "--query", query,
             "--groupBy", "film_id",
             "--aggregate", "actor_ids=actor_id",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/film/{film_id}.json"
         );

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJsonFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportJsonFilesTest.java
@@ -17,7 +17,7 @@ class ImportJsonFilesTest extends AbstractTest {
         run(
             "import_json_files",
             "--path", "src/test/resources/json-files",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "json-objects",
             "--uriTemplate", "/json-object/{number}.json",
@@ -49,7 +49,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "import_json_files",
             "--path", "src/test/resources/delimited-files/line-delimited-json.txt",
             "--jsonLines",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-json-test",
             "--uriTemplate", "/delimited/{lastName}.json"
@@ -67,7 +67,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "import_json_files",
             "--path", "src/test/resources/delimited-files/line-delimited-json.txt",
             "--jsonLines",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-json-test",
             "--jsonRootName", "myData",
@@ -85,7 +85,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "--path", "src/test/resources/delimited-files/custom-delimiter-json.txt",
             "--jsonLines",
             "-PlineSep=:\n",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "custom-delimited-test",
             "--uriTemplate", "/custom/delimited/{firstName}.json"
@@ -115,7 +115,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "import_files",
             "--path", "src/test/resources/json-files/object-files/objects.zip",
             "--compression", "zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "zipped-objects",
             "--uriReplace", ".*object-files,''"
@@ -134,7 +134,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "--path", "src/test/resources/delimited-files/line-delimited-json.txt",
             "--path", "src/test/resources/xml-file/single-xml.zip",
             "--jsonLines",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-json-test"
         ));
@@ -157,7 +157,7 @@ class ImportJsonFilesTest extends AbstractTest {
             "--path", "src/test/resources/xml-file/single-xml.zip",
             "--jsonLines",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-json-test"
         ));

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportMlcpArchivesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportMlcpArchivesTest.java
@@ -18,7 +18,7 @@ class ImportMlcpArchivesTest extends AbstractTest {
         run(
             "import_mlcp_archives",
             "--path", "src/test/resources/mlcp-archives",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {
@@ -43,7 +43,7 @@ class ImportMlcpArchivesTest extends AbstractTest {
             "import_mlcp_archives",
             "--path", "src/test/resources/mlcp-archives",
             "--categories", "collections,permissions",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {
@@ -66,7 +66,7 @@ class ImportMlcpArchivesTest extends AbstractTest {
             "import_mlcp_archives",
             "--path", "src/test/resources/mlcp-archives",
             "--path", "src/test/resources/mixed-files/goodbye.zip",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         );
 
         assertCollectionSize("The error from the non-MLCP-archive file goodbye.zip should have been logged " +
@@ -80,7 +80,7 @@ class ImportMlcpArchivesTest extends AbstractTest {
             "import_mlcp_archives",
             "--path", "src/test/resources/mixed-files/goodbye.zip",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         ));
 
         assertTrue(stderr.contains("Command failed, cause: Unable to read metadata for entry: goodbye.json"),

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesTest.java
@@ -16,7 +16,7 @@ class ImportOrcFilesTest extends AbstractTest {
         run(
             "import_orc_files",
             "--path", "src/test/resources/orc-files/orc-file.orc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orcFile-test",
             "--uriPrefix", "/orc-test"
@@ -35,7 +35,7 @@ class ImportOrcFilesTest extends AbstractTest {
         run(
             "import_orc_files",
             "--path", "src/test/resources/orc-files/authors.orc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriPrefix", "/orc-test",
             "--jsonRootName", "myOrcData",
@@ -51,7 +51,7 @@ class ImportOrcFilesTest extends AbstractTest {
         run(
             "import_orc_files",
             "--path", "src/test/resources/orc-files/orc-file.orc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orcFileWithCompressionTest-test",
             "--uriPrefix", "/orc-compressed-test",
@@ -72,7 +72,7 @@ class ImportOrcFilesTest extends AbstractTest {
             run(
                 "import_orc_files",
                 "--path", "src/test/resources/orc-files",
-                "--clientUri", makeClientUri(),
+                "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
                 "-Pspark.sql.parquet.filterPushdown=invalid-value"
             )
@@ -89,7 +89,7 @@ class ImportOrcFilesTest extends AbstractTest {
             "import_orc_files",
             "--path", "src/test/resources/orc-files/authors.orc",
             "--path", "src/test/resources/avro/colors.avro",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orc-data"
         ));
@@ -105,7 +105,7 @@ class ImportOrcFilesTest extends AbstractTest {
             "import_parquet_files",
             "--path", "src/test/resources/avro/colors.avro",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS
         ));
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesTest.java
@@ -14,7 +14,7 @@ class ImportParquetFilesTest extends AbstractTest {
         run(
             "import_parquet_files",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test",
             "--uriTemplate", "/parquet/{model}.json"
@@ -31,7 +31,7 @@ class ImportParquetFilesTest extends AbstractTest {
         run(
             "import_parquet_files",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test",
             "--jsonRootName", "car",
@@ -47,7 +47,7 @@ class ImportParquetFilesTest extends AbstractTest {
         run(
             "import_parquet_files",
             "--path", "src/test/resources/parquet/related/*.parquet",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test",
             "-PmergeSchema=true",
@@ -93,7 +93,7 @@ class ImportParquetFilesTest extends AbstractTest {
             run(
                 "import_parquet_files",
                 "--path", "src/test/resources/parquet/individual/cars.parquet",
-                "--clientUri", makeClientUri(),
+                "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
                 "-Pspark.sql.parquet.filterPushdown=invalid-value"
             )
@@ -113,7 +113,7 @@ class ImportParquetFilesTest extends AbstractTest {
             // Without mergeSchema=true, Spark will throw an error of "Unable to infer schema for Parquet". This seems
             // to occur if there's at least one bad file. With mergeSchema=true,
             "-PmergeSchema=true",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-cars"
         ));
@@ -133,7 +133,7 @@ class ImportParquetFilesTest extends AbstractTest {
             // This is kept here to ensure the command fails because it could read the Avro file and not because
             // Spark could not infer a schema.
             "-PmergeSchema=true",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS
         ));
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportRdfFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportRdfFilesTest.java
@@ -14,7 +14,7 @@ class ImportRdfFilesTest extends AbstractTest {
         run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/englishlocale.ttl",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "my-triples"
         );
@@ -34,7 +34,7 @@ class ImportRdfFilesTest extends AbstractTest {
         run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/englishlocale.ttl",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--graph", "my-graph"
         );
@@ -48,7 +48,7 @@ class ImportRdfFilesTest extends AbstractTest {
         run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/three-quads.trig",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--graphOverride", "my-other-graph"
         );
@@ -70,7 +70,7 @@ class ImportRdfFilesTest extends AbstractTest {
         run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/englishlocale2.ttl.gz",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--compression", "gzip"
         );
@@ -86,7 +86,7 @@ class ImportRdfFilesTest extends AbstractTest {
         run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/each-rdf-file-type.zip",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "all-my-rdf",
             "--compression", "zip"
@@ -111,7 +111,7 @@ class ImportRdfFilesTest extends AbstractTest {
         String stderr = runAndReturnStderr(() -> run(
             "import_rdf_files",
             "--path", "src/test/resources/rdf/englishlocale.ttl",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "my-triples",
             "--uriTemplate", "/test/{uri}"
@@ -130,7 +130,7 @@ class ImportRdfFilesTest extends AbstractTest {
             "import_rdf_files",
             "--path", "src/test/resources/mixed-files/hello2.txt.gz",
             "--path", "src/test/resources/rdf/englishlocale.ttl",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "my-triples"
         );
@@ -145,7 +145,7 @@ class ImportRdfFilesTest extends AbstractTest {
             "import_rdf_files",
             "--path", "src/test/resources/mixed-files/hello2.txt.gz",
             "--abortOnReadFailure",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--collections", "my-triples"
         ));
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportRowsAsXmlTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportRowsAsXmlTest.java
@@ -16,7 +16,7 @@ class ImportRowsAsXmlTest extends AbstractTest {
         run(
             "import_delimited_files",
             "--path", "src/test/resources/delimited-files/three-rows.csv",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-xml",
             "--uriTemplate", "/delimited/{number}.xml",
@@ -39,7 +39,7 @@ class ImportRowsAsXmlTest extends AbstractTest {
             "--jdbcPassword", PostgresUtil.PASSWORD,
             "--jdbcDriver", PostgresUtil.DRIVER,
             "--query", "select * from customer where customer_id < 11",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uriTemplate", "/customer/{customer_id}.xml",
             "--collections", "jdbc-customer",
@@ -58,7 +58,7 @@ class ImportRowsAsXmlTest extends AbstractTest {
         run(
             "import_parquet_files",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test",
             "--xmlRootName", "myParquet",
@@ -77,7 +77,7 @@ class ImportRowsAsXmlTest extends AbstractTest {
         run(
             "import_avro_files",
             "--path", "src/test/resources/avro/*",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-test",
             "--uriTemplate", "/avro/{color}.xml",
@@ -96,7 +96,7 @@ class ImportRowsAsXmlTest extends AbstractTest {
         run(
             "import_orc_files",
             "--path", "src/test/resources/orc-files/authors.orc",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orc-test",
             "--uriTemplate", "/orc/{ForeName}",

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/reprocess/ReprocessOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/reprocess/ReprocessOptionsTest.java
@@ -13,7 +13,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readInvoke() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readInvoke", "/my/invoke.sjs",
             "--readPartitionsInvoke", "/my/other-invoke.sjs",
             "--readVar", "param1=value1",
@@ -32,7 +32,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeInvoke() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readInvoke", "/my/invoke.sjs",
             "--writeInvoke", "/my/invoke.sjs",
             "--externalVariableName", "MY_VAR",
@@ -57,7 +57,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readJavascript() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readJavascript", "fn.currentDate()",
             "--readPartitionsJavascript", "console.log('')",
             "--writeJavascript", "fn.currentDate()"
@@ -72,7 +72,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeJavascript() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readJavascript", "fn.currentDate()",
             "--writeJavascript", "fn.currentDate()"
         );
@@ -85,7 +85,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readXquery() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readXquery", "fn:current-date()",
             "--readPartitionsXquery", "xdmp:log('')",
             "--writeXquery", "fn:current-date()"
@@ -100,7 +100,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeXquery() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readXquery", "fn:current-date()",
             "--writeXquery", "fn:current-date()"
         );
@@ -113,7 +113,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readJavascriptFile() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readJavascriptFile", "my-code.js",
             "--readPartitionsJavascriptFile", "path/my-partitions.js",
             "--writeJavascript", "fn.currentDate()"
@@ -128,7 +128,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void readXqueryFile() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readXqueryFile", "my-code.xqy",
             "--readPartitionsXqueryFile", "path/my-partitions.xqy",
             "--writeJavascript", "fn.currentDate()"
@@ -143,7 +143,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeJavascriptFile() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readJavascript", "doesn't matter",
             "--writeJavascriptFile", "my-code.js"
         );
@@ -156,7 +156,7 @@ class ReprocessOptionsTest extends AbstractOptionsTest {
     @Test
     void writeXqueryFile() {
         ReprocessCommand command = (ReprocessCommand) getCommand("reprocess",
-            "--clientUri", "user:password@host:8000",
+            "--connectionString", "user:password@host:8000",
             "--readJavascript", "doesn't matter",
             "--writeXqueryFile", "my-code.xqy"
         );

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/reprocess/ReprocessTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/reprocess/ReprocessTest.java
@@ -17,7 +17,7 @@ class ReprocessTest extends AbstractTest {
     void test() {
         run(
             "reprocess",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--readJavascript", "var collection; cts.uris(null, null, cts.collectionQuery(collection))",
             "--readVar", "collection=author",
             "--writeInvoke", "/writeDocument.sjs",
@@ -38,7 +38,7 @@ class ReprocessTest extends AbstractTest {
     void previewDoesntRequireWriteParam() {
         String stdout = runAndReturnStdout(() -> run(
             "reprocess",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--readJavascript", "cts.uris(null, null, cts.collectionQuery('author'))",
             "--preview", "2"
         ));
@@ -52,7 +52,7 @@ class ReprocessTest extends AbstractTest {
     void missingReadParam() {
         String stderr = runAndReturnStderr(() -> run(
             "reprocess",
-            "--clientUri", makeClientUri()
+            "--connectionString", makeConnectionString()
         ));
 
         assertTrue(
@@ -65,7 +65,7 @@ class ReprocessTest extends AbstractTest {
     void missingWriteParam() {
         String stderr = runAndReturnStderr(() -> run(
             "reprocess",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--readJavascript", "fn.currentDate()"
         ));
 
@@ -79,7 +79,7 @@ class ReprocessTest extends AbstractTest {
     void moreThanOnePartitionParam() {
         String stderr = runAndReturnStderr(() -> run(
             "reprocess",
-            "--clientUri", makeClientUri(),
+            "--connectionString", makeConnectionString(),
             "--readJavascript", "doesn't matter",
             "--writeJavascript", "doesn't matter",
             "--readPartitionsJavascript", "doesn't matter",


### PR DESCRIPTION
No functional changes. Just a lot of renaming. Same was done for "outputClientUri". 