### PR TITLE
MLE-14710 Better error messages for bad JDBC driver values

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcUtil.java
@@ -1,0 +1,17 @@
+package com.marklogic.flux.impl;
+
+import com.marklogic.flux.api.FluxException;
+
+public abstract class JdbcUtil {
+
+    public static Exception massageException(Exception ex) {
+        if (ex instanceof ClassNotFoundException) {
+            return new FluxException(String.format("Unable to load class: %s; for a JDBC driver, ensure you " +
+                "are specifying the fully-qualified class name for your JDBC driver.", ex.getMessage()), ex);
+        }
+        return ex;
+    }
+
+    private JdbcUtil() {
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
@@ -9,10 +9,7 @@ import com.beust.jcommander.ParametersDelegate;
 import com.marklogic.flux.api.JdbcExporter;
 import com.marklogic.flux.api.ReadRowsOptions;
 import com.marklogic.flux.api.SaveMode;
-import com.marklogic.flux.impl.AbstractCommand;
-import com.marklogic.flux.impl.JdbcParams;
-import com.marklogic.flux.impl.OptionsUtil;
-import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.*;
 import org.apache.spark.sql.*;
 
 import java.util.Map;
@@ -44,11 +41,16 @@ public class ExportJdbcCommand extends AbstractCommand<JdbcExporter> implements 
     }
 
     @Override
-    protected void applyWriter(SparkSession session, DataFrameWriter<Row> writer) {
-        writer.format("jdbc")
+    protected void applyWriter(SparkSession session, DataFrameWriter<Row> writer) throws Exception {
+        writer = writer.format("jdbc")
             .options(writeParams.makeOptions())
-            .mode(SparkUtil.toSparkSaveMode(writeParams.saveMode))
-            .save();
+            .mode(SparkUtil.toSparkSaveMode(writeParams.saveMode));
+
+        try {
+            writer.save();
+        } catch (Exception e) {
+            throw JdbcUtil.massageException(e);
+        }
     }
 
     public static class WriteJdbcParams extends JdbcParams<WriteRowsOptions> implements WriteRowsOptions {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
@@ -10,6 +10,7 @@ import com.marklogic.flux.api.JdbcImporter;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.JdbcParams;
+import com.marklogic.flux.impl.JdbcUtil;
 import com.marklogic.flux.impl.OptionsUtil;
 import org.apache.spark.sql.*;
 
@@ -34,10 +35,13 @@ public class ImportJdbcCommand extends AbstractCommand<JdbcImporter> implements 
     }
 
     @Override
-    protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
-        return session.read().format("jdbc")
-            .options(readParams.makeOptions())
-            .load();
+    protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) throws Exception {
+        DataFrameReader readerToLoad = session.read().format("jdbc").options(readParams.makeOptions());
+        try {
+            return readerToLoad.load();
+        } catch (Exception ex) {
+            throw JdbcUtil.massageException(ex);
+        }
     }
 
     @Override

--- a/flux-cli/src/test/java/com/marklogic/flux/api/OrcFilesImporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/OrcFilesImporterTest.java
@@ -40,7 +40,7 @@ class OrcFilesImporterTest extends AbstractTest {
                 .collections("orc-test"));
 
         FluxException ex = assertThrowsNtException(() -> importer.execute());
-        assertEquals("For input string: \"not-valid-value\"", ex.getMessage(), "Expecting a failure due to the " +
+        assertEquals("IllegalArgumentException: For input string: \"not-valid-value\"", ex.getMessage(), "Expecting a failure due to the " +
             "invalid value for the ORC 'mergeSchema' option.");
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -66,7 +66,7 @@ class HandleErrorTest extends AbstractTest {
                 "--path", "/not/valid",
                 "--connection-string", makeConnectionString()
             ),
-            "Command failed, cause: [PATH_NOT_FOUND] Path does not exist: file:/not/valid."
+            "Command failed, cause: AnalysisException: [PATH_NOT_FOUND] Path does not exist: file:/not/valid."
         );
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportAvroFilesTest.java
@@ -58,7 +58,7 @@ class ExportAvroFilesTest extends AbstractTest {
             "-PavroSchema=intentionally-invalid"
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: com.fasterxml.jackson.core.JsonParseException"),
+        assertTrue(stderr.contains("Command failed, cause: SchemaParseException: com.fasterxml.jackson.core.JsonParseException"),
             "This test is verifying that -P params are passed to the Avro data source. Since an invalid " +
                 "Avro schema is being set, this test expects an error. Unexpected stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcTest.java
@@ -81,6 +81,19 @@ class ExportJdbcTest extends AbstractExportJdbcTest {
             "set via command arguments, so the value of -Pdriver should be used, causing the query to work.");
     }
 
+    @Test
+    void badJdbcDriver() {
+        assertStderrContains(() -> run(
+            "export-jdbc",
+            "--connection-string", makeConnectionString(),
+            "--query", READ_AUTHORS_OPTIC_QUERY,
+            "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
+            "--jdbc-driver", "not.valid.driver.name",
+            "--table", EXPORTED_TABLE_NAME
+        ), "Command failed, cause: Unable to load class: not.valid.driver.name; " +
+            "for a JDBC driver, ensure you are specifying the fully-qualified class name for your JDBC driver.");
+    }
+
     private void exportFifteenAuthors() {
         exportFifteenAuthorsWithMode("errorifexists");
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
@@ -86,6 +86,18 @@ class ImportJdbcTest extends AbstractTest {
         assertCollectionSize("customer", 599);
     }
 
+    @Test
+    void badJdbcDriverValue() {
+        assertStderrContains(() -> run(
+            "import-jdbc",
+            "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
+            "--jdbc-driver", "not.valid.driver.value",
+            "--query", "select * from customer",
+            "--preview", "10"
+        ), "Command failed, cause: Unable to load class: not.valid.driver.value; " +
+            "for a JDBC driver, ensure you are specifying the fully-qualified class name for your JDBC driver.");
+    }
+
     private void verifyTenCustomersWereImported() {
         assertCollectionSize("customer", 10);
         JsonNode doc = readJsonDocument("/customer/1.json");


### PR DESCRIPTION
Also tweaked the handling of unrecognized exceptions to include the simple name of the exception class in the message. Hoping that will provide some helpful context so a user doesn't need to look at a stacktrace.