### PR TITLE
MLE-15472 Can now specify encoding for writing files and archives

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -27,6 +27,19 @@ The "help" for each command will first list the command-specific options, with e
 next to it. The command-specific options are followed by the connection options for connecting to MarkLogic, and those
 are followed by a list of options common to every Flux command. 
 
+## Command abbreviations
+
+You can specify a command name without entering its full name, as long as you enter a sufficient number of characters
+such that Flux can uniquely identify the command name.
+
+For example, instead of entering `import-aggregate-xml-files`, you can enter `import-ag` as it is the only command in
+Flux with that sequence of letters:
+
+    ./bin/flux import-ag --path path/to/data etc...
+
+If Flux cannot uniquely identify the command name, it will print an error and list the command names that match what
+you entered.
+
 ## Connecting to MarkLogic
 
 Every command in Flux will need to connect to a MarkLogic database, either for reading data or writing data or both. 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ArchiveFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ArchiveFilesExporter.java
@@ -14,9 +14,13 @@ public interface ArchiveFilesExporter extends Executor<ArchiveFilesExporter> {
         ReadArchiveDocumentOptions categories(String... categories);
     }
 
+    interface WriteArchiveFilesOptions extends WriteFilesOptions<WriteArchiveFilesOptions> {
+        WriteArchiveFilesOptions encoding(String encoding);
+    }
+
     ArchiveFilesExporter from(Consumer<ReadArchiveDocumentOptions> consumer);
 
-    ArchiveFilesExporter to(Consumer<WriteFilesOptions<? extends WriteFilesOptions>> consumer);
+    ArchiveFilesExporter to(Consumer<WriteArchiveFilesOptions> consumer);
 
     ArchiveFilesExporter to(String path);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesExporter.java
