### PR TITLE
Using pico mixins instead of arg groups

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/cli/PicoMain.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/PicoMain.java
@@ -23,6 +23,14 @@ import java.util.Optional;
 
 @CommandLine.Command(
     name = "./bin/flux",
+
+    // The scope allows for the following attributes to be inherited by the subcommands.
+    scope = CommandLine.ScopeType.INHERIT,
+    abbreviateSynopsis = true,
+    showAtFileInUsageHelp = true,
+    separator = " ",
+    requiredOptionMarker = '*',
+
     subcommands = {
         CommandLine.HelpCommand.class,
         CopyCommand.class,
@@ -80,6 +88,7 @@ public class PicoMain {
             .setAbbreviatedOptionsAllowed(true)
             .setAbbreviatedSubcommandsAllowed(true)
             .setCaseInsensitiveEnumValuesAllowed(true)
+            .setParameterExceptionHandler(new ShortErrorMessageHandler())
             .setExecutionStrategy(parseResult -> {
                 final Command command = (Command) parseResult.subcommand().commandSpec().userObject();
                 try {

--- a/flux-cli/src/main/java/com/marklogic/flux/cli/ShortErrorMessageHandler.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/ShortErrorMessageHandler.java
@@ -1,0 +1,33 @@
+package com.marklogic.flux.cli;
+
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+
+/**
+ * Copied from https://picocli.info/#_invalid_user_input . Typically, showing the usage - which has dozens of options -
+ * makes it very hard for the user to find the actual error message, which is printed first.
+ */
+class ShortErrorMessageHandler implements CommandLine.IParameterExceptionHandler {
+
+    public int handleParseException(CommandLine.ParameterException ex, String[] args) {
+        CommandLine cmd = ex.getCommandLine();
+        PrintWriter err = cmd.getErr();
+
+        // if tracing at DEBUG level, show the location of the issue
+        if ("DEBUG".equalsIgnoreCase(System.getProperty("picocli.trace"))) {
+            err.println(cmd.getColorScheme().stackTraceText(ex));
+        }
+
+        err.println(cmd.getColorScheme().errorText(ex.getMessage())); // bold red
+        CommandLine.UnmatchedArgumentException.printSuggestions(ex, err);
+        err.print(cmd.getHelp().fullSynopsis());
+
+        CommandLine.Model.CommandSpec spec = cmd.getCommandSpec();
+        err.printf("Run '%s --help' for more information.%n", spec.qualifiedName());
+
+        return cmd.getExitCodeExceptionMapper() != null
+            ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
+            : spec.exitCodeOnInvalidInput();
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -23,11 +23,12 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
 
     protected final Logger logger = LoggerFactory.getLogger("com.marklogic.flux");
 
-    @CommandLine.ArgGroup(exclusive = false, heading = "\nCommon Options\n")
-    private CommonParams commonParams = new CommonParams();
-
-    @CommandLine.ArgGroup(exclusive = false, heading = "\nConnection Options\n")
+    // This is declared before CommonParams so that it appears first in the picocli usage.
+    @CommandLine.ArgGroup(exclusive = false, heading = "Connection Options%n")
     private ConnectionParams connectionParams = new ConnectionParams();
+
+    @CommandLine.ArgGroup(exclusive = false, heading = "%nCommon Options%n")
+    private CommonParams commonParams = new CommonParams();
 
     private SparkSession sparkSession;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.flux.impl;
 
-import com.beust.jcommander.ParameterException;
 import com.marklogic.flux.api.AuthenticationType;
 import com.marklogic.flux.api.FluxException;
 
@@ -15,7 +14,7 @@ public class ConnectionParamsValidator {
         this.paramNames = new ParamNames(isOutput);
     }
 
-    public void validate(ConnectionInputs connectionInputs, CommonParams commonParams) throws ParameterException {
+    public void validate(ConnectionInputs connectionInputs, CommonParams commonParams) {
         if (connectionInputs.connectionString != null || (commonParams != null && commonParams.isPreviewRequested())) {
             return;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -263,14 +263,14 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         }
     }
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private CopyReadDocumentsParams readParams = new CopyReadDocumentsParams();
+
+    @CommandLine.Mixin
+    protected final CopyWriteDocumentsParams writeParams = new CopyWriteDocumentsParams();
 
     @CommandLine.ArgGroup(exclusive = false, heading = "\nOutput Connection Options\n")
     private OutputConnectionParams outputConnectionParams = new OutputConnectionParams();
-
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
-    protected final CopyWriteDocumentsParams writeParams = new CopyWriteDocumentsParams();
 
     @Override
     public void execute() {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/AbstractCustomExportCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/AbstractCustomExportCommand.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 abstract class AbstractCustomExportCommand<T extends Executor> extends AbstractCommand<T> {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected final CustomWriteParams writeParams = new CustomWriteParams();
 
     public static class CustomWriteParams implements CustomExportWriteOptions {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportDocumentsCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportDocumentsCommand.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 )
 public class CustomExportDocumentsCommand extends AbstractCustomExportCommand<CustomDocumentsExporter> implements CustomDocumentsExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadDocumentParamsImpl readParams = new ReadDocumentParamsImpl();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportRowsCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportRowsCommand.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 )
 public class CustomExportRowsCommand extends AbstractCustomExportCommand<CustomRowsExporter> implements CustomRowsExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadRowsParams readParams = new ReadRowsParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
@@ -22,10 +22,10 @@ import java.util.function.Consumer;
 )
 public class CustomImportCommand extends AbstractCommand<CustomImporter> implements CustomImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private CustomReadParams readParams = new CustomReadParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
@@ -16,7 +16,7 @@ import picocli.CommandLine;
  */
 abstract class AbstractExportRowsToFilesCommand<T extends Executor> extends AbstractCommand<T> {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected final ReadRowsParams readParams = new ReadRowsParams();
 
     // Sonar complaining about the use of ?; not sure yet how to "fix" it, so ignoring.

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.stream.Stream;
 )
 public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExporter> implements ArchiveFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadArchiveDocumentsParams readParams = new ReadArchiveDocumentsParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteArchiveFilesParams writeParams = new WriteArchiveFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportAvroFilesCommand.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 )
 public class ExportAvroFilesCommand extends AbstractExportRowsToFilesCommand<AvroFilesExporter> implements AvroFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteAvroFilesParams writeParams = new WriteAvroFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 )
 public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesCommand<DelimitedFilesExporter> implements DelimitedFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteDelimitedFilesParams writeParams = new WriteDelimitedFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
@@ -25,10 +25,10 @@ import java.util.function.Supplier;
 )
 public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> implements GenericFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadDocumentParamsImpl readParams = new ReadDocumentParamsImpl();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected WriteGenericFilesParams writeParams = new WriteGenericFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
@@ -20,10 +20,10 @@ import java.util.function.Consumer;
 )
 public class ExportJdbcCommand extends AbstractCommand<JdbcExporter> implements JdbcExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadRowsParams readParams = new ReadRowsParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteJdbcParams writeParams = new WriteJdbcParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 )
 public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesCommand<JsonLinesFilesExporter> implements JsonLinesFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteJsonFilesParams writeParams = new WriteJsonFilesParams();
 
     public static class WriteJsonFilesParams extends WriteStructuredFilesParams<WriteSparkFilesOptions> implements WriteSparkFilesOptions {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportOrcFilesCommand.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 )
 public class ExportOrcFilesCommand extends AbstractExportRowsToFilesCommand<OrcFilesExporter> implements OrcFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteOrcFilesParams writeParams = new WriteOrcFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportParquetFilesCommand.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 )
 public class ExportParquetFilesCommand extends AbstractExportRowsToFilesCommand<ParquetFilesExporter> implements ParquetFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteParquetFilesParams writeParams = new WriteParquetFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.stream.Stream;
 )
 public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> implements RdfFilesExporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected ReadTriplesParams readParams = new ReadTriplesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected WriteRdfFilesParams writeParams = new WriteRdfFilesParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlCommand.java
@@ -17,15 +17,14 @@ import java.util.function.Supplier;
 
 @CommandLine.Command(
     name = "import-aggregate-xml-files",
-    abbreviateSynopsis = true,
-    description = "Read aggregate XML files from local, HDFS, and S3 locations with each row being written to MarkLogic."
+    description = "%nRead aggregate XML files from local, HDFS, and S3 locations with each row being written to MarkLogic.%n"
 )
 public class ImportAggregateXmlCommand extends AbstractImportFilesCommand<AggregateXmlFilesImporter> implements AggregateXmlFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadXmlFilesParams readParams = new ReadXmlFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteDocumentParamsImpl writeParams = new WriteDocumentParamsImpl();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
@@ -22,10 +22,10 @@ import java.util.stream.Stream;
 )
 public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<ArchiveFilesImporter> implements ArchiveFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadArchiveFilesParams readParams = new ReadArchiveFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteDocumentParamsImpl writeParams = new WriteDocumentParamsImpl();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.function.Consumer;
 )
 public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFilesImporter> implements AvroFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadAvroFilesParams readParams = new ReadAvroFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeDocumentParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.function.Consumer;
 )
 public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<DelimitedFilesImporter> implements DelimitedFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadDelimitedFilesParams readParams = new ReadDelimitedFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -19,10 +19,10 @@ import java.util.function.Consumer;
 )
 public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesImporter> implements GenericFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadGenericFilesParams readParams = new ReadGenericFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteGenericDocumentsParams writeParams = new WriteGenericDocumentsParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
