### PR TITLE
Refactored how the preview feature works

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -3,7 +3,10 @@
  */
 package com.marklogic.flux.cli;
 
-import com.marklogic.flux.impl.*;
+import com.marklogic.flux.impl.AbstractCommand;
+import com.marklogic.flux.impl.Command;
+import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.VersionCommand;
 import com.marklogic.flux.impl.copy.CopyCommand;
 import com.marklogic.flux.impl.custom.CustomExportDocumentsCommand;
 import com.marklogic.flux.impl.custom.CustomExportRowsCommand;
@@ -15,8 +18,6 @@ import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
-
-import java.util.Optional;
 
 @CommandLine.Command(
     name = "./bin/flux",
@@ -97,10 +98,7 @@ public class Main {
             if (logger.isDebugEnabled()) {
                 logger.debug("Spark master URL: {}", session.sparkContext().master());
             }
-            Optional<Preview> preview = command.execute(session);
-            if (preview.isPresent()) {
-                preview.get().showPreview();
-            }
+            command.execute(session);
         } catch (Exception ex) {
             if (parseResult.subcommand().hasMatchedOption("--stacktrace")) {
                 logger.error("Displaying stacktrace due to use of --stacktrace option", ex);

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/Command.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/Command.java
@@ -6,16 +6,12 @@ package com.marklogic.flux.impl;
 import org.apache.spark.sql.SparkSession;
 import picocli.CommandLine;
 
-import java.util.Optional;
-
 public interface Command {
 
     /**
      * @param session the Spark session to use for executing the command
-     * @return Some commands may support a "preview" that returns the rows that were read without passing them to
-     * the writer. Those commands can return a preview of the dataset that has been read by the command.
      */
-    Optional<Preview> execute(SparkSession session);
+    void execute(SparkSession session);
 
     /**
      * With picocli, we don't have a JCommander-like facility for validating all the params before the command is

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -7,9 +7,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -24,14 +22,10 @@ public class CommonParams {
     @CommandLine.Option(names = "--count", description = "Show a count of records to be read from the data source without writing any of the data.")
     private boolean count;
 
-    @CommandLine.Option(names = "--preview", description = "Show up to the first N records of data read by the command.")
-    private Integer preview;
-
-    @CommandLine.Option(names = "--preview-drop", description = "Specify one or more columns to drop when using --preview.", arity = "*")
-    private List<String> previewColumnsToDrop = new ArrayList<>();
-
-    @CommandLine.Option(names = "--preview-vertical", description = "Preview the data in a vertical format instead of in a table.")
-    private boolean previewVertical;
+    // picocli doesn't allow a Mixin on an ArgGroup, so we use another ArgGroup here. No need for a heading though as
+    // we still want these to show up in the Common Options section in each command's "help" output.
+    @CommandLine.ArgGroup(exclusive = false)
+    private Preview preview = new Preview();
 
     @CommandLine.Option(names = "--repartition", description = "Specify the number of partitions to be used for writing data.")
     private Integer repartition;
@@ -65,10 +59,6 @@ public class CommonParams {
         return dataset;
     }
 
-    public Preview makePreview(Dataset<Row> dataset) {
-        return new Preview(dataset, preview, previewColumnsToDrop, previewVertical);
-    }
-
     public void setCount(boolean count) {
         this.count = count;
     }
@@ -77,12 +67,8 @@ public class CommonParams {
         return count;
     }
 
-    public void setPreview(Integer preview) {
-        this.preview = preview;
-    }
-
     public boolean isPreviewRequested() {
-        return preview != null;
+        return preview != null && preview.getNumberRows() > 0;
     }
 
     public void setLimit(Integer limit) {
@@ -99,5 +85,9 @@ public class CommonParams {
 
     public Map<String, String> getConfigParams() {
         return configParams;
+    }
+
+    public Preview getPreview() {
+        return preview;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
@@ -14,8 +14,8 @@ public class ConnectionParamsValidator {
         this.paramNames = new ParamNames(isOutput);
     }
 
-    public void validate(ConnectionInputs connectionInputs, CommonParams commonParams) {
-        if (connectionInputs.connectionString != null || (commonParams != null && commonParams.isPreviewRequested())) {
+    public void validate(ConnectionInputs connectionInputs) {
+        if (connectionInputs.connectionString != null) {
             return;
         }
 
@@ -31,14 +31,18 @@ public class ConnectionParamsValidator {
         AuthenticationType authType = connectionInputs.authType;
         boolean isDigestOrBasicAuth = authType == null || (AuthenticationType.DIGEST.equals(authType) || AuthenticationType.BASIC.equals(authType));
         if (isDigestOrBasicAuth) {
-            if (connectionInputs.username == null) {
-                throw new FluxException(String.format("Must specify a MarkLogic user via %s when using 'BASIC' or 'DIGEST' authentication.",
-                    paramNames.username));
-            }
-            if (connectionInputs.password == null) {
-                throw new FluxException(String.format("Must specify a password via %s when using 'BASIC' or 'DIGEST' authentication.",
-                    paramNames.password));
-            }
+            validateUsernameAndPassword(connectionInputs);
+        }
+    }
+
+    private void validateUsernameAndPassword(ConnectionInputs connectionInputs) {
+        if (connectionInputs.username == null) {
+            throw new FluxException(String.format("Must specify a MarkLogic user via %s when using 'BASIC' or 'DIGEST' authentication.",
+                paramNames.username));
+        }
+        if (connectionInputs.password == null) {
+            throw new FluxException(String.format("Must specify a password via %s when using 'BASIC' or 'DIGEST' authentication.",
+                paramNames.password));
         }
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/Preview.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/Preview.java
@@ -5,24 +5,22 @@ package com.marklogic.flux.impl;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import picocli.CommandLine;
 
 import java.util.List;
 
 public class Preview {
 
-    private final int numberRows;
-    private final Dataset<Row> dataset;
-    private final List<String> columnsToDrop;
-    private final boolean vertical;
+    @CommandLine.Option(names = "--preview", description = "Show up to the first N records of data read by the command.")
+    private int numberRows;
 
-    public Preview(Dataset<Row> dataset, int numberRows, List<String> columnsToDrop, boolean vertical) {
-        this.dataset = dataset;
-        this.numberRows = numberRows;
-        this.columnsToDrop = columnsToDrop;
-        this.vertical = vertical;
-    }
+    @CommandLine.Option(names = "--preview-drop", description = "Specify one or more columns to drop when using --preview.", arity = "*")
+    private List<String> columnsToDrop;
 
-    public void showPreview() {
+    @CommandLine.Option(names = "--preview-vertical", description = "Preview the data in a vertical format instead of in a table.")
+    private boolean vertical;
+
+    public void showPreview(Dataset<Row> dataset) {
         Dataset<Row> datasetPreview = dataset;
         if (columnsToDrop != null && !columnsToDrop.isEmpty()) {
             datasetPreview = datasetPreview.drop(columnsToDrop.toArray(new String[]{}));
@@ -31,7 +29,7 @@ public class Preview {
         datasetPreview.show(numberRows, Integer.MAX_VALUE, vertical);
     }
 
-    public Dataset<Row> getDataset() {
-        return dataset;
+    public int getNumberRows() {
+        return numberRows;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/VersionCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/VersionCommand.java
@@ -5,7 +5,6 @@ import org.apache.spark.sql.SparkSession;
 import picocli.CommandLine;
 
 import java.util.ListResourceBundle;
-import java.util.Optional;
 import java.util.ResourceBundle;
 
 @CommandLine.Command(
@@ -22,7 +21,7 @@ public class VersionCommand implements Command {
     private boolean verbose;
 
     @Override
-    public Optional<Preview> execute(SparkSession session) {
+    public void execute(SparkSession session) {
         ResourceBundle versionProperties = getResourceBundle();
         final String version = versionProperties.getString("version");
         final String javaVersion = System.getProperty("java.version");
@@ -38,7 +37,6 @@ public class VersionCommand implements Command {
             commandLine.getOut().println("Java version: " + javaVersion);
             commandLine.getOut().println("Spark version: " + sparkVersion);
         }
-        return Optional.empty();
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -284,7 +284,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         super.validateCommandLineOptions(parseResult);
         if (outputConnectionParams.atLeastOutputConnectionParameterExists(parseResult)) {
             CopyCommand copyCommand = (CopyCommand) parseResult.subcommand().commandSpec().userObject();
-            new ConnectionParamsValidator(true).validate(copyCommand.outputConnectionParams, copyCommand.getCommonParams());
+            new ConnectionParamsValidator(true).validate(copyCommand.outputConnectionParams);
         }
         OptionsUtil.verifyHasAtLeastOneOption(parseResult, ReadDocumentParams.REQUIRED_QUERY_OPTIONS);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -138,6 +138,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
             run(
                 "import-delimited-files",
                 "--path", "src/test/resources/delimited-files/three-rows.csv",
+                "--connection-string", makeConnectionString(),
                 "--limit", "1",
                 "--preview", "3",
                 "--preview-vertical"

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
@@ -92,6 +92,7 @@ class ImportJdbcTest extends AbstractTest {
             "import-jdbc",
             "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
             "--jdbc-driver", "not.valid.driver.value",
+            "--connection-string", makeConnectionString(),
             "--query", "select * from customer",
             "--preview", "10"
         ), "Command failed, cause: Unable to load class: not.valid.driver.value; " +

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -119,6 +119,7 @@ class ImportParquetFilesTest extends AbstractTest {
     void invalidParquetFile() {
         String stderr = runAndReturnStderr(() ->
             run("import-parquet-files",
+                "--connection-string", makeConnectionString(),
                 "--path", "src/test/resources/parquet/individual/invalid.parquet",
                 "--preview", "10",
                 "--abort-on-read-failure"


### PR DESCRIPTION
I was looking into enhancing this to support showing the dataset schema as well and realized that the current impl is a bit messy. This cleans things up.

Also, the feature of "Don't require a connection string when doing a preview" was very half-baked - only worked for imports - and so I removed it for now until it can be properly supported.
