### PR TITLE
MLE-14514 Can now obtain a count of rows to be read

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/api/Executor.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/api/Executor.java
@@ -19,7 +19,7 @@ public interface Executor<T extends Executor> {
      *                     here to avoid adding the Spark API and all of its dependencies to the compile-time
      *                     classpath of clients.
      */
-    void executeWithSession(Object sparkSession);
+    T withSparkSession(Object sparkSession);
 
     /**
      * @param consumer Provided by the caller to configure the given options object.
@@ -40,4 +40,9 @@ public interface Executor<T extends Executor> {
      * @return instance of this executor
      */
     T limit(int limit);
+
+    /**
+     * @return the count of rows to be read by this executor from its data source.
+     */
+    long count();
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/CommonParams.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/CommonParams.java
@@ -16,6 +16,9 @@ public class CommonParams {
     @Parameter(names = "--limit", description = "Number of rows to read from the data source.")
     private Integer limit;
 
+    @Parameter(names = "--count", description = "Show a count of rows to be read from the data source without writing any of the rows.")
+    private boolean count;
+
     @Parameter(names = "--preview", description = "Show up to the first N rows of data read by the command.")
     private Integer preview;
 
@@ -51,55 +54,27 @@ public class CommonParams {
         return new Preview(dataset, preview, previewColumnsToDrop, vertical);
     }
 
-    public boolean isPreviewRequested() {
-        return preview != null;
+    public void setCount(boolean count) {
+        this.count = count;
     }
 
-    public Integer getLimit() {
-        return limit;
-    }
-
-    public void setLimit(Integer limit) {
-        this.limit = limit;
-    }
-
-    public Integer getPreview() {
-        return preview;
+    public boolean isCount() {
+        return count;
     }
 
     public void setPreview(Integer preview) {
         this.preview = preview;
     }
 
-    public List<String> getPreviewColumnsToDrop() {
-        return previewColumnsToDrop;
+    public boolean isPreviewRequested() {
+        return preview != null;
     }
 
-    public void setPreviewColumnsToDrop(List<String> previewColumnsToDrop) {
-        this.previewColumnsToDrop = previewColumnsToDrop;
-    }
-
-    public Boolean getPreviewVertical() {
-        return previewVertical;
-    }
-
-    public void setPreviewVertical(Boolean previewVertical) {
-        this.previewVertical = previewVertical;
-    }
-
-    public Integer getRepartition() {
-        return repartition;
+    public void setLimit(Integer limit) {
+        this.limit = limit;
     }
 
     public void setRepartition(Integer repartition) {
         this.repartition = repartition;
-    }
-
-    public Boolean getShowStacktrace() {
-        return showStacktrace;
-    }
-
-    public void setShowStacktrace(Boolean showStacktrace) {
-        this.showStacktrace = showStacktrace;
     }
 }

--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/Preview.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/Preview.java
@@ -27,4 +27,8 @@ public class Preview {
         // Not truncating at all. For now, users can drop columns if their values are too long.
         datasetPreview.show(numberRows, Integer.MAX_VALUE, vertical);
     }
+
+    public Dataset<Row> getDataset() {
+        return dataset;
+    }
 }

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/ExecuteWithCustomSparkSessionTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/ExecuteWithCustomSparkSessionTest.java
@@ -27,7 +27,8 @@ class ExecuteWithCustomSparkSessionTest extends AbstractTest {
             .writeDocuments(options -> options
                 .collections("custom-session")
                 .permissionsString(DEFAULT_PERMISSIONS))
-            .executeWithSession(session);
+            .withSparkSession(session)
+            .execute();
 
         assertTrue(testListener.events.size() > 0, "This verifies that our custom Spark session is used instead of " +
             "a default one. We don't care how many Spark events are captured. We just need proof that our custom listener " +
@@ -42,8 +43,8 @@ class ExecuteWithCustomSparkSessionTest extends AbstractTest {
             .writeDocuments(options -> options
                 .collections("custom-session")
                 .permissionsString(DEFAULT_PERMISSIONS));
-
-        NtException ex = assertThrowsNtException(() -> importer.executeWithSession("This will cause an error"));
+        
+        NtException ex = assertThrowsNtException(() -> importer.withSparkSession("This will cause an error"));
         assertEquals("The session object must be an instance of org.apache.spark.sql.SparkSession", ex.getMessage());
     }
 

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/api/ParquetFilesImporterTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/api/ParquetFilesImporterTest.java
@@ -31,6 +31,20 @@ class ParquetFilesImporterTest extends AbstractTest {
     }
 
     @Test
+    void count() {
+        long count = NT.importParquetFiles()
+            .connectionString(makeConnectionString())
+            .readFiles(options -> options
+                .paths("src/test/resources/parquet/related/*.parquet")
+                .additionalOptions(Map.of("mergeSchema", "true")))
+            .writeDocuments(options -> options.collections("parquet-test"))
+            .count();
+
+        assertEquals(6, count);
+        assertCollectionSize("parquet-test", 0);
+    }
+
+    @Test
     void missingPath() {
         ParquetFilesImporter importer = NT.importParquetFiles()
             .connectionString(makeConnectionString());

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportParquetFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportParquetFilesTest.java
@@ -27,6 +27,23 @@ class ImportParquetFilesTest extends AbstractTest {
     }
 
     @Test
+    void count() {
+        String stderr = runAndReturnStderr(() -> run(
+            "import_parquet_files",
+            "--count",
+            "--path", "src/test/resources/parquet/individual/cars.parquet",
+            "--connectionString", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "parquet-test"
+        ));
+
+        assertCollectionSize("No data should be written when --count is included",
+            "parquet-test", 0);
+        assertFalse(stderr.contains("Command failed"), "No error should have occurred; the count of rows read should " +
+            "have been logged, which we unfortunately don't yet know how to make assertions against.");
+    }
+
+    @Test
     void jsonRootName() {
         run(
             "import_parquet_files",


### PR DESCRIPTION
I changed the design of specifying a custom Spark session to instead use a `with` method vs overriding `execute()`. The latter doesn't scale well, because when adding something like `count()` (and possibly `show()` in the future), we'd need to override those method as well. 