### PR TITLE
Every command now supports Spark config options

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/OptionsUtil.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/OptionsUtil.java
@@ -26,30 +26,7 @@ public abstract class OptionsUtil {
         options.putAll(makeOptions(keysAndValues));
         return options;
     }
-
-    /**
-     * Spark configuration options begin with "spark.sql." - for example, see
-     * https://spark.apache.org/docs/latest/sql-data-sources-parquet.html . For these to have an effect, they must
-     * be included in the Spark configuration instead of as an option for the reader or writer.
-     *
-     * @param option
-     * @return
-     */
-    public static boolean isSparkConfigurationOption(Map.Entry<String, String> option) {
-        return option.getKey() != null && option.getKey().startsWith("spark.sql.");
-    }
-
-    /**
-     * Any option - typically from a map of dynamic parameters - that does not begin with "spark.sql." is considered
-     * to be a data source option that should be included as an option for the reader or writer.
-     *
-     * @param option
-     * @return
-     */
-    public static boolean isSparkDataSourceOption(Map.Entry<String, String> option) {
-        return option.getKey() != null && !option.getKey().startsWith("spark.sql.");
-    }
-
+    
     private OptionsUtil() {
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/AbstractImportStructuredFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/AbstractImportStructuredFilesCommand.java
@@ -4,7 +4,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
-import org.apache.spark.sql.SparkSession;
 
 import java.util.Map;
 
@@ -35,21 +34,10 @@ abstract class AbstractImportStructuredFilesCommand extends AbstractImportFilesC
     }
 
     @Override
