### PR TITLE
MLE-14304 Can now specify partitions for reading some files

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/AggregateXmlFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/AggregateXmlFilesImporter.java
@@ -14,6 +14,8 @@ public interface AggregateXmlFilesImporter extends Executor<AggregateXmlFilesImp
         ReadXmlFilesOptions uriNamespace(String uriNamespace);
 
         ReadXmlFilesOptions compressionType(CompressionType compressionType);
+
+        ReadXmlFilesOptions partitions(Integer partitions);
     }
 
     AggregateXmlFilesImporter readFiles(Consumer<ReadXmlFilesOptions> consumer);

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/ArchiveFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/ArchiveFilesImporter.java
@@ -6,6 +6,7 @@ public interface ArchiveFilesImporter extends Executor<ArchiveFilesImporter> {
 
     interface ReadArchiveFilesOptions extends ReadFilesOptions<ReadArchiveFilesOptions> {
         ReadArchiveFilesOptions categories(String... categories);
+        ReadArchiveFilesOptions partitions(Integer partitions);
     }
 
     ArchiveFilesImporter readFiles(Consumer<ReadArchiveFilesOptions> consumer);

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/GenericFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/GenericFilesImporter.java
@@ -10,6 +10,7 @@ public interface GenericFilesImporter extends Executor<GenericFilesImporter> {
 
     interface ReadGenericFilesOptions extends ReadFilesOptions<ReadGenericFilesOptions> {
         ReadGenericFilesOptions compressionType(CompressionType compressionType);
+        ReadGenericFilesOptions partitions(Integer partitions);
     }
 
     interface WriteGenericDocumentsOptions extends WriteDocumentsOptions<WriteGenericDocumentsOptions> {

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/MlcpArchiveFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/MlcpArchiveFilesImporter.java
@@ -6,6 +6,7 @@ public interface MlcpArchiveFilesImporter extends Executor<MlcpArchiveFilesImpor
 
     interface ReadMlcpArchiveFilesOptions extends ReadFilesOptions<ReadMlcpArchiveFilesOptions> {
         ReadMlcpArchiveFilesOptions categories(String... categories);
+        ReadMlcpArchiveFilesOptions partitions(Integer partitions);
     }
 
     MlcpArchiveFilesImporter readFiles(Consumer<ReadMlcpArchiveFilesOptions> consumer);

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/RdfFilesImporter.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/RdfFilesImporter.java
@@ -6,6 +6,7 @@ public interface RdfFilesImporter extends Executor<RdfFilesImporter> {
 
     interface ReadRdfFilesOptions extends ReadFilesOptions<ReadRdfFilesOptions> {
         ReadRdfFilesOptions compressionType(CompressionType compressionType);
+        ReadRdfFilesOptions partitions(Integer partitions);
     }
 
     interface WriteTriplesDocumentsOptions extends WriteDocumentsOptions<WriteTriplesDocumentsOptions> {

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportAggregateXmlCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportAggregateXmlCommand.java
@@ -66,10 +66,14 @@ public class ImportAggregateXmlCommand extends AbstractImportFilesCommand<Aggreg
         )
         private CompressionType compressionType;
 
+        @Parameter(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
+        private Integer partitions;
+
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(
                 super.makeOptions(),
+                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null,
                 Options.READ_AGGREGATES_XML_ELEMENT, element,
                 Options.READ_AGGREGATES_XML_NAMESPACE, namespace,
                 Options.READ_AGGREGATES_XML_URI_ELEMENT, uriElement,
@@ -105,6 +109,12 @@ public class ImportAggregateXmlCommand extends AbstractImportFilesCommand<Aggreg
         @Override
         public ReadXmlFilesOptions compressionType(CompressionType compressionType) {
             this.compressionType = compressionType;
+            return this;
+        }
+
+        @Override
+        public ReadXmlFilesOptions partitions(Integer partitions) {
+            this.partitions = partitions;
             return this;
         }
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportArchiveFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportArchiveFilesCommand.java
@@ -45,17 +45,27 @@ public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<Archiv
             "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
         private String categories;
 
+        @Parameter(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
+        private Integer partitions;
+
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
                 Options.READ_FILES_TYPE, "archive",
-                Options.READ_ARCHIVES_CATEGORIES, categories
+                Options.READ_ARCHIVES_CATEGORIES, categories,
+                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
             );
         }
 
         @Override
         public ReadArchiveFilesOptions categories(String... categories) {
             this.categories = Stream.of(categories).collect(Collectors.joining(","));
+            return this;
+        }
+
+        @Override
+        public ReadArchiveFilesOptions partitions(Integer partitions) {
+            this.partitions = partitions;
             return this;
         }
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportFilesCommand.java
@@ -64,11 +64,21 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
             return this;
         }
 
+        @Parameter(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
+        private Integer partitions;
+
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
+                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null,
                 Options.READ_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null
             );
+        }
+
+        @Override
+        public ReadGenericFilesOptions partitions(Integer partitions) {
+            this.partitions = partitions;
+            return this;
         }
     }
 

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportMlcpArchiveFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportMlcpArchiveFilesCommand.java
@@ -44,17 +44,27 @@ public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<Ml
             "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
         private String categories;
 
+        @Parameter(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
+        private Integer partitions;
+
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
                 Options.READ_FILES_TYPE, "mlcp_archive",
-                Options.READ_ARCHIVES_CATEGORIES, categories
+                Options.READ_ARCHIVES_CATEGORIES, categories,
+                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
             );
         }
 
         @Override
         public ReadMlcpArchiveFilesOptions categories(String... categories) {
             this.categories = Stream.of(categories).collect(Collectors.joining(","));
+            return this;
+        }
+
+        @Override
+        public ReadMlcpArchiveFilesOptions partitions(Integer partitions) {
+            this.partitions = partitions;
             return this;
         }
     }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportRdfFilesCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/importdata/ImportRdfFilesCommand.java
