### PR TITLE
Added --preview-schema

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -154,6 +154,19 @@ Note that in the case of previewing an import, Flux will show the data as it has
 Spark rows with columns. The data is not shown as a set of documents yet, as the transformation of rows to documents 
 occurs when the data is written to MarkLogic.
 
+For some commands, it may be helpful to see the schema of the data read from the command's data source. For example, 
+when exporting data with a MarkLogic Optic query, you may wish to verify that the datatypes of each column are what you
+expect before writing the data to a Parquet file or relational database. Use the `--preview-schema` option to request 
+that Flux log the schema and not write any data:
+
+```
+./bin/flux export-parquet-files \
+    --connection-string "flux-example-user:password@localhost:8004" \
+    --query "op.fromView('Example', 'Employees')" \
+    --path export/parquet \
+    --preview-schema
+```
+
 ## Applying a limit
 
 For many use cases, it can be useful to only process a small subset of the source data to ensure that the results

--- a/docs/export/custom-export.md
+++ b/docs/export/custom-export.md
@@ -37,8 +37,8 @@ via `custom-export-rows`:
 
 When using `custom-export-rows` with an Optic query to select rows from MarkLogic, each row sent to the connector or 
 data source defined by `--target` will have a schema based on the output of the Optic query. You may find the 
-`--preview` option helpful in understanding what data will be these rows. See [Common Options](../common-options.md) 
-for more information.
+`--preview` and `--preview-schema` options helpful in understanding what data will be in these rows. 
+See [Common Options](../common-options.md) for more information.
 
 ## Exporting documents
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -46,7 +46,7 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
             Dataset<Row> dataset = readDataset(session);
             if (commonParams.isCount()) {
                 logger.info("Count: {}", dataset.count());
-            } else if (commonParams.isPreviewRequested()) {
+            } else if (commonParams.getPreview().isPreviewRequested()) {
                 commonParams.getPreview().showPreview(dataset);
             } else {
                 applyWriter(session, dataset.write());

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -59,16 +59,8 @@ public class CommonParams {
         return dataset;
     }
 
-    public void setCount(boolean count) {
-        this.count = count;
-    }
-
     public boolean isCount() {
         return count;
-    }
-
-    public boolean isPreviewRequested() {
-        return preview != null && preview.getNumberRows() > 0;
     }
 
     public void setLimit(Integer limit) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -84,9 +84,6 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
     }
 
     private void validateWriteParams(CommandLine.ParseResult parseResult) {
-        if (parseResult.subcommand().hasMatchedOption("--preview")) {
-            return;
-        }
         String[] options = new String[]{
             "--write-invoke", "--write-javascript", "--write-xquery", "--write-javascript-file", "--write-xquery-file"
         };

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/PreviewTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/PreviewTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ */
+package com.marklogic.flux.impl;
+
+import com.marklogic.flux.AbstractTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PreviewTest extends AbstractTest {
+
+    @Test
+    void limitAndPreview() {
+        run(
+            "import-delimited-files",
+            "--path", "src/test/resources/delimited-files/three-rows.csv",
+            "--connection-string", makeConnectionString(),
+            "--limit", "1",
+            "--preview", "3",
+            "--preview-vertical",
+            "--collections", "sample"
+        );
+
+        // We have not had reliable success with capturing stdout and making assertions on it, so this just verifies
+        // that nothing is written.
+        assertCollectionSize("Verifying that nothing is written to the collection", "sample", 0);
+    }
+
+    @Test
+    void preview() {
+        run(
+            "import-files",
+            "--path", "src/test/resources/mixed-files",
+            "--preview", "2",
+            "--preview-drop", "content", "modificationTime",
+            "--preview-vertical",
+            "--collections", "sample"
+        );
+
+        assertCollectionSize("Verifying that nothing is written to the collection", "sample", 0);
+    }
+
+    @Test
+    void previewSchema(@TempDir Path tempDir) {
+        run(
+            "export-parquet",
+            "--path", tempDir.toFile().getAbsolutePath(),
+            "--connection-string", makeConnectionString(),
+            "--query", "op.fromView('Medical', 'Authors')",
+            "--preview-schema"
+        );
+
+        assertEquals(0, tempDir.toFile().listFiles().length,
+            "Verifying that nothing was exported since preview-schema was used, which should result in the Spark " +
+                "dataset schema being logged at the INFO level (which we're not yet able to assert on).");
+    }
+}

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -10,7 +10,6 @@ import com.marklogic.client.io.JacksonHandle;
 import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.flux.AbstractTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -125,29 +124,6 @@ class ImportDelimitedFilesTest extends AbstractTest {
         assertEquals(JsonNodeType.STRING, doc.get("number").getNodeType());
         assertEquals(JsonNodeType.STRING, doc.get("color").getNodeType());
         assertEquals(JsonNodeType.STRING, doc.get("flag").getNodeType());
-    }
-
-    /**
-     * We expect limit and preview to work for every command; this is just a simple sanity check
-     * for this command.
-     */
-    @Test
-    @Disabled("stdout isn't being captured correctly for this test, will debug soon.")
-    void limitAndPreview() {
-        String stdout = runAndReturnStdout(() -> {
-            run(
-                "import-delimited-files",
-                "--path", "src/test/resources/delimited-files/three-rows.csv",
-                "--connection-string", makeConnectionString(),
-                "--limit", "1",
-                "--preview", "3",
-                "--preview-vertical"
-            );
-        });
-
-        String message = "Unexpected stdout: " + stdout;
-        assertTrue(stdout.contains("number | 1"), message);
-        assertFalse(stdout.contains("number | 2"), message);
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -5,7 +5,6 @@ package com.marklogic.flux.impl.importdata;
 
 import com.marklogic.flux.AbstractTest;
 import com.marklogic.junit5.XmlNode;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.util.FileCopyUtils;
@@ -16,7 +15,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImportFilesTest extends AbstractTest {
 
@@ -84,30 +84,6 @@ class ImportFilesTest extends AbstractTest {
             .xquery("xdmp:node-kind(doc('/hello.xml.unknown')/node())")
             .evalAs(String.class);
         assertEquals("element", kind);
-    }
-
-    /**
-     * preview = show the first N rows from the reader, and don't invoke the writer.
-     */
-    @Test
-    @Disabled("Another stdout test that runs fine by itself, but fails when the suite is run.")
-    void preview() {
-        String stdout = runAndReturnStdout(() -> run(
-            "import-files",
-            "--path", "src/test/resources/mixed-files",
-            "--preview", "2",
-            "--preview-drop", "content", "modificationTime",
-            "--preview-vertical"
-        ));
-
-        String message = "Unexpected output to stdout: " + stdout;
-        assertTrue(stdout.contains("RECORD 0"), message);
-        assertTrue(stdout.contains("RECORD 1"), message);
-        assertFalse(stdout.contains("RECORD 2"), message);
-        assertTrue(stdout.contains("path"), message);
-        assertTrue(stdout.contains("length"), message);
-        assertFalse(stdout.contains("content"), message);
-        assertFalse(stdout.contains("modificationTime"), message);
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
@@ -93,8 +93,7 @@ class ImportJdbcTest extends AbstractTest {
             "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
             "--jdbc-driver", "not.valid.driver.value",
             "--connection-string", makeConnectionString(),
-            "--query", "select * from customer",
-            "--preview", "10"
+            "--query", "select * from customer"
         ), "Command failed, cause: Unable to load class: not.valid.driver.value; " +
             "for a JDBC driver, ensure you are specifying the fully-qualified class name for your JDBC driver.");
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -121,7 +121,6 @@ class ImportParquetFilesTest extends AbstractTest {
             run("import-parquet-files",
                 "--connection-string", makeConnectionString(),
                 "--path", "src/test/resources/parquet/individual/invalid.parquet",
-                "--preview", "10",
                 "--abort-on-read-failure"
             )
         );

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
@@ -38,20 +38,6 @@ class ReprocessTest extends AbstractTest {
     }
 
     @Test
-    void previewDoesntRequireWriteParam() {
-        String stdout = runAndReturnStdout(() -> run(
-            "reprocess",
-            "--connection-string", makeConnectionString(),
-            "--read-javascript", "cts.uris(null, null, cts.collectionQuery('author'))",
-            "--preview", "2"
-        ));
-
-        assertTrue(stdout.contains("only showing top 2 rows"),
-            "No 'write' param should be required when a user uses '--preview', as the user is specifically asking " +
-                "just to see the read data and not to write anything.");
-    }
-
-    @Test
     void missingReadParam() {
         String stderr = runAndReturnStderr(() -> run(
             "reprocess",


### PR DESCRIPTION
Moved the various "--preview" tests into one test class as well. Updated docs to mention this new feature, which seems particularly useful for `custom-export-rows`. 