### PR TITLE
Tweaking JSON import docs

### DIFF
--- a/docs/import/import-files/json.md
+++ b/docs/import/import-files/json.md
@@ -6,8 +6,10 @@ grand_parent: Importing Data
 nav_order: 4
 ---
 
-Flux can import JSON files - both files containing JSON objects and arrays and also files conforming to the 
-[JSON Lines format](https://jsonlines.org/).
+Flux provides special handling for JSON files that either conform to the
+[JSON Lines format](https://jsonlines.org/) or contain arrays of objects, where each object should become a separate 
+document in MarkLogic. If you wish to import JSON files as-is, you may find it simpler to 
+[import them as generic files](generic-files.md) instead. 
 
 ## Table of contents
 {: .no_toc .text-delta }
@@ -17,11 +19,9 @@ Flux can import JSON files - both files containing JSON objects and arrays and a
 
 ## Usage
 
-The `import-json-files` command reads JSON files and writes the contents of each file as one or more JSON
-documents in MarkLogic. If a file contains a single JSON object, it will be written as a single document to MarkLogic.
-If a file contains an array of JSON objects, each object will be written as a separate document to MarkLogic. To avoid
-this behavior for an array of JSON objects, use the `import-files` command instead which loads files without any 
-additional processing.
+The `import-json-files` command defaults to writing a single document to MarkLogic if a file contains a
+JSON object and writing multiple documents to MarkLogic if a file contains an array of JSON objects. If you would 
+rather a file with an array of object be written as a single document, use the `import-files` command instead.
 
 You must specify at least one `--path` option along with connection information for the MarkLogic database you wish to write to:
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJsonFilesCommand.java
@@ -13,7 +13,8 @@ import java.util.function.Consumer;
 
 @CommandLine.Command(
     name = "import-json-files",
-    description = "Read JSON files, including JSON Lines files, from local, HDFS, and S3 locations using Spark's support " +
+    description = "Read either JSON Lines files or files containing arrays of JSON objects from " +
+        "local, HDFS, and S3 locations using Spark's support " +
     "defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html, with each object being written " +
     "as a JSON document to MarkLogic."
 )


### PR DESCRIPTION
The naming here is tricky because regular JSON object files are handled by `import-files`, and this is for two different types of files that need special handling - JSON Lines and arrays of JSON objects, each of which produce multiple documents in MarkLogic. `import-json-files` doesn't quite capture that the intent is really more of "import special JSON files".
