### PR TITLE
ML-14061 Can now do basic import of all file types

### DIFF
--- a/client-project/build.gradle
+++ b/client-project/build.gradle
@@ -8,5 +8,9 @@ repositories {
 }
 
 dependencies {
-  implementation "com.marklogic:new-tool-cli:0.3-SNAPSHOT"
+  implementation ("com.marklogic:new-tool-cli:0.3-SNAPSHOT") {
+    // It's possible to exclude this from the runtime classpath if none of the classes a user interacts with
+    // implement JCommander interfaces.
+    // exclude module: "jcommander"
+  }
 }

--- a/client-project/src/main/java/org/example/App.java
+++ b/client-project/src/main/java/org/example/App.java
@@ -1,16 +1,18 @@
 package org.example;
 
+import com.marklogic.newtool.api.DocumentType;
 import com.marklogic.newtool.api.NT;
 
 public class App {
 
     public static void main(String[] args) {
         // Currently depends on spark-etl test-app.
-        NT.importFiles()
-                .withConnectionString("new-tool-user:password@localhost:8003")
-                .withPath("../new-tool-cli/src/test/resources/mixed-files")
-                .withCollections("client-files")
-                .withPermissionsString("new-tool-role,read,new-tool-role,update")
-                .execute();
+        NT.importGenericFiles()
+            .withConnectionString("new-tool-user:password@localhost:8003")
+            .withPath("../new-tool-cli/src/test/resources/mixed-files")
+            .withCollections("client-files")
+            .withPermissionsString("new-tool-role,read,new-tool-role,update")
+            .withDocumentType(DocumentType.JSON)
+            .execute();
     }
 }

--- a/new-tool-cli/build.gradle
+++ b/new-tool-cli/build.gradle
@@ -119,6 +119,11 @@ java {
   withJavadocJar()
   withSourcesJar()
 }
