### PR TITLE
Renamed library artifact to "flux-api"

### DIFF
--- a/client-project/build.gradle
+++ b/client-project/build.gradle
@@ -8,5 +8,11 @@ repositories {
 }
 
 dependencies {
-  implementation "com.marklogic:flux-cli:0.3-SNAPSHOT"
+  implementation "com.marklogic:flux-api:0.3-SNAPSHOT"
+}
+
+task runApp(type: JavaExec) {
+  description = "Verify that the example program can be compiled and run with flux-api as a dependency."
+  mainClass = "org.example.App"
+  classpath = sourceSets.main.runtimeClasspath
 }

--- a/client-project/src/main/java/org/example/App.java
+++ b/client-project/src/main/java/org/example/App.java
@@ -8,9 +8,9 @@ public class App {
         // Currently depends on flux test-app.
         Flux.importGenericFiles()
             .connectionString("flux-test-user:password@localhost:8003")
-            .readFiles(options -> options
+            .from(options -> options
                 .paths("../flux-cli/src/test/resources/mixed-files"))
-            .writeDocuments(options -> options
+            .to(options -> options
                 .collections("client-files")
                 .permissionsString("flux-test-role,read,flux-test-role,update"))
             .execute();

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -131,9 +131,13 @@ java {
 publishing {
   publications {
     mainJava(MavenPublication) {
+      groupId = group
+      // Using a more fitting name of "flux-api". May eventually break out the current "flux-cli" module into
+      // multiple Gradle subprojects, such as "flux-api" and "flux-cli".
+      artifactId = "flux-api"
+      version = version
       from components.java
       pom {
-        name = "${group}:${project.name}"
         description = "Flux ETL for MarkLogic"
         packaging = "jar"
         url = "https://github.com/marklogic/${project.name}"


### PR DESCRIPTION
"flux-cli" wasn't a good name for a user that is only using the Flux API and not the CLI. 