### PR TITLE
Tweaks to generic and delimited import docs

### DIFF
--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -6,7 +6,7 @@ grand_parent: Importing Data
 nav_order: 3
 ---
 
-Flux can import rows from delimited text files, with each row being written as a document to MarkLogic.
+Flux can import rows from delimited text files, with each row being written as a JSON or XML document to MarkLogic.
 
 ## Table of contents
 {: .no_toc .text-delta }
@@ -16,31 +16,68 @@ Flux can import rows from delimited text files, with each row being written as a
 
 ## Usage
 
-The `import-delimited-files` command is used to read delimited text files. The command defaults to using a comma as
-the delimiter for each row value. You must specify at least one `--path` option along with connection information 
-for the MarkLogic database you wish to write to:
+The `import-delimited-files` command imports delimited text files specified via one or more occurrences of the 
+`--path` option:
 
-    ./bin/flux import-delimited-files --path /path/to/files --connection-string "user:password@localhost:8000"
+```
+./bin/flux import-delimited-files \
+    --path /path/to/files \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The command uses a comma as the default delimiter. You can override this via `--delimiter`:
+
+```
+./bin/flux import-delimited-files \
+    --path /path/to/files --delimiter ; \
+    --connection-string "user:password@localhost:8000" etc...
+```
 
 ## Specifying a JSON root name
 
-By default, each column found in a delimited text file will become a top-level field in the JSON document written to 
+By default, each column in a delimited text file will become a top-level field in a JSON document written to 
 MarkLogic. It is often useful to have a single "root" field in a JSON document so that it is more self-describing. It
 can help with indexing purposes in MarkLogic as well. To include a JSON root field, use the `--json-root-name` option with
 a value for the name of the root field. The data read from a row will then be nested under this root field.
 
+For example, including an option of `--json-root-name` will produce JSON documents with the following format:
+
+```
+{
+    "Customer": {
+        "field1": "value1",
+        etc...
+    }
+}
+```
+
 ## Creating XML documents
 
-To create XML documents for the rows in a delimited text file instead of JSON documents, include the `--xml-root-name`
+To create an XML document for each row in a delimited text file instead of a JSON document, include the `--xml-root-name`
 option to specify the name of the root element in each XML document. You can optionally include `--xml-namespace` to 
 specify a namespace for the root element that will then be inherited by every child element as well.
 
+For example, including `--xml-root-name Customer --xml-namespace "org:example"` in the options will produce XML 
+documents with the following format:
+
+```
+<Customer xmlns="org:example">
+    <field1>value1</field1>
+    etc...
+</Customer>
+```
+
 ## Specifying an encoding
 
-MarkLogic stores all data [in the UTF-8 encoding](https://docs.marklogic.com/guide/search-dev/encodings_collations#id_87576).
+MarkLogic stores all content [in the UTF-8 encoding](https://docs.marklogic.com/guide/search-dev/encodings_collations#id_87576).
 If your delimited text files use a different encoding, you must specify that via the `--encoding` option - e.g.:
 
-    ./bin/flux import-delimited-text-files --path source --encoding ISO-8859-1 ...
+```
+./bin/flux import-delimited-text-files \
+    --path source \
+    --encoding ISO-8859-1 \
+    etc...
+```
 
 ## Advanced options
 

--- a/docs/import/import-files/generic-files.md
+++ b/docs/import/import-files/generic-files.md
@@ -18,11 +18,16 @@ other than potentially decompressing the files.
 
 ## Usage
 
-The `import-files` command is used to import a set of files into MarkLogic, with each file being written as a separate
+The `import-files` command imports a set of files into MarkLogic, with each file being written as a separate
 document. You must specify at least one `--path` option along with connection information for the MarkLogic database
 you wish to write to. For example:
 
-    ./bin/flux import-files --path /path/to/files --connection-string user:password@localhost:8000
+```
+./bin/flux import-files \
+    --path /path/to/files \
+    --connection-string user:password@localhost:8000 \
+    --permissions rest-reader,read,rest-writer,update
+```
 
 ## Controlling document URIs
 
@@ -40,8 +45,8 @@ The value of this option must be one of `JSON`, `XML`, or `TEXT`.
 
 ## Specifying an encoding
 
-MarkLogic stores all data [in the UTF-8 encoding](https://docs.marklogic.com/guide/search-dev/encodings_collations#id_87576).
-If your files use a different encoding, you must specify that via the `--encoding` option - e.g.:
+MarkLogic stores all content [in the UTF-8 encoding](https://docs.marklogic.com/guide/search-dev/encodings_collations#id_87576).
+If your files use a different encoding, you must specify that via the `--encoding` option:
 
     ./bin/flux import-files --path source --encoding ISO-8859-1 ...
 

--- a/docs/import/import-files/selecting-files.md
+++ b/docs/import/import-files/selecting-files.md
@@ -18,7 +18,9 @@ of specifying paths are described below.
 ## Specifying paths
 
 The `--path` option controls where files are read from. You can specify multiple occurrences of `--path`, each with a 
-different value, to import files from many sources in a single command invocation. 
+different value, to import files from many sources in a single command invocation:
+
+    --path relative/path/to/files --path /absolute/path/to/files
 
 The value of the `--path` option can be any directory or file path. You can use wildcards in any part of the path. For
 example, the following, would select every file starting with `example` in any child directory of the root `/data`

--- a/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
@@ -20,6 +20,8 @@ public interface DelimitedFilesImporter extends Executor<DelimitedFilesImporter>
     DelimitedFilesImporter to(Consumer<WriteStructuredDocumentsOptions> consumer);
 
     interface ReadDelimitedFilesOptions extends ReadFilesOptions<ReadDelimitedFilesOptions> {
+        ReadDelimitedFilesOptions delimiter(String delimiter);
+
         ReadDelimitedFilesOptions additionalOptions(Map<String, String> options);
 
         ReadDelimitedFilesOptions groupBy(String columnName);

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -44,6 +44,9 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
 
     public static class ReadDelimitedFilesParams extends ReadFilesParams<ReadDelimitedFilesOptions> implements ReadDelimitedFilesOptions {
 
+        @CommandLine.Option(names = "--delimiter", description = "Specify a delimiter; defaults to a comma.")
+        private String delimiter;
+
         @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
 
@@ -62,11 +65,20 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
             Map<String, String> options = super.makeOptions();
             options.putIfAbsent("header", "true");
             options.putIfAbsent("inferSchema", "true");
+            if (delimiter != null) {
+                options.putIfAbsent("sep", delimiter);
+            }
             if (encoding != null) {
                 options.putIfAbsent("encoding", encoding);
             }
             options.putAll(additionalOptions);
             return options;
+        }
+
+        @Override
+        public ReadDelimitedFilesOptions delimiter(String delimiter) {
+            this.delimiter = delimiter;
+            return this;
         }
 
         @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -102,7 +102,10 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
         private DocumentType documentType;
 
         @Override
-        @CommandLine.Option(names = "--document-type", description = "Forces a type for any document with an unrecognized URI extension.")
+        @CommandLine.Option(
+            names = "--document-type",
+            description = "Forces a type for any document with an unrecognized URI extension. " + OptionsUtil.VALID_VALUES_DESCRIPTION
+        )
         public WriteGenericDocumentsOptions documentType(DocumentType documentType) {
             this.documentType = documentType;
             return this;

--- a/flux-cli/src/test/java/com/marklogic/flux/CopyrightTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/CopyrightTest.java
@@ -15,6 +15,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class CopyrightTest {
 
     /**
@@ -37,12 +39,11 @@ class CopyrightTest {
                     try (FileReader reader = new FileReader(file.toFile())) {
                         String content = FileCopyUtils.copyToString(reader);
                         String message = String.format("Does not start with copyright comment: %s", file.toFile().getAbsolutePath());
-                        if (!content.startsWith("/*")) {
-                            throw new RuntimeException(message);
-                        }
-                        if (!content.contains("Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.")) {
-                            throw new RuntimeException(message);
-                        }
+                        assertTrue(content.startsWith("/*"), message);
+                        assertTrue(
+                            content.contains("Copyright © 2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved."),
+                            message
+                        );
                     }
                 }
                 return FileVisitResult.CONTINUE;

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -70,6 +70,24 @@ class ImportDelimitedFilesTest extends AbstractTest {
         run(
             "import-delimited-files",
             "--path", "src/test/resources/delimited-files/semicolon-delimiter.csv",
+            "--delimiter", ";",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "delimited-test",
+            "--uri-template", "/delimited/{number}.json"
+        );
+
+        assertCollectionSize("delimited-test", 3);
+        verifyDoc("/delimited/1.json", 1, "blue", true);
+        verifyDoc("/delimited/2.json", 2, "red", false);
+        verifyDoc("/delimited/3.json", 3, "green", true);
+    }
+
+    @Test
+    void customDelimiterViaSparkOption() {
+        run(
+            "import-delimited-files",
+            "--path", "src/test/resources/delimited-files/semicolon-delimiter.csv",
             "-Psep=;",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,


### PR DESCRIPTION
Also added `--delimiter` as a first-class option as it felt awkward to require the user to do `-Psep`.
