### PR TITLE
MLE-14706 Supporting whitespace in options file via move to picocli

### DIFF
--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
     exclude module: "rocksdbjni"
   }
+  implementation 'info.picocli:picocli:4.7.6'
   implementation "org.jcommander:jcommander:1.83"
 
   implementation "com.marklogic:marklogic-spark-connector:2.2-SNAPSHOT"

--- a/flux-cli/src/main/java/com/marklogic/flux/cli/PicoMain.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/PicoMain.java
@@ -1,0 +1,19 @@
+package com.marklogic.flux.cli;
+
+import com.marklogic.flux.impl.export.ExportDelimitedFilesCommand;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    subcommands = {
+        ExportDelimitedFilesCommand.class,
+        CommandLine.HelpCommand.class
+    }
+)
+public class PicoMain {
+
+    public static void main(String[] args) {
+        new CommandLine(new PicoMain())
+            .setUseSimplifiedAtFiles(true)
+            .execute(args);
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -12,13 +12,15 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
-public abstract class AbstractCommand<T extends Executor> implements Command, Executor<T> {
+public abstract class AbstractCommand<T extends Executor> implements Command, Executor<T>, Callable<Void> {
 
     protected static final String MARKLOGIC_CONNECTOR = "marklogic";
 
@@ -28,6 +30,7 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
     private CommonParams commonParams = new CommonParams();
 
     @ParametersDelegate
+    @CommandLine.ArgGroup(exclusive = false, heading = "Connection Options\n")
     private ConnectionParams connectionParams = new ConnectionParams();
 
     @DynamicParameter(
@@ -37,6 +40,12 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
     private Map<String, String> configParams = new HashMap<>();
 
     private SparkSession sparkSession;
+
+    @Override
+    public Void call() {
+        execute();
+        return null;
+    }
 
     @Override
     public final Optional<Preview> execute(SparkSession session) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
@@ -9,6 +9,7 @@ import com.marklogic.client.DatabaseClient;
 import com.marklogic.flux.api.AuthenticationType;
 import com.marklogic.flux.api.ConnectionOptions;
 import com.marklogic.flux.api.SslHostnameVerifier;
+import picocli.CommandLine;
 
 @Parameters(parametersValidators = ConnectionParamsValidator.class)
 public class ConnectionParams extends ConnectionInputs implements ConnectionOptions {
@@ -19,6 +20,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
         description = "Defines a connection string as user:password@host:port; only usable when using 'DIGEST' or 'BASIC' authentication.",
         validateWith = ConnectionStringValidator.class
     )
+    @CommandLine.Option(names = "--connection-string")
     public ConnectionOptions connectionString(String connectionString) {
         this.connectionString = connectionString;
         return this;

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
@@ -9,6 +9,7 @@ import com.marklogic.flux.api.WriteFilesOptions;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.SparkUtil;
 import org.apache.spark.sql.*;
+import picocli.CommandLine;
 
 /**
  * Support class for concrete commands that want to run an Optic DSL query to read rows and then write them to one or
@@ -17,6 +18,7 @@ import org.apache.spark.sql.*;
 abstract class AbstractExportRowsToFilesCommand<T extends Executor> extends AbstractCommand<T> {
 
     @ParametersDelegate
+    @CommandLine.ArgGroup(exclusive = false, heading = "Read Options\n")
     protected final ReadRowsParams readParams = new ReadRowsParams();
 
     // Sonar complaining about the use of ?; not sure yet how to "fix" it, so ignoring.

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
@@ -3,23 +3,24 @@
  */
 package com.marklogic.flux.impl.export;
 
-import com.beust.jcommander.DynamicParameter;
-import com.beust.jcommander.Parameters;
-import com.beust.jcommander.ParametersDelegate;
 import com.marklogic.flux.api.DelimitedFilesExporter;
 import com.marklogic.flux.api.ReadRowsOptions;
 import com.marklogic.flux.api.WriteSparkFilesOptions;
 import com.marklogic.flux.impl.OptionsUtil;
+import picocli.CommandLine;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-@Parameters(commandDescription = "Read rows via Optic from MarkLogic and write them to delimited text files on a " +
-    "local filesystem, HDFS, or S3.")
+@CommandLine.Command(
+    name = "export-delimited-files",
+    abbreviateSynopsis = true,
+    description = "Read rows via Optic from MarkLogic and write them to delimited text files on a local filesystem, HDFS, or S3."
+)
 public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesCommand<DelimitedFilesExporter> implements DelimitedFilesExporter {
 
-    @ParametersDelegate
+    @CommandLine.ArgGroup(exclusive = false)
     private WriteDelimitedFilesParams writeParams = new WriteDelimitedFilesParams();
 
     @Override
@@ -34,10 +35,10 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
 
     public static class WriteDelimitedFilesParams extends WriteStructuredFilesParams<WriteSparkFilesOptions> implements WriteSparkFilesOptions {
 
-        @DynamicParameter(
-            names = "-P",
-            description = "Specify any Spark CSV option defined at " +
-                "https://spark.apache.org/docs/latest/sql-data-sources-csv.html; e.g. -PquoteAll=true.")
+        @CommandLine.Option(
+            names = {"-P"},
+            description = "Specify any Spark CSV option defined at https://spark.apache.org/docs/latest/sql-data-sources-csv.html; e.g. -PquoteAll=true."
+        )
         private Map<String, String> additionalOptions = new HashMap<>();
 
         @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
@@ -7,6 +7,7 @@ import com.beust.jcommander.Parameter;
 import com.marklogic.flux.impl.OptionsUtil;
 import com.marklogic.flux.api.ReadRowsOptions;
 import com.marklogic.spark.Options;
+import picocli.CommandLine;
 
 import java.util.Map;
 
@@ -16,19 +17,23 @@ import java.util.Map;
 public class ReadRowsParams implements ReadRowsOptions {
 
     @Parameter(names = "--query", description = "The Optic DSL query for retrieving rows; must use op.fromView as an accessor.")
+    @CommandLine.Option(names = "--query")
     private String query;
 
     @Parameter(names = "--batch-size", description = "Approximate number of rows to retrieve in each call to MarkLogic; defaults to 100000.")
+    @CommandLine.Option(names = "--batch-size")
     private Integer batchSize;
 
     // Not yet showing this in usage as it is confusing for a typical user to understand and would only need to be
     // set if push down aggregation is producing incorrect results. See the MarkLogic Spark connector documentation
     // for more information.
     @Parameter(names = "--disable-aggregation-push-down", hidden = true)
+    @CommandLine.Option(names = "--disable-aggregation-push-down", hidden = true)
     private Boolean disableAggregationPushDown;
 
     @Parameter(names = "--partitions", description = "Number of partitions to create when reading rows from MarkLogic. " +
         "Increasing this may improve performance as the number of rows to read increases.")
+    @CommandLine.Option(names = "--partitions")
     private Integer partitions;
 
     public Map<String, String> makeOptions() {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteFilesParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteFilesParams.java
@@ -8,6 +8,7 @@ import com.beust.jcommander.ParametersDelegate;
 import com.marklogic.flux.api.FluxException;
 import com.marklogic.flux.api.WriteFilesOptions;
 import com.marklogic.flux.impl.S3Params;
+import picocli.CommandLine;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -15,12 +16,14 @@ import java.util.function.Supplier;
 public abstract class WriteFilesParams<T extends WriteFilesOptions> implements Supplier<Map<String, String>>, WriteFilesOptions<T> {
 
     @Parameter(required = true, names = "--path", description = "Path expression for where files should be written.")
+    @CommandLine.Option(names = "--path")
     private String path;
 
     @ParametersDelegate
     private S3Params s3Params = new S3Params();
 
     @Parameter(names = "--file-count", description = "Specifies how many files should be written; also an alias for '--repartition'.")
+    @CommandLine.Option(names = "--file-count")
     protected Integer fileCount;
 
     public String getPath() {

--- a/flux-cli/src/test/java/com/marklogic/flux/AbstractTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/AbstractTest.java
@@ -5,11 +5,12 @@ package com.marklogic.flux;
 
 import com.marklogic.client.DatabaseClient;
 import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.flux.api.FluxException;
+import com.marklogic.flux.cli.Main;
+import com.marklogic.flux.cli.PicoMain;
 import com.marklogic.junit5.AbstractMarkLogicTest;
 import com.marklogic.mgmt.ManageClient;
 import com.marklogic.mgmt.ManageConfig;
-import com.marklogic.flux.api.FluxException;
-import com.marklogic.flux.cli.Main;
 import com.marklogic.rest.util.RestTemplateUtil;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.AfterEach;
@@ -19,6 +20,8 @@ import org.springframework.web.client.RestTemplate;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -87,7 +90,12 @@ public abstract class AbstractTest extends AbstractMarkLogicTest {
     }
 
     protected final void run(String... args) {
-        Main.main(args);
+        List<String> commands = Arrays.asList("export-delimited-files");
+        if (args.length > 0 && commands.contains(args[0])) {
+            PicoMain.main(args);
+        } else {
+            Main.main(args);
+        }
     }
 
     /**

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
@@ -19,14 +19,6 @@ class HelpTest extends AbstractTest {
             "Summary usage is expected to show each command its description, but no parameters; stdout: " + stdout);
 
         assertFalse(stdout.contains("-host"), "No parameters should be shown with summary usage; stdout: " + stdout);
-
-        assertTrue(
-            stdout.contains("Read delimited text files from local, HDFS, and S3 locations using Spark's \n"),
-            "Each command description is expected to wrap at 120 characters. This test may break when new commands " +
-                "are introduced with long names, or if the import-delimited-files description changes. If " +
-                "so, just update this assertion to capture the description text that occurs before the first newline " +
-                "symbol. stdout: " + stdout
-        );
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommandTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommandTest.java
@@ -28,6 +28,31 @@ class ExportDelimitedFilesCommandTest extends AbstractTest {
             "--file-count", "1"
         );
 
+        verifyDelimitedFile(tempDir);
+    }
+
+    /**
+     * Verifies that an options file can have values with whitespace in them, which picocli supports and
+     * JCommander oddly does not. Users will frequently have spaces in any Optic or search queries that they put into
+     * options files. And it's common to put queries into options files as they are awkward to type directly on the
+     * command line.
+     *
+     * @param tempDir
+     * @throws IOException
+     */
+    @Test
+    void optionsFileWithSpacesInIt(@TempDir Path tempDir) throws IOException {
+        run(
+            "export-delimited-files",
+            "--connection-string", makeConnectionString(),
+            "@src/test/resources/options-files/export-rows.txt",
+            "--path", tempDir.toFile().getAbsolutePath()
+        );
+
+        verifyDelimitedFile(tempDir);
+    }
+
+    private void verifyDelimitedFile(Path tempDir) throws IOException {
         File[] files = tempDir.toFile().listFiles((dir, name) -> name.endsWith(".csv"));
         assertEquals(1, files.length);
 

--- a/flux-cli/src/test/resources/options-files/export-rows.txt
+++ b/flux-cli/src/test/resources/options-files/export-rows.txt
@@ -1,0 +1,6 @@
+--query
+op.fromView("Medical", "Authors", "").orderBy(op.asc(op.col("LastName")))
+--file-count
+1
+--partitions
+1


### PR DESCRIPTION
Converted the command for exporting CSV over to picocli and verified that it supports whitespace in options files.

Next PR will be a big search/replace on all the JCommander annotations, as they mostly switch over easily to picocli annotations. 