@@ -22,10 +22,10 @@ import java.util.function.Consumer;
 )
 public class ImportJdbcCommand extends AbstractCommand<JdbcImporter> implements JdbcImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private ReadJdbcParams readParams = new ReadJdbcParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
@@ -20,10 +20,10 @@ import java.util.function.Consumer;
 )
 public class ImportJsonFilesCommand extends AbstractImportFilesCommand<JsonFilesImporter> implements JsonFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadJsonFilesParams readParams = new ReadJsonFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
@@ -21,10 +21,10 @@ import java.util.stream.Stream;
 )
 public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<MlcpArchiveFilesImporter> implements MlcpArchiveFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadMlcpArchiveFilesParams readParams = new ReadMlcpArchiveFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteDocumentParamsImpl writeParams = new WriteDocumentParamsImpl();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.function.Consumer;
 )
 public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesImporter> implements OrcFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadOrcFilesParams readParams = new ReadOrcFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
@@ -23,10 +23,10 @@ import java.util.function.Consumer;
 )
 public class ImportParquetFilesCommand extends AbstractImportFilesCommand<ParquetFilesImporter> implements ParquetFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadParquetFilesParams readParams = new ReadParquetFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteStructuredDocumentParams writeParams = new WriteStructuredDocumentParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
