### PR TITLE
MLE-14784 Added --encoding convenience for exporting JSON and CSV

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesExporter.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.flux.api;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -15,7 +16,13 @@ public interface DelimitedFilesExporter extends Executor<DelimitedFilesExporter>
 
     DelimitedFilesExporter from(String opticQuery);
 
-    DelimitedFilesExporter to(Consumer<WriteSparkFilesOptions> consumer);
+    DelimitedFilesExporter to(Consumer<WriteDelimitedFilesOptions> consumer);
 
     DelimitedFilesExporter to(String path);
+
+    interface WriteDelimitedFilesOptions extends WriteFilesOptions<WriteDelimitedFilesOptions> {
+        WriteDelimitedFilesOptions encoding(String encoding);
+
+        WriteDelimitedFilesOptions additionalOptions(Map<String, String> options);
+    }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/JsonLinesFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/JsonLinesFilesExporter.java
@@ -3,6 +3,7 @@
  */
 package com.marklogic.flux.api;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -15,7 +16,13 @@ public interface JsonLinesFilesExporter extends Executor<JsonLinesFilesExporter>
 
     JsonLinesFilesExporter from(String opticQuery);
 
-    JsonLinesFilesExporter to(Consumer<WriteSparkFilesOptions> consumer);
+    JsonLinesFilesExporter to(Consumer<WriteJsonLinesFilesOptions> consumer);
 
     JsonLinesFilesExporter to(String path);
+
+    interface WriteJsonLinesFilesOptions extends WriteFilesOptions<WriteJsonLinesFilesOptions> {
+        WriteJsonLinesFilesOptions encoding(String encoding);
+
+        WriteJsonLinesFilesOptions additionalOptions(Map<String, String> options);
+    }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
@@ -5,7 +5,6 @@ package com.marklogic.flux.impl.export;
 
 import com.marklogic.flux.api.DelimitedFilesExporter;
 import com.marklogic.flux.api.ReadRowsOptions;
-import com.marklogic.flux.api.WriteSparkFilesOptions;
 import com.marklogic.flux.impl.OptionsUtil;
 import picocli.CommandLine;
 
@@ -33,7 +32,10 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
         return writeParams;
     }
 
-    public static class WriteDelimitedFilesParams extends WriteStructuredFilesParams<WriteSparkFilesOptions> implements WriteSparkFilesOptions {
+    public static class WriteDelimitedFilesParams extends WriteStructuredFilesParams<WriteDelimitedFilesOptions> implements WriteDelimitedFilesOptions {
+
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 for writing files.")
+        private String encoding;
 
         @CommandLine.Option(
             names = {"-P"},
@@ -44,12 +46,21 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
         @Override
         public Map<String, String> get() {
             Map<String, String> options = OptionsUtil.makeOptions("header", "true");
+            if (encoding != null) {
+                options.put("encoding", encoding);
+            }
             options.putAll(additionalOptions);
             return options;
         }
 
         @Override
-        public WriteSparkFilesOptions additionalOptions(Map<String, String> options) {
+        public WriteDelimitedFilesOptions encoding(String encoding) {
+            this.encoding = encoding;
+            return this;
+        }
+
+        @Override
+        public WriteDelimitedFilesOptions additionalOptions(Map<String, String> options) {
             this.additionalOptions = options;
             return this;
         }
@@ -68,7 +79,7 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
     }
 
     @Override
-    public DelimitedFilesExporter to(Consumer<WriteSparkFilesOptions> consumer) {
+    public DelimitedFilesExporter to(Consumer<WriteDelimitedFilesOptions> consumer) {
         consumer.accept(writeParams);
         return this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
@@ -6,7 +6,6 @@ package com.marklogic.flux.impl.export;
 import com.marklogic.flux.api.JsonLinesFilesExporter;
 import com.marklogic.flux.api.ReadRowsOptions;
 import com.marklogic.flux.api.WriteFilesOptions;
-import com.marklogic.flux.api.WriteSparkFilesOptions;
 import picocli.CommandLine;
 
 import java.util.HashMap;
@@ -23,7 +22,10 @@ public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesComman
     @CommandLine.Mixin
     private WriteJsonFilesParams writeParams = new WriteJsonFilesParams();
 
-    public static class WriteJsonFilesParams extends WriteStructuredFilesParams<WriteSparkFilesOptions> implements WriteSparkFilesOptions {
+    public static class WriteJsonFilesParams extends WriteStructuredFilesParams<WriteJsonLinesFilesOptions> implements WriteJsonLinesFilesOptions {
+
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 for writing files.")
+        private String encoding;
 
         @CommandLine.Option(
             names = "-P",
@@ -34,11 +36,22 @@ public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesComman
 
         @Override
         public Map<String, String> get() {
-            return additionalOptions;
+            Map<String, String> options = new HashMap<>();
+            if (encoding != null) {
+                options.put("encoding", encoding);
+            }
+            options.putAll(additionalOptions);
+            return options;
         }
 
         @Override
-        public WriteSparkFilesOptions additionalOptions(Map<String, String> options) {
+        public WriteJsonLinesFilesOptions encoding(String encoding) {
+            this.encoding = encoding;
+            return this;
+        }
+
+        @Override
+        public WriteJsonLinesFilesOptions additionalOptions(Map<String, String> options) {
             this.additionalOptions = options;
             return this;
         }
@@ -66,7 +79,7 @@ public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesComman
     }
 
     @Override
-    public JsonLinesFilesExporter to(Consumer<WriteSparkFilesOptions> consumer) {
+    public JsonLinesFilesExporter to(Consumer<WriteJsonLinesFilesOptions> consumer) {
         consumer.accept(writeParams);
         return this;
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesOptionsTest.java
@@ -1,0 +1,30 @@
+package com.marklogic.flux.impl.export;
+
+import com.marklogic.flux.impl.AbstractOptionsTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportDelimitedFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        ExportDelimitedFilesCommand command = (ExportDelimitedFilesCommand) getCommand(
+            "export-delimited-files",
+            "--connection-string", "test:test@host:8000",
+            "--query", "anything",
+            "--path", "anywhere",
+            "--encoding", "UTF-16",
+            "-Pkey=value"
+        );
+
+        Map<String, String> options = command.getWriteFilesParams().get();
+        assertEquals("true", options.get("header"), "The command should default to including the header, both for " +
+            "consistency with MLCP and because it's very common to want a header in a delimited file.");
+        assertEquals("value", options.get("key"));
+        assertEquals("UTF-16", options.get("encoding"), "--encoding is included for consistency with other commands " +
+            "that support a custom encoding, even though a user can also specify it via -Pencoding=");
+    }
+}

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesOptionsTest.java
@@ -1,0 +1,28 @@
+package com.marklogic.flux.impl.export;
+
+import com.marklogic.flux.impl.AbstractOptionsTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportJsonLinesFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        ExportJsonLinesFilesCommand command = (ExportJsonLinesFilesCommand) getCommand(
+            "export-json-lines-files",
+            "--connection-string", "test:test@host:8000",
+            "--query", "anything",
+            "--path", "anywhere",
+            "--encoding", "UTF-16",
+            "-Pkey=value"
+        );
+
+        Map<String, String> options = command.getWriteFilesParams().get();
+        assertEquals("value", options.get("key"));
+        assertEquals("UTF-16", options.get("encoding"), "--encoding is included for consistency with other commands " +
+            "that support a custom encoding, even though a user can also specify it via -Pencoding=");
+    }
+}


### PR DESCRIPTION
A user can already do this via `-Pencoding=UTF-16`. This is just making the UX consistent. We may still add encoding support for writing text/archive files. 