-    protected final void modifySparkSession(SparkSession session) {
-        if (dynamicParams != null) {
-            dynamicParams.entrySet().stream()
-                .filter(OptionsUtil::isSparkConfigurationOption)
-                .forEach(entry -> session.conf().set(entry.getKey(), entry.getValue()));
-        }
-    }
-
-    @Override
     protected Map<String, String> makeReadOptions() {
         Map<String, String> options = super.makeReadOptions();
         if (dynamicParams != null) {
-            dynamicParams.entrySet().stream()
-                .filter(OptionsUtil::isSparkDataSourceOption)
-                .forEach(entry -> options.put(entry.getKey(), entry.getValue()));
+            options.putAll(dynamicParams);
         }
         return options;
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAvroFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAvroFilesCommand.java
@@ -8,14 +8,14 @@ import java.util.Map;
 
 @Parameters(commandDescription = "Read Avro files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-avro.html, with each row being written " +
-    "to MarkLogic.")
+    "as a JSON or XML document in MarkLogic.")
 public class ImportAvroFilesCommand extends AbstractImportStructuredFilesCommand {
 
     @DynamicParameter(
         names = "-P",
-        description = "Specify any Spark Avro option or configuration item defined at" +
-            "https://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true or " +
-            "-Pspark.sql.avro.filterPushdown.enabled=false."
+        description = "Specify any Spark Avro data source option defined at " +
+            "https://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true. " +
+            "Spark configuration options must be defined via '-C'."
     )
     private Map<String, String> avroParams;
 

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesCommand.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @Parameters(commandDescription = "Read delimited text files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-csv.html, with each row being written " +
-    "as a JSON document to MarkLogic.")
+    "as a JSON  or XML document to MarkLogic.")
 public class ImportDelimitedFilesCommand extends AbstractImportStructuredFilesCommand {
 
     @DynamicParameter(

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportJdbcCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportJdbcCommand.java
@@ -11,7 +11,7 @@ import org.apache.spark.sql.*;
 
 import java.util.*;
 
-@Parameters(commandDescription = "Read rows via JDBC and write JSON documents to MarkLogic.")
+@Parameters(commandDescription = "Read rows via JDBC and write JSON or XML documents to MarkLogic.")
 public class ImportJdbcCommand extends AbstractCommand {
 
     @ParametersDelegate

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportOrcFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportOrcFilesCommand.java
@@ -8,14 +8,14 @@ import java.util.Map;
 
 @Parameters(commandDescription = "Read ORC files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-orc.html, with each row being " +
-    "written as a JSON document in MarkLogic.")
+    "written as a JSON or XML document in MarkLogic.")
 public class ImportOrcFilesCommand extends AbstractImportStructuredFilesCommand {
 
     @DynamicParameter(
         names = "-P",
-        description = "Specify any Spark ORC option or configuration item defined at " +
-            "https://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -PmergeSchema=true or " +
-            "-Pspark.sql.orc.filterPushdown=false."
+        description = "Specify any Spark ORC data source option defined at " +
+            "https://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -PmergeSchema=true. " +
+            "Spark configuration options must be defined via '-C'."
     )
     private Map<String, String> orcParams;
 

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportParquetFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportParquetFilesCommand.java
@@ -8,14 +8,14 @@ import java.util.Map;
 
 @Parameters(commandDescription = "Read Parquet files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-parquet.html, with each row being written " +
-    "as a JSON document in MarkLogic.")
+    "as a JSON or XML document in MarkLogic.")
 public class ImportParquetFilesCommand extends AbstractImportStructuredFilesCommand {
 
     @DynamicParameter(
         names = "-P",
-        description = "Specify any Spark Parquet option or configuration item defined at " +
-            "https://spark.apache.org/docs/latest/sql-data-sources-parquet.html; e.g. -PmergeSchema=true or " +
-            "-Pspark.sql.parquet.filterPushdown=false."
+        description = "Specify any Spark Parquet data source option defined at " +
+            "https://spark.apache.org/docs/latest/sql-data-sources-parquet.html; e.g. -PmergeSchema=true. " +
+            "Spark configuration options must be defined via '-C'."
     )
     private Map<String, String> parquetParams;
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesOptionsTest.java
@@ -15,7 +15,7 @@ class ImportAvroFilesOptionsTest extends AbstractOptionsTest {
             "import_avro_files",
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
-            "-Pspark.sql.parquet.filterPushdown=false",
+            "-Cspark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportAvroFilesTest.java
@@ -70,7 +70,7 @@ class ImportAvroFilesTest extends AbstractTest {
                 "--path", "src/test/resources/avro/*",
                 "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
-                "-Pspark.sql.parquet.filterPushdown=invalid-value"
+                "-Cspark.sql.parquet.filterPushdown=invalid-value"
             )
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesOptionsTest.java
@@ -15,7 +15,7 @@ class ImportOrcFilesOptionsTest extends AbstractOptionsTest {
             "import_orc_files",
             "--path", "/doesnt/matter",
             "-PmergeSchema=true",
-            "-Pspark.sql.parquet.filterPushdown=false",
+            "-Cspark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportOrcFilesTest.java
@@ -64,7 +64,7 @@ class ImportOrcFilesTest extends AbstractTest {
                 "--path", "src/test/resources/orc-files",
                 "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
-                "-Pspark.sql.parquet.filterPushdown=invalid-value"
+                "-Cspark.sql.parquet.filterPushdown=invalid-value"
             )
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesOptionsTest.java
@@ -15,7 +15,7 @@ class ImportParquetFilesOptionsTest extends AbstractOptionsTest {
             "import_parquet_files",
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
-            "-Pspark.sql.parquet.filterPushdown=false",
+            "-Cspark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/command/importdata/ImportParquetFilesTest.java
@@ -95,7 +95,7 @@ class ImportParquetFilesTest extends AbstractTest {
                 "--path", "src/test/resources/parquet/individual/cars.parquet",
                 "--connectionString", makeConnectionString(),
                 "--permissions", DEFAULT_PERMISSIONS,
-                "-Pspark.sql.parquet.filterPushdown=invalid-value"
+                "-Cspark.sql.parquet.filterPushdown=invalid-value"
             )
         );
 


### PR DESCRIPTION
This is slightly more complicated for Avro/Parquet/ORC import, as a user must now distinguish between data source options and Spark configuration options. However, the Spark documentation already distinguishes the two. 

The benefit is that every command now supports Spark config options via `-C`. This will be useful for the upcoming "custom" commands. 