@@ -17,6 +17,8 @@ public interface GenericFilesExporter extends Executor<GenericFilesExporter> {
 
         WriteGenericFilesOptions prettyPrint(Boolean value);
 
+        WriteGenericFilesOptions encoding(String encoding);
+
         WriteGenericFilesOptions zipFileCount(Integer zipFileCount);
 
         WriteGenericFilesOptions s3AddCredentials();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
@@ -4,7 +4,6 @@
 package com.marklogic.flux.impl.export;
 
 import com.marklogic.flux.api.ArchiveFilesExporter;
-import com.marklogic.flux.api.WriteFilesOptions;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.OptionsUtil;
 import com.marklogic.spark.Options;
@@ -26,7 +25,7 @@ public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExpor
     private ReadArchiveDocumentsParams readParams = new ReadArchiveDocumentsParams();
 
     @CommandLine.Mixin
-    private WriteArchiveFilesParams writeParams = new WriteArchiveFilesParams();
+    protected WriteArchiveFilesParams writeParams = new WriteArchiveFilesParams();
 
     @Override
     protected void validateDuringApiUsage() {
@@ -61,11 +60,23 @@ public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExpor
             .save(writeParams.getPath());
     }
 
-    public static class WriteArchiveFilesParams extends WriteFilesParams<WriteArchiveFilesParams> {
+    public static class WriteArchiveFilesParams extends WriteFilesParams<WriteArchiveFilesOptions> implements WriteArchiveFilesOptions {
+
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding for writing files.")
+        private String encoding;
+
+        @Override
+        public WriteArchiveFilesOptions encoding(String encoding) {
+            this.encoding = encoding;
+            return this;
+        }
 
         @Override
         public Map<String, String> get() {
-            return OptionsUtil.makeOptions(Options.WRITE_FILES_COMPRESSION, "zip");
+            return OptionsUtil.makeOptions(
+                Options.WRITE_FILES_COMPRESSION, "zip",
+                Options.WRITE_FILES_ENCODING, encoding
+            );
         }
     }
 
@@ -109,7 +120,7 @@ public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExpor
     }
 
     @Override
-    public ArchiveFilesExporter to(Consumer<WriteFilesOptions<? extends WriteFilesOptions>> consumer) {
+    public ArchiveFilesExporter to(Consumer<WriteArchiveFilesOptions> consumer) {
         consumer.accept(writeParams);
         return this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
@@ -34,7 +34,7 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
 
     public static class WriteDelimitedFilesParams extends WriteStructuredFilesParams<WriteDelimitedFilesOptions> implements WriteDelimitedFilesOptions {
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 for writing files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding for writing files.")
         private String encoding;
 
         @CommandLine.Option(

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
@@ -78,6 +78,9 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         @CommandLine.Option(names = "--pretty-print", description = "Pretty-print the contents of JSON and XML files.")
         private Boolean prettyPrint;
 
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding for writing files.")
+        private String encoding;
+
         @CommandLine.Option(names = "--zip-file-count", description = "Specifies how many ZIP files should be written when --compression is set to 'ZIP'; also an alias for '--repartition'.")
         private Integer zipFileCount;
 
@@ -85,7 +88,8 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         public Map<String, String> get() {
             return OptionsUtil.makeOptions(
                 Options.WRITE_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null,
-                Options.WRITE_FILES_PRETTY_PRINT, prettyPrint != null ? prettyPrint.toString() : null
+                Options.WRITE_FILES_PRETTY_PRINT, prettyPrint != null ? prettyPrint.toString() : null,
+                Options.WRITE_FILES_ENCODING, encoding
             );
         }
 
@@ -104,6 +108,12 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         @Override
         public WriteGenericFilesOptions prettyPrint(Boolean value) {
             this.prettyPrint = value;
+            return this;
+        }
+
+        @Override
+        public WriteGenericFilesOptions encoding(String encoding) {
+            this.encoding = encoding;
             return this;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
@@ -24,7 +24,7 @@ public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesComman
 
     public static class WriteJsonFilesParams extends WriteStructuredFilesParams<WriteJsonLinesFilesOptions> implements WriteJsonLinesFilesOptions {
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 for writing files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding for writing files.")
         private String encoding;
 
         @CommandLine.Option(

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlCommand.java
@@ -69,7 +69,7 @@ public class ImportAggregateXmlCommand extends AbstractImportFilesCommand<Aggreg
         )
         private CompressionType compressionType;
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
@@ -52,7 +52,7 @@ public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<Archiv
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
         private Integer partitions;
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -44,7 +44,7 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
 
     public static class ReadDelimitedFilesParams extends ReadFilesParams<ReadDelimitedFilesOptions> implements ReadDelimitedFilesOptions {
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @CommandLine.Option(

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -63,7 +63,7 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
             + OptionsUtil.VALID_VALUES_DESCRIPTION)
         private CompressionType compressionType;
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
@@ -48,7 +48,7 @@ public class ImportJsonFilesCommand extends AbstractImportFilesCommand<JsonFiles
         )
         private Boolean jsonLines;
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @CommandLine.Option(

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
@@ -48,7 +48,7 @@ public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<Ml
             "Valid choices are: collections, permissions, quality, properties, and metadatavalues.")
         private String categories;
 
-        @CommandLine.Option(names = "--encoding", description = "Specify an encoding other than UTF-8 when reading files.")
+        @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesOptionsTest.java
@@ -44,4 +44,18 @@ class ExportFilesOptionsTest extends AbstractOptionsTest {
         assertFalse(options.containsKey(Options.WRITE_FILES_PRETTY_PRINT));
         assertEquals("ZIP", options.get(Options.WRITE_FILES_COMPRESSION));
     }
+
+    @Test
+    void encoding() {
+        ExportFilesCommand command = (ExportFilesCommand) getCommand(
+            "export-files",
+            "--connection-string", "test:test@host:8000",
+            "--collections", "anything",
+            "--path", "anywhere",
+            "--encoding", "ISO-8859-1"
+        );
+
+        Map<String, String> options = command.writeParams.get();
+        assertEquals("ISO-8859-1", options.get(Options.WRITE_FILES_ENCODING));
+    }
 }


### PR DESCRIPTION
Tweaked the description of "--encoding" as well as a user may have their JVM defaulting to something other than UTF-8, which means they may want to set encoding to UTF-8. 