### PR TITLE
MLE-14483 Verifying Spark conf can be overridden

### DIFF
--- a/new-tool-cli/src/main/java/com/marklogic/newtool/impl/SparkUtil.java
+++ b/new-tool-cli/src/main/java/com/marklogic/newtool/impl/SparkUtil.java
@@ -10,9 +10,9 @@ public class SparkUtil {
     }
 
     public static SparkSession buildSparkSession() {
-        // Will make these hardcoded strings configurable soon.
         return SparkSession.builder()
             .master("local[*]")
+            // These can be overridden via the "-C" CLI option.
             .config("spark.ui.showConsoleProgress", "true")
             .config("spark.sql.session.timeZone", "UTC")
             .getOrCreate();

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/AbstractTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/AbstractTest.java
@@ -85,7 +85,9 @@ public abstract class AbstractTest extends AbstractMarkLogicTest {
     }
 
     /**
-     * Handy method for running anything and returning everything written to stdout.
+     * Handy method for running anything and returning everything written to stdout - except that this is
+     * proving to be very fragile, as sometimes nothing gets written to the byte stream. An individual test that uses
+     * this will work fine, but then it may fail when run in the entire suite. Not yet known why.
      */
     protected final String runAndReturnStdout(Runnable r) {
         System.out.flush();

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/OverrideSparkConfTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/OverrideSparkConfTest.java
@@ -1,0 +1,31 @@
+package com.marklogic.newtool.impl;
+
+import com.marklogic.newtool.AbstractTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OverrideSparkConfTest extends AbstractTest {
+
+    /**
+     * Verifies that the default spark.sql.session.timeZone of UTC that is set via SparkUtil can still be overridden
+     * via the "-C" option. This test may intermittently fail, as runAndReturnStdout hasn't proven to be 100%
+     * reliable.
+     */
+    @Test
+    @Disabled("Another disabled test due to runAndReturnStdout not being reliable; should work fine when run manually.")
+    void overriddenTimeZone() {
+        String stdout = runAndReturnStdout(() -> run(
+            "import_orc_files",
+            "-Cspark.sql.session.timeZone=America/Los_Angeles",
+            "--path", "src/test/resources/orc-files/authors.orc",
+            "--preview", "1"
+        ));
+
+        assertTrue(stdout.contains("2022-07-13 02:00:00"),
+            "The timeZone should have been overridden so that 02:00 is shown instead of " +
+                "09:00 (the value shown for UTC); actual stdout: " + stdout);
+    }
+
+}

--- a/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportOrcFilesTest.java
+++ b/new-tool-cli/src/test/java/com/marklogic/newtool/impl/importdata/ImportOrcFilesTest.java
@@ -1,8 +1,6 @@
 package com.marklogic.newtool.impl.importdata;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.marklogic.client.document.JSONDocumentManager;
-import com.marklogic.client.io.StringHandle;
 import com.marklogic.newtool.AbstractTest;
 import org.junit.jupiter.api.Test;
 
@@ -105,10 +103,9 @@ class ImportOrcFilesTest extends AbstractTest {
     }
 
     private void verifyDocContent(String uri) {
-        JSONDocumentManager documentManager = getDatabaseClient().newJSONDocumentManager();
-        String docContent = documentManager.read(uri).next().getContent(new StringHandle()).toString();
-        assertTrue(docContent.contains("CitationID"));
-        assertTrue(docContent.contains("LastName"));
-        assertTrue(docContent.contains("ForeName"));
+        JsonNode doc = readJsonDocument(uri);
+        assertTrue(doc.has("CitationID"));
+        assertTrue(doc.has("LastName"));
+        assertTrue(doc.has("ForeName"));
     }
 }


### PR DESCRIPTION
I was thinking we needed a way to override the two conf options in SparkUtil, but this test verifies that a user can already do that via "-C". 