### PR TITLE
MLE-14386 API user can now provide their own Spark session

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/Executor.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/Executor.java
@@ -7,7 +7,19 @@ import java.util.function.Consumer;
  */
 public interface Executor<T extends Executor> {
 
+    /**
+     * Execute this executor instance with a default Spark session.
+     */
     void execute();
+
+    /**
+     * Execute this executor with a user-defined Spark session.
+     *
+     * @param sparkSession must be an instance of {@code org.apache.spark.sql.SparkSession}. The Spark type is not used
+     *                     here to avoid adding the Spark API and all of its dependencies to the compile-time
+     *                     classpath of clients.
+     */
+    void executeWithSession(Object sparkSession);
 
     /**
      * @param consumer Provided by the caller to configure the given options object.

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/AbstractCommand.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/AbstractCommand.java
@@ -93,6 +93,14 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
     }
 
     @Override
+    public void executeWithSession(Object sparkSession) {
+        if (!(sparkSession instanceof SparkSession)) {
+            throw new NtException("The session object must be an instance of org.apache.spark.sql.SparkSession");
+        }
+        execute((SparkSession) sparkSession);
+    }
+
+    @Override
     public T connection(Consumer consumer) {
         consumer.accept(getConnectionParams());
         return (T) this;

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/ExecuteWithCustomSparkSessionTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/ExecuteWithCustomSparkSessionTest.java
@@ -1,0 +1,59 @@
+package com.marklogic.newtool.api;
+
+import com.marklogic.newtool.AbstractTest;
+import com.marklogic.newtool.impl.SparkUtil;
+import org.apache.spark.SparkFirehoseListener;
+import org.apache.spark.scheduler.SparkListenerEvent;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExecuteWithCustomSparkSessionTest extends AbstractTest {
+
+    @Test
+    void test() {
+        SparkSession session = SparkUtil.buildSparkSession();
+        TestListener testListener = new TestListener();
+        session.sparkContext().addSparkListener(testListener);
+
+        NT.importGenericFiles()
+            .connectionString(makeConnectionString())
+            .readFiles("src/test/resources/mixed-files")
+            .writeDocuments(options -> options
+                .collections("custom-session")
+                .permissionsString(DEFAULT_PERMISSIONS))
+            .executeWithSession(session);
+
+        assertTrue(testListener.events.size() > 0, "This verifies that our custom Spark session is used instead of " +
+            "a default one. We don't care how many Spark events are captured. We just need proof that our custom listener " +
+            "was invoked at least once.");
+    }
+
+    @Test
+    void notASparkSession() {
+        GenericFilesImporter importer = NT.importGenericFiles()
+            .connectionString(makeConnectionString())
+            .readFiles("src/test/resources/mixed-files")
+            .writeDocuments(options -> options
+                .collections("custom-session")
+                .permissionsString(DEFAULT_PERMISSIONS));
+
+        NtException ex = assertThrowsNtException(() -> importer.executeWithSession("This will cause an error"));
+        assertEquals("The session object must be an instance of org.apache.spark.sql.SparkSession", ex.getMessage());
+    }
+
+    static class TestListener extends SparkFirehoseListener {
+
+        List<SparkListenerEvent> events = new ArrayList<>();
+
+        @Override
+        public void onEvent(SparkListenerEvent event) {
+            this.events.add(event);
+        }
+    }
+}


### PR DESCRIPTION
It occurred to me that instead of providing a hook to configure the Spark runtime, we can just let a user provide their own Spark session, configured however they want. 

`Object` is used instead of `SparkSession` to keep the Spark API off the compile-time classpath. 