@@ -21,10 +21,10 @@ import java.util.function.Supplier;
 )
 public class ImportRdfFilesCommand extends AbstractImportFilesCommand<RdfFilesImporter> implements RdfFilesImporter {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING, multiplicity = "1")
+    @CommandLine.Mixin
     private ReadRdfFilesParams readParams = new ReadRdfFilesParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     private WriteTriplesDocumentsParams writeParams = new WriteTriplesDocumentsParams();
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ReadFilesParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ReadFilesParams.java
@@ -15,8 +15,9 @@ import java.util.*;
  */
 public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOptions<T> {
 
+    // "path" is the name so that picocli shows "--path <path>" instead of "--path <paths>".
     @CommandLine.Option(required = true, names = "--path", description = "Specify one or more path expressions for selecting files to import.")
-    private List<String> paths = new ArrayList<>();
+    private List<String> path = new ArrayList<>();
 
     @CommandLine.Option(names = "--abort-on-read-failure", description = "Causes the command to abort when it fails to read a file.")
     private Boolean abortOnReadFailure = false;
@@ -31,7 +32,7 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
     private S3Params s3Params = new S3Params();
 
     public boolean hasAtLeastOnePath() {
-        return paths != null && !paths.isEmpty();
+        return path != null && !path.isEmpty();
     }
 
     public Map<String, String> makeOptions() {
@@ -80,7 +81,7 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
     }
 
     public List<String> getPaths() {
-        return paths;
+        return path;
     }
 
     public S3Params getS3Params() {
@@ -89,7 +90,7 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
 
     @Override
     public T paths(String... paths) {
-        this.paths = Arrays.asList(paths);
+        this.path = Arrays.asList(paths);
         return (T) this;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -27,10 +27,10 @@ import java.util.stream.Stream;
 )
 public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Reprocessor {
 
-    @CommandLine.ArgGroup(exclusive = false, heading = READER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected ReadParams readParams = new ReadParams();
 
-    @CommandLine.ArgGroup(exclusive = false, heading = WRITER_OPTIONS_HEADING)
+    @CommandLine.Mixin
     protected WriteParams writeParams = new WriteParams();
 
     @Override

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -26,7 +26,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void invalidParam() {
         assertStderrContains(
-            () -> run("import-files", "--not-a-real-param"),
+            () -> run("import-files", "--not-a-real-param", "--path", "anywhere"),
             "Unknown option: '--not-a-real-param'"
         );
     }
@@ -34,7 +34,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void invalidParamWithSingleQuotesInIt() {
         assertStderrContains(
-            () -> run("import-files", "-not-a-'real'-param"),
+            () -> run("import-files", "-not-a-'real'-param", "--path", "anywhere"),
             "Unknown option: '-not-a-'real'-param'"
         );
     }
@@ -51,7 +51,7 @@ class HandleErrorTest extends AbstractTest {
     void missingRequiredParam() {
         assertStderrContains(
             () -> run("import-files", "--connection-string", makeConnectionString()),
-            "Error: Missing required argument(s): (--path=<paths>"
+            "Missing required option: '--path <path>'"
         );
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
@@ -43,7 +43,7 @@ class HelpTest extends AbstractTest {
     void noCommandAfterHelp() {
         String stdout = runAndReturnStdout(() -> run("help"));
         System.out.println(stdout);
-        assertTrue(stdout.contains("Usage: ./bin/flux help [-h] [COMMAND]"),
+        assertTrue(stdout.contains("Usage: ./bin/flux help [OPTIONS] [COMMAND]"),
             "If 'help' is run with no command, then the help for 'help' should be shown.");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
@@ -5,8 +5,8 @@ package com.marklogic.flux.impl.importdata;
 
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.StringHandle;
-import com.marklogic.junit5.XmlNode;
 import com.marklogic.flux.AbstractTest;
+import com.marklogic.junit5.XmlNode;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -20,13 +20,19 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
 
     @Test
     void elementIsRequired() {
-        String stderr = runAndReturnStderr(() -> run(
+        assertStderrContains(() -> run(
             "import-aggregate-xml-files",
             "--path", "src/test/resources/xml-file/people.xml",
             "--connection-string", makeConnectionString()
-        ));
-        assertTrue(stderr.contains("Error: Missing required argument(s): --element=<element>"),
-            "Unexpected stderr: " + stderr);
+        ), "Missing required option: '--element <element>'");
+    }
+
+    @Test
+    void elementAndPathAreRequired() {
+        assertStderrContains(() -> run(
+            "import-aggregate-xml-files",
+            "--connection-string", makeConnectionString()
+        ), "Missing required options: '--path <path>', '--element <element>'");
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -22,10 +22,12 @@ class ImportFilesTest extends AbstractTest {
     String[] uris = new String[]{"/hello.json", "/hello.txt", "/hello.xml", "/hello2.txt.gz"};
 
     @Test
-    void test() {
+    void multiplePaths() {
         run(
             "import-files",
-            "--path", "src/test/resources/mixed-files/hello*",
+            "--path", "src/test/resources/mixed-files/hello*txt*",
+            "--path", "src/test/resources/mixed-files/hello.json",
+            "--path", "src/test/resources/mixed-files/hello.xml",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",


### PR DESCRIPTION
Realized that this reuses the validation support, like "required", better than arg groups do. We lose headings for read/write options, but I think we're fine because we still have them for the generic connection / common options which now appear below the command-specific options.