### PR TITLE
MLE-14737 Showing nice error message when no Optic query was found

### DIFF
--- a/flux-cli/src/main/resources/marklogic-spark-messages_en.properties
+++ b/flux-cli/src/main/resources/marklogic-spark-messages_en.properties
@@ -5,6 +5,7 @@
 spark.marklogic.client.uri=--connection-string
 spark.marklogic.read.batchSize=--batch-size
 spark.marklogic.read.documents.partitionsPerForest=--partitions-per-forest
+spark.marklogic.read.noOpticQuery=Must define an Optic query
 spark.marklogic.read.numPartitions=--partitions
 spark.marklogic.write.batchSize=--batch-size
 spark.marklogic.write.documentType=--document-type

--- a/flux-cli/src/test/java/com/marklogic/flux/api/AvroFilesExporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/AvroFilesExporterTest.java
@@ -4,6 +4,7 @@
 package com.marklogic.flux.api;
 
 import com.marklogic.flux.AbstractTest;
+import com.marklogic.spark.ConnectorException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -11,6 +12,7 @@ import java.io.File;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AvroFilesExporterTest extends AbstractTest {
 
@@ -39,6 +41,18 @@ class AvroFilesExporterTest extends AbstractTest {
 
         File[] files = tempDir.toFile().listFiles(file -> file.getName().endsWith(".avro"));
         assertEquals(1, files.length);
+    }
+
+    @Test
+    void noQuery() {
+        AvroFilesExporter exporter = Flux.exportAvroFiles()
+            .connectionString(makeConnectionString())
+            .to("build/doesnt-matter");
+
+        ConnectorException ex = assertThrows(ConnectorException.class, () -> exporter.execute());
+        assertEquals("Must define an Optic query", ex.getMessage(), "Verifying that a friendly error message that " +
+            "doesn't have a connector option name in it is shown. This is expected to be shown for any command " +
+            "that depends on running an Optic query.");
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
@@ -15,8 +15,8 @@ class ErrorMessagesTest {
     @Test
     void verifyEachKeyIsOverridden() {
         ResourceBundle bundle = ResourceBundle.getBundle("marklogic-spark-messages");
-        assertEquals(15, bundle.keySet().size(),
-            "Expecting 15 keys as of the upcoming 2.3.0 release. Bump this up as more keys are added. Each key should " +
+        assertEquals(16, bundle.keySet().size(),
+            "Expecting 16 keys as of the upcoming 2.3.0 release. Bump this up as more keys are added. Each key should " +
                 "also be verified in an assertion below.");
 
         assertEquals("--connection-string", bundle.getString(Options.CLIENT_URI));
@@ -34,5 +34,6 @@ class ErrorMessagesTest {
         assertEquals("--transform-params", bundle.getString(Options.WRITE_TRANSFORM_PARAMS));
         assertEquals("--uri-template", bundle.getString(Options.WRITE_URI_TEMPLATE));
         assertEquals("--xml-root-name", bundle.getString(Options.WRITE_XML_ROOT_NAME));
+        assertEquals("Must define an Optic query", bundle.getString("spark.marklogic.read.noOpticQuery"));
     }
 }


### PR DESCRIPTION
The point of this ticket is for a nice error when no query is found, but I ran into this small issue first and figured I'd do a quick fix for it. 