### PR TITLE
MLE-14714 Better errors for bad aggregation expressions

### DIFF
--- a/docs/import/import-jdbc.md
+++ b/docs/import/import-jdbc.md
@@ -63,7 +63,7 @@ To facilitate producing hierarchical documents with multiple sets of related dat
 to combine multiple rows from a SQL query (which typically will include one or more joins) into hierarchical documents:
 
 - `--group-by` specifies a column name to group rows by; this is typically the column used in a join.
-- `--aggregate` specifies a string of the form `new_column_name=column1;column2;column3`. The `new_column_name` column
+- `--aggregate` specifies a string of the form `new_column_name=column1,column2,column3`. The `new_column_name` column
   will contain an array of objects, with each object having columns of `column`, `column2`, and `column3`.
 
 For example, consider the [Postgres tutorial database](https://www.postgresqltutorial.com/postgresql-getting-started/postgresql-sample-database/)
@@ -75,7 +75,7 @@ following options would be used to achieve that (connection details are omitted 
 ./bin/flux import-jdbc \
     --query "select c.*, p.payment_id, p.amount, p.payment_date from customer c inner join payment p on c.customer_id = p.customer_id" \
     --group-by customer_id \
-    --aggregate "payments=payment_id;amount;payment_date"
+    --aggregate "payments=payment_id,amount,payment_date"
 ```
 
 The options above result in the following aggregation being performed:

--- a/flux-cli/src/main/java/com/marklogic/flux/api/FluxException.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/FluxException.java
@@ -13,4 +13,8 @@ public class FluxException extends RuntimeException {
     public FluxException(Throwable cause) {
         super(cause.getMessage(), cause);
     }
+
+    public FluxException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/AggregationParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/AggregationParams.java
@@ -1,16 +1,20 @@
 package com.marklogic.flux.impl.importdata;
 
-import com.beust.jcommander.Parameter;
-import org.apache.spark.sql.Column;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.functions;
+import com.beust.jcommander.*;
+import com.marklogic.flux.api.FluxException;
+import org.apache.spark.sql.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-class AggregationParams {
+class AggregationParams implements IStringConverter<AggregationParams.Aggregation> {
+
+    // Have not found a way to make this configurable in the CLI yet. The StringConverter interface is invoked first
+    // by JCommander, which means the logic for converting the aggregation expression doesn't know what value a user
+    // would have chosen for overriding this. Could hack something into the Main class to peek at the delimiter value
+    // provided by a user, but for now assuming that it will be very unlikely for a Spark column name to have a comma
+    // in it.
+    private static final String AGGREGATE_DELIMITER = ",";
 
     @Parameter(names = "--group-by", description = "Name of a column to group the rows by before constructing documents.")
     private String groupBy;
@@ -18,24 +22,42 @@ class AggregationParams {
     @Parameter(
         names = "--aggregate",
         description = "Define an aggregation of multiple columns into a new column. Each aggregation must be of the " +
-            "the form newColumnName=column1;column2;etc. Requires the user of --group-by."
+            "the form newColumnName=column1,column2,etc. Requires the use of --group-by.",
+        listConverter = AggregationParams.class
     )
-    private List<String> aggregationExpressions = new ArrayList<>();
+    private List<Aggregation> aggregations = new ArrayList<>();
+
+    public static class Aggregation {
+        private String newColumnName;
+        private List<String> columnNamesToGroup;
+
+        public Aggregation(String newColumnName, List<String> columnNamesToGroup) {
+            this.newColumnName = newColumnName;
+            this.columnNamesToGroup = columnNamesToGroup;
+        }
+    }
+
+    @Override
+    public Aggregation convert(String value) {
+        String[] parts = value.split("=");
+        if (parts.length != 2) {
+            throw new FluxException(String.format("Invalid aggregation: %s; must be of " +
+                "the form newColumnName=columnToGroup1,columnToGroup2,etc.", value));
+        }
+        final String newColumnName = parts[0];
+        String[] columnNamesToAggregate = parts[1].split(AGGREGATE_DELIMITER);
+        return new Aggregation(newColumnName, Arrays.asList(columnNamesToAggregate));
+    }
 
     public void setGroupBy(String groupBy) {
         this.groupBy = groupBy;
     }
 
     public void addAggregationExpression(String newColumnName, String... columns) {
-        if (this.aggregationExpressions == null) {
-            this.aggregationExpressions = new ArrayList<>();
+        if (this.aggregations == null) {
+            this.aggregations = new ArrayList<>();
         }
-        String expression = newColumnName + "=" + Stream.of(columns).collect(Collectors.joining(";"));
-        this.aggregationExpressions.add(expression);
-    }
-
-    public void setAggregationExpressions(List<String> aggregationExpressions) {
-        this.aggregationExpressions = aggregationExpressions;
+        this.aggregations.add(new Aggregation(newColumnName, Arrays.asList(columns)));
     }
 
     public Dataset<Row> applyGroupBy(Dataset<Row> dataset) {
@@ -43,45 +65,31 @@ class AggregationParams {
             return dataset;
         }
 
-        Map<String, List<String>> aggregationMap = makeAggregationMap();
+        final RelationalGroupedDataset groupedDataset = dataset.groupBy(this.groupBy);
 
-        List<Column> columns = getColumnsNotInAggregation(dataset, aggregationMap);
-        List<Column> aggregationColumns = makeAggregationColumns(aggregationMap);
+        List<Column> columns = getColumnsNotInAggregation(dataset);
+        List<Column> aggregationColumns = makeAggregationColumns();
         columns.addAll(aggregationColumns);
-        return dataset.groupBy(this.groupBy).agg(
-            columns.get(0),
-            columns.subList(1, columns.size()).toArray(new Column[]{})
-        );
-    }
-
-    /**
-     * Parses the value of each "--aggregation" parameter and returns a map, where each key is a new column name
-     * containing an aggregation, and each value is a list of the column names to be aggregated together.
-     *
-     * @return
-     */
-    private Map<String, List<String>> makeAggregationMap() {
-        Map<String, List<String>> aggregationMap = new LinkedHashMap<>();
-        if (aggregationExpressions != null) {
-            aggregationExpressions.forEach(expr -> {
-                String[] parts = expr.split("=");
-                String[] columnNames = parts[1].split(";");
-                aggregationMap.put(parts[0], Arrays.asList(columnNames));
-            });
+        final Column aliasColumn = columns.get(0);
+        final Column[] columnsToGroup = columns.subList(1, columns.size()).toArray(new Column[]{});
+        try {
+            return groupedDataset.agg(aliasColumn, columnsToGroup);
+        } catch (Exception e) {
+            String columnNames = aggregations.stream().map(agg -> agg.columnNamesToGroup.toString()).collect(Collectors.joining(", "));
+            throw new FluxException(String.format("Unable to aggregate columns: %s; please ensure that each column " +
+                "name will be present in the data read from the data source.", columnNames), e);
         }
-        return aggregationMap;
     }
 
     /**
      * @param dataset
-     * @param aggregationMap
      * @return a list of columns reflecting each column that is not referenced in an aggregation and is also not the
      * "groupBy" column. These columns are assumed to have the same value in every row, and thus only the first value
      * is needed for each column.
      */
-    private List<Column> getColumnsNotInAggregation(Dataset<Row> dataset, Map<String, List<String>> aggregationMap) {
+    private List<Column> getColumnsNotInAggregation(Dataset<Row> dataset) {
         Set<String> aggregatedColumnNames = new HashSet<>();
-        aggregationMap.values().forEach(aggregatedColumnNames::addAll);
+        aggregations.forEach(agg -> aggregatedColumnNames.addAll(agg.columnNamesToGroup));
 
         List<Column> columns = new ArrayList<>();
         for (String name : dataset.schema().names()) {
@@ -93,26 +101,24 @@ class AggregationParams {
     }
 
     /**
-     * @param aggregationMap
-     * @return a list of columns, one per aggregation in the map.
+     * @return a list of columns, one per aggregation.
      */
-    private List<Column> makeAggregationColumns(Map<String, List<String>> aggregationMap) {
+    private List<Column> makeAggregationColumns() {
         List<Column> columns = new ArrayList<>();
-        for (Map.Entry<String, List<String>> entry : aggregationMap.entrySet()) {
-            final String alias = entry.getKey();
-            final List<String> columnNames = entry.getValue();
+        aggregations.forEach(aggregation -> {
+            final List<String> columnNames = aggregation.columnNamesToGroup;
             if (columnNames.size() == 1) {
                 Column column = new Column(columnNames.get(0));
                 Column listOfValuesColumn = functions.collect_list(functions.concat(column));
-                columns.add(listOfValuesColumn.alias(alias));
+                columns.add(listOfValuesColumn.alias(aggregation.newColumnName));
             } else {
                 Column[] structColumns = columnNames.stream().map(functions::col).toArray(Column[]::new);
                 Column arrayColumn = functions.collect_list(functions.struct(structColumns));
                 // array_distinct removes duplicate objects that can result from 2+ joins existing in the query.
                 // See https://www.sparkreference.com/reference/array_distinct/ for performance considerations.
-                columns.add(functions.array_distinct(arrayColumn).alias(alias));
+                columns.add(functions.array_distinct(arrayColumn).alias(aggregation.newColumnName));
             }
-        }
+        });
         return columns;
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -51,7 +51,7 @@ class ImportAvroFilesTest extends AbstractTest {
             "import-avro-files",
             "--path", "src/test/resources/avro",
             "--group-by", "flag", // Weird, but effective for our test data.
-            "--aggregate", "values=number;color",
+            "--aggregate", "values=number,color",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "my-avro",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -203,7 +203,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "import-delimited-files",
             "--path", "src/test/resources/delimited-files/join-rows.csv",
             "--group-by", "number",
-            "--aggregate", "objects=color;flag",
+            "--aggregate", "objects=color,flag",
             "--permissions", "rest-reader,read,rest-writer,update",
             "--connection-string", makeConnectionString(),
             "--collections", "my-csv",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithAggregatesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithAggregatesTest.java
@@ -28,7 +28,7 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
             "--jdbc-driver", PostgresUtil.DRIVER,
             "--query", query,
             "--group-by", "customer_id",
-            "--aggregate", "payments=payment_id;amount;payment_date",
+            "--aggregate", "payments=payment_id,amount,payment_date",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uri-template", "/customer/{customer_id}.json"
@@ -77,8 +77,8 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
             "--jdbc-driver", PostgresUtil.DRIVER,
             "--query", query,
             "--group-by", "customer_id",
-            "--aggregate", "payments=payment_id;amount",
-            "--aggregate", "rentals=rental_id;inventory_id",
+            "--aggregate", "payments=payment_id,amount",
+            "--aggregate", "rentals=rental_id,inventory_id",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uri-template", "/customer/{customer_id}.json"
@@ -132,5 +132,41 @@ class ImportJdbcWithAggregatesTest extends AbstractTest {
         assertEquals(3, film.size(), "Expecting 3 fields - film_id, title, and actor_ids");
         assertEquals(1, film.get("film_id").asInt());
         assertEquals(10, film.get("actor_ids").size(), "Expecting 10 actor references to film 1; doc: " + film);
+    }
+
+    @Test
+    void missingEqualsInAggregationExpression() {
+        assertStderrContains(() -> run(
+            "import-jdbc",
+            "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
+            "--jdbc-driver", PostgresUtil.DRIVER,
+            "--query", "select * from customer",
+            "--group-by", "customer_id",
+            "--aggregate", "payments,payment_id,amount",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS
+        ), "Invalid aggregation: payments,payment_id,amount; must be of the form " +
+            "newColumnName=columnToGroup1,columnToGroup2,etc.");
+    }
+
+    @Test
+    void badColumnName() {
+        String query = "select c.customer_id, c.first_name, p.payment_id, p.amount, p.payment_date\n" +
+            "        from customer c\n" +
+            "        inner join public.payment p on c.customer_id = p.customer_id\n" +
+            "        where c.customer_id < 10";
+
+        assertStderrContains(() -> run(
+            "import-jdbc",
+            "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
+            "--jdbc-driver", PostgresUtil.DRIVER,
+            "--query", query,
+            "--group-by", "customer_id",
+            "--aggregate", "payments=payment_id,notfound",
+            "--aggregate", "dates=payment_date",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS
+        ), "Unable to aggregate columns: [payment_id, notfound], [payment_date]; please ensure that each column name " +
+            "will be present in the data read from the data source.");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
@@ -30,7 +30,7 @@ class ImportOrcFilesTest extends AbstractTest {
             "import-orc-files",
             "--path", "src/test/resources/orc-files/authors.orc",
             "--group-by", "CitationID",
-            "--aggregate", "names=ForeName;LastName",
+            "--aggregate", "names=ForeName,LastName",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orc-test",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -33,7 +33,7 @@ class ImportParquetFilesTest extends AbstractTest {
             "import-parquet-files",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--group-by", "cyl",
-            "--aggregate", "models=model;mpg",
+            "--aggregate", "models=model,mpg",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "cyl-test",


### PR DESCRIPTION
In the process, I realized it's necessary to look for bad expressions immediately instead of parsing them later. So added the `Aggregation` class to make that easier to do. 

Also, the delimiter is now ",", which is possible now that we're using our own JCommander string converter. 