### PR TITLE
MLE-14265 Better error message for bad connection string

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/NtException.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/NtException.java
@@ -6,6 +6,10 @@ package com.marklogic.newtool.api;
  */
 public class NtException extends RuntimeException {
 
+    public NtException(String message) {
+        super(message);
+    }
+
     public NtException(Throwable cause) {
         super(cause.getMessage(), cause);
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionInputs.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionInputs.java
@@ -2,6 +2,7 @@ package com.marklogic.newtool.impl;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.newtool.api.AuthenticationType;
+import com.marklogic.newtool.api.NtException;
 import com.marklogic.newtool.api.SslHostnameVerifier;
 import com.marklogic.spark.Options;
 
@@ -42,8 +43,16 @@ public abstract class ConnectionInputs {
     public String getSelectedHost() {
         if (connectionString != null) {
             // TBD Ideally reuse this logic from the connector.
+            final String errorMessage = "Invalid value for --connectionString; must be username:password@host:port";
             String[] parts = connectionString.split("@");
-            return parts[1].split(":")[0];
+            if (parts.length != 2) {
+                throw new NtException(errorMessage);
+            }
+            parts = parts[1].split(":");
+            if (parts.length != 2) {
+                throw new NtException(errorMessage);
+            }
+            return parts[0];
         }
         return host;
     }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/ValidateMarkLogicConnectionTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/ValidateMarkLogicConnectionTest.java
@@ -39,16 +39,28 @@ class ValidateMarkLogicConnectionTest extends AbstractTest {
     }
 
     @Test
-    void badClientUri() {
+    void badConnectionString() {
         String output = runAndReturnStderr(() -> run(
             "import_files",
             "--path", "src/test/resources/mixed-files",
             "--connectionString", "admin-missing-password@localhost:8003"
         ));
 
-        assertTrue(output.contains("Invalid value for --connectionString"),
+        assertTrue(output.contains("Invalid value for --connectionString; must be username:password@host:port"),
             "Unexpected output: " + output + "; this test also confirms that the ETL tool is overriding " +
                 "error messages from the connector so that CLI option names appear instead of connector " +
                 "option names. This is also confirmed by ErrorMessagesTest.");
+    }
+
+    @Test
+    void connectionStringWithoutUserOrPassword() {
+        String output = runAndReturnStderr(() -> run(
+            "import_files",
+            "--path", "src/test/resources/mixed-files",
+            "--connectionString", "localhost:8003"
+        ));
+
+        assertTrue(output.contains("Invalid value for --connectionString; must be username:password@host:port"),
+            "Unexpected output: " + output);
     }
 }


### PR DESCRIPTION
The connector will validate the connection string, but in this scenario where we are logging the host, a connection string without an "@" needs to be handled. 