+
+javadoc {
+  include "com/marklogic/newtool/api/**"
+}
+
 publishing {
   publications {
     mainJava(MavenPublication) {

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/AggregateXmlFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/AggregateXmlFilesImporter.java
@@ -1,0 +1,8 @@
+package com.marklogic.newtool.api;
+
+public interface AggregateXmlFilesImporter extends FilesImporter<AggregateXmlFilesImporter> {
+
+    AggregateXmlFilesImporter withElement(String element);
+
+    AggregateXmlFilesImporter withNamespace(String namespace);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/ArchivesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/ArchivesImporter.java
@@ -1,0 +1,6 @@
+package com.marklogic.newtool.api;
+
+public interface ArchivesImporter extends FilesImporter<ArchivesImporter> {
+
+    ArchivesImporter withCategoriesString(String commaDelimitedCategories);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/AvroFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/AvroFilesImporter.java
@@ -1,0 +1,4 @@
+package com.marklogic.newtool.api;
+
+public interface AvroFilesImporter extends FilesImporter<AvroFilesImporter> {
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/DelimitedFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/DelimitedFilesImporter.java
@@ -1,0 +1,4 @@
+package com.marklogic.newtool.api;
+
+public interface DelimitedFilesImporter extends FilesImporter<DelimitedFilesImporter> {
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/DocumentType.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/DocumentType.java
@@ -1,0 +1,7 @@
+package com.marklogic.newtool.api;
+
+public enum DocumentType {
+    JSON,
+    TEXT,
+    XML
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/FilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/FilesImporter.java
@@ -1,0 +1,13 @@
+package com.marklogic.newtool.api;
+
+/**
+ * Base interface for objects that can import files as documents in MarkLogic.
+ */
+public interface FilesImporter<T extends FilesImporter> extends Importer<T> {
+
+    T withPath(String path);
+
+    T withFilter(String filter);
+
+    T withRecursiveFileLookup(boolean value);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/GenericFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/GenericFilesImporter.java
@@ -1,19 +1,6 @@
 package com.marklogic.newtool.api;
 
-import com.marklogic.client.io.DocumentMetadataHandle;
+public interface GenericFilesImporter extends FilesImporter<GenericFilesImporter> {
 
-import java.util.Map;
-import java.util.Set;
-
-public interface GenericFilesImporter extends Executor<GenericFilesImporter> {
-
-    GenericFilesImporter withPath(String path);
-
-    GenericFilesImporter withCollections(String... collections);
-
-    GenericFilesImporter withCollectionsString(String commaDelimitedCollections);
-
-    GenericFilesImporter withPermissions(Map<String, Set<DocumentMetadataHandle.Capability>> permissions);
-
-    GenericFilesImporter withPermissionsString(String rolesAndCapabilities);
+    GenericFilesImporter withDocumentType(DocumentType documentType);
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/Importer.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/Importer.java
@@ -1,0 +1,20 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.client.io.DocumentMetadataHandle;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Base interface for executors that can import data as documents in MarkLogic.
+ */
+public interface Importer<T extends Executor> extends Executor<T> {
+
+    T withCollections(String... collections);
+
+    T withCollectionsString(String commaDelimitedCollections);
+
+    T withPermissions(Map<String, Set<DocumentMetadataHandle.Capability>> permissions);
+
+    T withPermissionsString(String rolesAndCapabilities);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/JsonFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/JsonFilesImporter.java
@@ -1,0 +1,15 @@
+package com.marklogic.newtool.api;
+
+public interface JsonFilesImporter extends FilesImporter<JsonFilesImporter> {
+
+    /**
+     * @param value If true, then each file is expected to corresponds to the JSON Lines format with one JSON object
+     *              per line.
+     */
+    JsonFilesImporter withJsonLines(boolean value);
+
+    /**
+     * @param jsonRootName Name of a root field to add to each JSON document.
+     */
+    JsonFilesImporter withJsonRootName(String jsonRootName);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/MlcpArchivesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/MlcpArchivesImporter.java
@@ -1,0 +1,6 @@
+package com.marklogic.newtool.api;
+
+public interface MlcpArchivesImporter extends FilesImporter<MlcpArchivesImporter> {
+
+    MlcpArchivesImporter withCategoriesString(String commaDelimitedCategories);
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/NT.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/NT.java
@@ -1,8 +1,24 @@
 package com.marklogic.newtool.api;
 
-import com.marklogic.newtool.command.importdata.ImportFilesCommand;
+import com.marklogic.newtool.command.importdata.*;
 
 public interface NT {
+
+    static AggregateXmlFilesImporter importAggregateXmlFiles() {
+        return new ImportAggregateXmlCommand();
+    }
+
+    static ArchivesImporter importArchives() {
+        return new ImportArchivesCommand();
+    }
+
+    static AvroFilesImporter importAvroFiles() {
+        return new ImportAvroFilesCommand();
+    }
+
+    static DelimitedFilesImporter importDelimitedFiles() {
+        return new ImportDelimitedFilesCommand();
+    }
 
     /**
      * @return an object that can import any type of file as-is, with the document type being determined by
@@ -10,5 +26,21 @@ public interface NT {
      */
     static GenericFilesImporter importGenericFiles() {
         return new ImportFilesCommand();
+    }
+
+    static JsonFilesImporter importJsonFiles() {
+        return new ImportJsonFilesCommand();
+    }
+
+    static MlcpArchivesImporter importMlcpArchives() {
+        return new ImportMlcpArchivesCommand();
+    }
+
+    static OrcFilesImporter importOrcFiles() {
+        return new ImportOrcFilesCommand();
+    }
+    
+    static ParquetFilesImporter importParquetFiles() {
+        return new ImportParquetFilesCommand();
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/OrcFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/OrcFilesImporter.java
@@ -1,0 +1,4 @@
+package com.marklogic.newtool.api;
+
+public interface OrcFilesImporter extends FilesImporter<OrcFilesImporter> {
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/ParquetFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/ParquetFilesImporter.java
@@ -1,0 +1,4 @@
+package com.marklogic.newtool.api;
+
+public interface ParquetFilesImporter extends FilesImporter<ParquetFilesImporter> {
+}

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/AbstractImportStructuredFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/AbstractImportStructuredFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import com.marklogic.newtool.api.FilesImporter;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
 
@@ -10,7 +11,7 @@ import java.util.Map;
 /**
  * "Structured files" = rows with an arbitrary schema that can be converted into either JSON or XML documents.
  */
-abstract class AbstractImportStructuredFilesCommand extends AbstractImportFilesCommand {
+abstract class AbstractImportStructuredFilesCommand<T extends FilesImporter<T>> extends AbstractImportFilesCommand<T> {
 
     @Parameter(
         names = "--jsonRootName",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAggregateXmlCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAggregateXmlCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.AggregateXmlFilesImporter;
 import com.marklogic.newtool.command.CompressionType;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
@@ -10,16 +11,9 @@ import java.util.Map;
 
 @Parameters(commandDescription = "Read aggregate XML files from local, HDFS, and S3 locations using Spark's support " +
     "with each row being written to MarkLogic.")
-public class ImportAggregateXmlCommand extends AbstractImportFilesCommand {
+public class ImportAggregateXmlCommand extends AbstractImportFilesCommand<AggregateXmlFilesImporter> implements AggregateXmlFilesImporter {
 
-    @Parameter(required = true, names = "--element",
-        description = "Specifies the local name of the element to use as the root of each document."
-    )
     private String element;
-
-    @Parameter(names = "--namespace",
-        description = "Specifies the namespace of the element to use as the root of each document."
-    )
     private String namespace;
 
     @Parameter(names = "--uriElement",
@@ -52,5 +46,23 @@ public class ImportAggregateXmlCommand extends AbstractImportFilesCommand {
             Options.READ_AGGREGATES_XML_URI_NAMESPACE, uriNamespace,
             Options.READ_FILES_COMPRESSION, compression != null ? compression.name() : null
         );
+    }
+
+    @Override
+    @Parameter(required = true, names = "--element",
+        description = "Specifies the local name of the element to use as the root of each document."
+    )
+    public AggregateXmlFilesImporter withElement(String element) {
+        this.element = element;
+        return this;
+    }
+
+    @Override
+    @Parameter(names = "--namespace",
+        description = "Specifies the namespace of the element to use as the root of each document."
+    )
+    public AggregateXmlFilesImporter withNamespace(String namespace) {
+        this.namespace = namespace;
+        return this;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportArchivesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportArchivesCommand.java
@@ -2,17 +2,15 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.ArchivesImporter;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
 
 import java.util.Map;
 
 @Parameters(commandDescription = "Read local, HDFS, and S3 archive files created via the 'export_archives' command and write the documents in each archive to MarkLogic.")
-public class ImportArchivesCommand extends AbstractImportFilesCommand {
-
-    @Parameter(names = "--categories", description = "Comma-delimited sequence of categories of metadata to include. " +
-        "If not specified, all types of metadata are included. " +
-        "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
+public class ImportArchivesCommand extends AbstractImportFilesCommand<ArchivesImporter> implements ArchivesImporter {
+    
     private String categories;
 
     @Override
@@ -26,5 +24,14 @@ public class ImportArchivesCommand extends AbstractImportFilesCommand {
             Options.READ_FILES_TYPE, "archive",
             Options.READ_ARCHIVES_CATEGORIES, categories
         );
+    }
+
+    @Override
+    @Parameter(names = "--categories", description = "Comma-delimited sequence of categories of metadata to include. " +
+        "If not specified, all types of metadata are included. " +
+        "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
+    public ArchivesImporter withCategoriesString(String commaDelimitedCategories) {
+        this.categories = commaDelimitedCategories;
+        return this;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAvroFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportAvroFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.AvroFilesImporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.Map;
 @Parameters(commandDescription = "Read Avro files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-avro.html, with each row being written " +
     "as a JSON or XML document in MarkLogic.")
-public class ImportAvroFilesCommand extends AbstractImportStructuredFilesCommand {
+public class ImportAvroFilesCommand extends AbstractImportStructuredFilesCommand<AvroFilesImporter> implements AvroFilesImporter {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportDelimitedFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.DelimitedFilesImporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.Map;
 @Parameters(commandDescription = "Read delimited text files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-csv.html, with each row being written " +
     "as a JSON  or XML document to MarkLogic.")
-public class ImportDelimitedFilesCommand extends AbstractImportStructuredFilesCommand {
+public class ImportDelimitedFilesCommand extends AbstractImportStructuredFilesCommand<DelimitedFilesImporter> implements DelimitedFilesImporter {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportFilesCommand.java
@@ -2,32 +2,19 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.marklogic.client.io.DocumentMetadataHandle;
-import com.marklogic.newtool.SparkUtil;
+import com.marklogic.newtool.api.DocumentType;
 import com.marklogic.newtool.api.GenericFilesImporter;
 import com.marklogic.newtool.command.CompressionType;
-import com.marklogic.newtool.command.Preview;
 import com.marklogic.spark.Options;
 
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Parameters(commandDescription = "Read local, HDFS, and S3 files and write the contents of each file as a document in MarkLogic.")
-public class ImportFilesCommand extends AbstractImportFilesCommand implements GenericFilesImporter {
-    
-    public enum DocumentType {
-        JSON,
-        TEXT,
-        XML
-    }
+public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesImporter> implements GenericFilesImporter {
 
     @Parameter(names = "--compression", description = "When importing compressed files, specify the type of compression used.")
     private CompressionType compression;
 
-    @Parameter(names = "--documentType", description = "Forces a type for any document with an unrecognized URI extension.")
     private DocumentType documentType;
 
     @Override
@@ -54,54 +41,9 @@ public class ImportFilesCommand extends AbstractImportFilesCommand implements Ge
     }
 
     @Override
-    public Optional<Preview> execute() {
-        return execute(SparkUtil.buildSparkSession());
-    }
-
-    @Override
-    public GenericFilesImporter withConnectionString(String connectionString) {
-        getConnectionParams().setConnectionString(connectionString);
-        return this;
-    }
-
-    @Override
-    public GenericFilesImporter withPath(String path) {
-        getReadFilesParams().getPaths().add(path);
-        return this;
-    }
-
-    @Override
-    public GenericFilesImporter withCollectionsString(String commaDelimitedCollections) {
-        getWriteDocumentParams().setCollections(commaDelimitedCollections);
-        return this;
-    }
-
-    @Override
-    public GenericFilesImporter withCollections(String... collections) {
-        getWriteDocumentParams().setCollections(Stream.of(collections).collect(Collectors.joining(",")));
-        return this;
-    }
-
-    @Override
-    public GenericFilesImporter withPermissionsString(String rolesAndCapabilities) {
-        getWriteDocumentParams().setPermissions(rolesAndCapabilities);
-        return this;
-    }
-
-    @Override
-    public GenericFilesImporter withPermissions(Map<String, Set<DocumentMetadataHandle.Capability>> permissions) {
-        // This likely won't stay here, will get refactored to a non-command-specific location.
-        StringBuilder sb = new StringBuilder();
-        permissions.entrySet().stream().forEach(entry -> {
-            String role = entry.getKey();
-            entry.getValue().forEach(capability -> {
-                if (!sb.toString().equals("")) {
-                    sb.append(",");
-                }
-                sb.append(role).append(",").append(capability.name());
-            });
-        });
-        getWriteDocumentParams().setPermissions(sb.toString());
+    @Parameter(names = "--documentType", description = "Forces a type for any document with an unrecognized URI extension.")
+    public GenericFilesImporter withDocumentType(DocumentType documentType) {
+        this.documentType = documentType;
         return this;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportJsonFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportJsonFilesCommand.java
@@ -3,6 +3,7 @@ package com.marklogic.newtool.command.importdata;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.JsonFilesImporter;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
 
@@ -12,18 +13,10 @@ import java.util.Map;
 @Parameters(commandDescription = "Read JSON files, including JSON Lines files, from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-json.html , with each object being written " +
     "as a JSON document in MarkLogic.")
-public class ImportJsonFilesCommand extends AbstractImportFilesCommand {
+public class ImportJsonFilesCommand extends AbstractImportFilesCommand<JsonFilesImporter> implements JsonFilesImporter {
 
-    @Parameter(
-        names = "--jsonLines",
-        description = "Specifies that the file contains one JSON object per line, per the JSON Lines format defined at https://jsonlines.org/ ."
-    )
     private Boolean jsonLines;
 
-    @Parameter(
-        names = "--jsonRootName",
-        description = "Name of a root field to add to each JSON document."
-    )
     private String jsonRootName;
 
     @DynamicParameter(
@@ -55,5 +48,25 @@ public class ImportJsonFilesCommand extends AbstractImportFilesCommand {
         return OptionsUtil.addOptions(super.makeWriteOptions(),
             Options.WRITE_JSON_ROOT_NAME, jsonRootName
         );
+    }
+
+    @Override
+    @Parameter(
+        names = "--jsonLines",
+        description = "Specifies that the file contains one JSON object per line, per the JSON Lines format defined at https://jsonlines.org/ ."
+    )
+    public JsonFilesImporter withJsonLines(boolean value) {
+        this.jsonLines = value;
+        return this;
+    }
+
+    @Override
+    @Parameter(
+        names = "--jsonRootName",
+        description = "Name of a root field to add to each JSON document."
+    )
+    public JsonFilesImporter withJsonRootName(String jsonRootName) {
+        this.jsonRootName = jsonRootName;
+        return this;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportMlcpArchivesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportMlcpArchivesCommand.java
@@ -2,17 +2,15 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.MlcpArchivesImporter;
 import com.marklogic.newtool.command.OptionsUtil;
 import com.marklogic.spark.Options;
 
 import java.util.Map;
 
 @Parameters(commandDescription = "Read local, HDFS, and S3 archive files written by MLCP and write the documents in each archive to MarkLogic.")
-public class ImportMlcpArchivesCommand extends AbstractImportFilesCommand {
-
-    @Parameter(names = "--categories", description = "Comma-delimited sequence of categories of metadata to include. " +
-        "If not specified, all types of metadata are included. " +
-        "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
+public class ImportMlcpArchivesCommand extends AbstractImportFilesCommand<MlcpArchivesImporter> implements MlcpArchivesImporter {
+    
     private String categories;
 
     @Override
@@ -26,5 +24,14 @@ public class ImportMlcpArchivesCommand extends AbstractImportFilesCommand {
             Options.READ_FILES_TYPE, "mlcp_archive",
             Options.READ_ARCHIVES_CATEGORIES, categories
         );
+    }
+
+    @Override
+    @Parameter(names = "--categories", description = "Comma-delimited sequence of categories of metadata to include. " +
+        "If not specified, all types of metadata are included. " +
+        "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
+    public MlcpArchivesImporter withCategoriesString(String commaDelimitedCategories) {
+        this.categories = commaDelimitedCategories;
+        return this;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportOrcFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportOrcFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.OrcFilesImporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.Map;
 @Parameters(commandDescription = "Read ORC files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-orc.html, with each row being " +
     "written as a JSON or XML document in MarkLogic.")
-public class ImportOrcFilesCommand extends AbstractImportStructuredFilesCommand {
+public class ImportOrcFilesCommand extends AbstractImportStructuredFilesCommand<OrcFilesImporter> implements OrcFilesImporter {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportParquetFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ImportParquetFilesCommand.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.command.importdata;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameters;
+import com.marklogic.newtool.api.ParquetFilesImporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,7 @@ import java.util.Map;
 @Parameters(commandDescription = "Read Parquet files from local, HDFS, and S3 locations using Spark's support " +
     "defined at https://spark.apache.org/docs/latest/sql-data-sources-parquet.html, with each row being written " +
     "as a JSON or XML document in MarkLogic.")
-public class ImportParquetFilesCommand extends AbstractImportStructuredFilesCommand {
+public class ImportParquetFilesCommand extends AbstractImportStructuredFilesCommand<ParquetFilesImporter> implements ParquetFilesImporter {
 
     @DynamicParameter(
         names = "-P",

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ReadFilesParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/command/importdata/ReadFilesParams.java
@@ -84,4 +84,12 @@ public class ReadFilesParams {
     public S3Params getS3Params() {
         return s3Params;
     }
+
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    public void setRecursiveFileLookup(Boolean recursiveFileLookup) {
+        this.recursiveFileLookup = recursiveFileLookup;
+    }
 }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/AggregateXmlFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/AggregateXmlFilesImporterTest.java
@@ -1,0 +1,27 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.junit5.XmlNode;
+import com.marklogic.newtool.AbstractTest;
+import org.jdom2.Namespace;
+import org.junit.jupiter.api.Test;
+
+class AggregateXmlFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importAggregateXmlFiles()
+            .withConnectionString(makeConnectionString())
+            .withPath("src/test/resources/xml-file/people-with-namespace.xml")
+            .withCollections("xml-files")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withElement("person")
+            .withNamespace("org:example")
+            .execute();
+
+        getUrisInCollection("xml-files", 3).forEach(uri -> {
+            XmlNode doc = readXmlDocument(uri);
+            doc.setNamespaces(new Namespace[]{Namespace.getNamespace("ex", "org:example")});
+            doc.assertElementExists("/ex:person/ex:name");
+        });
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/ArchivesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/ArchivesImporterTest.java
@@ -1,0 +1,18 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class ArchivesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importArchives()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-archives")
+            .withPath("src/test/resources/archive-files/archive.zip")
+            .execute();
+
+        assertCollectionSize("api-archives", 2);
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/AvroFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/AvroFilesImporterTest.java
@@ -1,0 +1,19 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class AvroFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importAvroFiles()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-avro")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withPath("src/test/resources/avro/colors.avro")
+            .execute();
+
+        assertCollectionSize("api-avro", 3);
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/DelimitedFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/DelimitedFilesImporterTest.java
@@ -1,0 +1,20 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class DelimitedFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importDelimitedFiles()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-csv")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withPath("src/test/resources/delimited-files/three-rows.csv")
+            .execute();
+
+        assertCollectionSize("api-csv", 3);
+    }
+
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/JsonFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/JsonFilesImporterTest.java
@@ -1,0 +1,29 @@
+package com.marklogic.newtool.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importJsonFiles()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-json")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withJsonLines(true)
+            .withJsonRootName("rootTest")
+            .withPath("src/test/resources/delimited-files/line-delimited-json.txt")
+            .execute();
+
+        getUrisInCollection("api-json", 3).forEach(uri -> {
+            JsonNode doc = readJsonDocument(uri);
+            assertTrue(doc.has("rootTest"));
+            assertTrue(doc.get("rootTest").has("firstName"));
+        });
+    }
+
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/MlcpArchivesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/MlcpArchivesImporterTest.java
@@ -1,0 +1,18 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class MlcpArchivesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importMlcpArchives()
+            .withConnectionString(makeConnectionString())
+            .withPath("src/test/resources/mlcp-archives")
+            .execute();
+
+        assertCollectionSize("collection1", 2);
+        assertCollectionSize("collection2", 2);
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/OrcFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/OrcFilesImporterTest.java
@@ -1,0 +1,20 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class OrcFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importOrcFiles()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-orc")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withPath("src/test/resources/orc-files/authors.orc")
+            .execute();
+
+        assertCollectionSize("api-orc", 15);
+    }
+
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/ParquetFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/ParquetFilesImporterTest.java
@@ -1,0 +1,20 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Test;
+
+class ParquetFilesImporterTest extends AbstractTest {
+
+    @Test
+    void test() {
+        NT.importParquetFiles()
+            .withConnectionString(makeConnectionString())
+            .withCollections("api-parquet")
+            .withPermissionsString(DEFAULT_PERMISSIONS)
+            .withPath("src/test/resources/parquet/individual/cars.parquet")
+            .execute();
+
+        assertCollectionSize("api-parquet", 32);
+    }
+
+}


### PR DESCRIPTION
Lot of files, but not really much logic:

- New interface for each of the commands for importing files.
- New small test for each of the API interfaces.

Main thing this does is establish the hierarchy for the API interfaces. 