@@ -42,17 +42,27 @@ public class ImportRdfFilesCommand extends AbstractImportFilesCommand<RdfFilesIm
         @Parameter(names = "--compression", description = "When importing compressed files, specify the type of compression used.")
         private CompressionType compressionType;
 
+        @Parameter(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
+        private Integer partitions;
+
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
                 Options.READ_FILES_TYPE, "rdf",
-                Options.READ_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null
+                Options.READ_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null,
+                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
             );
         }
 
         @Override
         public ReadRdfFilesOptions compressionType(CompressionType compressionType) {
             this.compressionType = compressionType;
+            return this;
+        }
+
+        @Override
+        public ReadRdfFilesOptions partitions(Integer partitions) {
+            this.partitions = partitions;
             return this;
         }
     }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportAggregateXmlFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportAggregateXmlFilesOptionsTest.java
@@ -1,0 +1,24 @@
+package com.marklogic.newtool.impl.importdata;
+
+import com.marklogic.newtool.impl.AbstractOptionsTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+class ImportAggregateXmlFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void numPartitions() {
+        ImportAggregateXmlCommand command = (ImportAggregateXmlCommand) getCommand(
+            "import_aggregate_xml_files",
+            "--path", "src/test/resources/xml-file",
+            "--preview", "10",
+            "--element", "anything",
+            "--partitions", "3"
+        );
+
+        assertOptions(command.getReadParams().makeOptions(),
+            Options.READ_AGGREGATES_XML_ELEMENT, "anything",
+            Options.READ_NUM_PARTITIONS, "3"
+        );
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportArchiveFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportArchiveFilesOptionsTest.java
@@ -1,0 +1,22 @@
+package com.marklogic.newtool.impl.importdata;
+
+import com.marklogic.newtool.impl.AbstractOptionsTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+class ImportArchiveFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void numPartitions() {
+        ImportArchiveFilesCommand command = (ImportArchiveFilesCommand) getCommand(
+            "import_archive_files",
+            "--path", "src/test/resources/archive-files",
+            "--preview", "10",
+            "--partitions", "18"
+        );
+
+        assertOptions(command.getReadParams().makeOptions(),
+            Options.READ_NUM_PARTITIONS, "18"
+        );
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportFilesOptionsTest.java
@@ -15,6 +15,7 @@ class ImportFilesOptionsTest extends AbstractOptionsTest {
             "--username", "someuser",
             "--password", "someword",
             "--path", "src/test/resources/mixed-files/hello*",
+            "--partitions", "6",
             "--documentType", "XML",
             "--abortOnWriteFailure",
             "--batchSize", "50",
@@ -37,6 +38,10 @@ class ImportFilesOptionsTest extends AbstractOptionsTest {
             Options.CLIENT_PORT, "8001",
             Options.CLIENT_USERNAME, "someuser",
             Options.CLIENT_PASSWORD, "someword"
+        );
+
+        assertOptions(command.getReadParams().makeOptions(),
+            Options.READ_NUM_PARTITIONS, "6"
         );
 
         assertOptions(command.getWriteParams().makeOptions(),

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportMlcpArchiveFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportMlcpArchiveFilesOptionsTest.java
@@ -1,0 +1,22 @@
+package com.marklogic.newtool.impl.importdata;
+
+import com.marklogic.newtool.impl.AbstractOptionsTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+class ImportMlcpArchiveFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void numPartitions() {
+        ImportMlcpArchiveFilesCommand command = (ImportMlcpArchiveFilesCommand) getCommand(
+            "import_mlcp_archive_files",
+            "--path", "src/test/resources/archive-files",
+            "--preview", "10",
+            "--partitions", "7"
+        );
+
+        assertOptions(command.getReadParams().makeOptions(),
+            Options.READ_NUM_PARTITIONS, "7"
+        );
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportRdfFilesOptionsTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportRdfFilesOptionsTest.java
@@ -1,0 +1,22 @@
+package com.marklogic.newtool.impl.importdata;
+
+import com.marklogic.newtool.impl.AbstractOptionsTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+class ImportRdfFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void numPartitions() {
+        ImportRdfFilesCommand command = (ImportRdfFilesCommand) getCommand(
+            "import_rdf_files",
+            "--path", "src/test/resources/rdf",
+            "--preview", "10",
+            "--partitions", "4"
+        );
+
+        assertOptions(command.getReadParams().makeOptions(),
+            Options.READ_NUM_PARTITIONS, "4"
+        );
+    }
+}


### PR DESCRIPTION
The import commands that use Spark data sources have other mechanisms for determining partitions. 

The tests simply verify that when `--partitions` is passed in, the value is correctly added to the list of reader options. 