### PR TITLE
MLE-14387 Now validating output connection parameters correctly

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionInputs.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionInputs.java
@@ -1,5 +1,7 @@
 package com.marklogic.newtool.impl;
 
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.newtool.api.AuthenticationType;
 import com.marklogic.newtool.api.NtException;
@@ -15,6 +17,13 @@ import java.util.Map;
  * with parameter annotations.
  */
 public abstract class ConnectionInputs {
+
+    public static class ConnectionStringValidator implements IParameterValidator {
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            new ConnectionString(value, name);
+        }
+    }
 
     protected String connectionString;
     protected String host;

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionParams.java
@@ -1,41 +1,20 @@
 package com.marklogic.newtool.impl;
 
-import com.beust.jcommander.IParametersValidator;
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.newtool.api.AuthenticationType;
 import com.marklogic.newtool.api.ConnectionOptions;
 import com.marklogic.newtool.api.SslHostnameVerifier;
 
-import java.util.Map;
-
-@Parameters(parametersValidators = ConnectionParams.class)
-public class ConnectionParams extends ConnectionInputs implements IParametersValidator, ConnectionOptions {
-
-    @Override
-    public void validate(Map<String, Object> parameters) throws ParameterException {
-        if (parameters.get("--connectionString") == null && parameters.get("--preview") == null) {
-            if (parameters.get("--host") == null) {
-                throw new ParameterException("Must specify a MarkLogic host via --host or --connectionString.");
-            }
-            if (parameters.get("--port") == null) {
-                throw new ParameterException("Must specify a MarkLogic app server port via --port or --connectionString.");
-            }
-
-            String authType = (String) parameters.get("--authType");
-            boolean isDigestOrBasicAuth = authType == null || ("digest".equalsIgnoreCase(authType) || "basic".equalsIgnoreCase(authType));
-            if (isDigestOrBasicAuth && parameters.get("--username") == null) {
-                throw new ParameterException("Must specify a MarkLogic user via --username when using 'BASIC' or 'DIGEST' authentication.");
-            }
-        }
-    }
+@Parameters(parametersValidators = ConnectionParamsValidator.class)
+public class ConnectionParams extends ConnectionInputs implements ConnectionOptions {
 
     @Override
     @Parameter(
         names = {"--connectionString"},
-        description = "Defines a connection string as user:password@host:port; only usable when using 'DIGEST' or 'BASIC' authentication."
+        description = "Defines a connection string as user:password@host:port; only usable when using 'DIGEST' or 'BASIC' authentication.",
+        validateWith = ConnectionStringValidator.class
     )
     public ConnectionOptions connectionString(String connectionString) {
         this.connectionString = connectionString;

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionParamsValidator.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/ConnectionParamsValidator.java
@@ -1,0 +1,64 @@
+package com.marklogic.newtool.impl;
+
+import com.beust.jcommander.IParametersValidator;
+import com.beust.jcommander.ParameterException;
+
+import java.util.Map;
+
+public class ConnectionParamsValidator implements IParametersValidator {
+
+    private final ParamNames paramNames;
+
+    public ConnectionParamsValidator() {
+        this(false);
+    }
+
+    public ConnectionParamsValidator(boolean isOutput) {
+        this.paramNames = new ParamNames(isOutput);
+    }
+
+    @Override
+    public void validate(Map<String, Object> parameters) throws ParameterException {
+        if (parameters.get(paramNames.connectionString) == null && parameters.get("--preview") == null) {
+            if (parameters.get(paramNames.host) == null) {
+                throw new ParameterException(String.format("Must specify a MarkLogic host via %s or %s.",
+                    paramNames.host, paramNames.connectionString));
+            }
+            if (parameters.get(paramNames.port) == null) {
+                throw new ParameterException(String.format("Must specify a MarkLogic app server port via %s or %s.",
+                    paramNames.port, paramNames.connectionString));
+            }
+
+            String authType = (String) parameters.get(paramNames.authType);
+            boolean isDigestOrBasicAuth = authType == null || ("digest".equalsIgnoreCase(authType) || "basic".equalsIgnoreCase(authType));
+            if (isDigestOrBasicAuth) {
+                if (parameters.get(paramNames.username) == null) {
+                    throw new ParameterException(String.format("Must specify a MarkLogic user via %s when using 'BASIC' or 'DIGEST' authentication.",
+                        paramNames.username));
+                }
+                if (parameters.get(paramNames.password) == null) {
+                    throw new ParameterException(String.format("Must specify a password via %s when using 'BASIC' or 'DIGEST' authentication.",
+                        paramNames.password));
+                }
+            }
+        }
+    }
+
+    private static class ParamNames {
+        final String connectionString;
+        final String host;
+        final String port;
+        final String authType;
+        final String username;
+        final String password;
+
+        ParamNames(boolean isOutput) {
+            connectionString = isOutput ? "--outputConnectionString" : "--connectionString";
+            host = isOutput ? "--outputHost" : "--host";
+            port = isOutput ? "--outputPort" : "--port";
+            authType = isOutput ? "--outputAuthType" : "--authType";
+            username = isOutput ? "--outputUsername" : "--username";
+            password = isOutput ? "--outputPassword" : "--password";
+        }
+    }
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/copy/CopyTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/copy/CopyTest.java
@@ -63,6 +63,59 @@ class CopyTest extends AbstractTest {
         assertDirectoryCount("/copied/", 15);
     }
 
+    @Test
+    void badConnectionString() {
+        assertStderrContains(() -> run(
+            "copy",
+            "--collections", "author",
+            "--connectionString", makeConnectionString(),
+            "--outputConnectionString", "not@valid"
+        ), "Invalid value for --outputConnectionString; must be username:password@host:port/optionalDatabaseName");
+    }
+
+    @Test
+    void missingHost() {
+        assertStderrContains(() -> run(
+            "copy",
+            "--collections", "author",
+            "--connectionString", makeConnectionString(),
+            "--outputPort", "8000"
+        ), "Must specify a MarkLogic host via --outputHost or --outputConnectionString.");
+    }
+
+    @Test
+    void missingPort() {
+        assertStderrContains(() -> run(
+            "copy",
+            "--collections", "author",
+            "--connectionString", makeConnectionString(),
+            "--outputHost", "localhost"
+        ), "Must specify a MarkLogic app server port via --outputPort or --outputConnectionString.");
+    }
+
+    @Test
+    void missingUsername() {
+        assertStderrContains(() -> run(
+            "copy",
+            "--collections", "author",
+            "--connectionString", makeConnectionString(),
+            "--outputHost", "localhost",
+            "--outputPort", "8000"
+        ), "Must specify a MarkLogic user via --outputUsername when using 'BASIC' or 'DIGEST' authentication.");
+    }
+
+    @Test
+    void missingPassword() {
+        assertStderrContains(() -> run(
+            "copy",
+            "--collections", "author",
+            "--connectionString", makeConnectionString(),
+            "--outputHost", "localhost",
+            "--outputPort", "8000",
+            "--outputUsername", "someone"
+        ), "Must specify a password via --outputPassword when using 'BASIC' or 'DIGEST' authentication.");
+    }
+
     private void assertDirectoryCount(String directoryPrefix, int expectedCount) {
         QueryManager queryManager = getDatabaseClient().newQueryManager();
         StructuredQueryDefinition query = queryManager.newStructuredQueryBuilder().directory(true, directoryPrefix);


### PR DESCRIPTION
Created `ConnectionParamsValidator` to avoid duplication of the logic for regular connection params and output connection params. 

Also added a validator for `--connectionString` and `--outputConnectionString` which ensures we fail ASAP if either one of those is invalid. 