### PR TITLE
Renamed preview-vertical to preview-list

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -138,7 +138,7 @@ you can preview an import without writing any of the data to MarkLogic:
 ```
 
 The number after `--preview` specifies how many records to show. You can use `--preview-drop` to specify potentially
-verbose columns to drop from the preview. And you can use `--preview-vertical` to see the results in a vertical display
+verbose columns to drop from the preview. And you can use `--preview-list` to see the results in a list
 instead of in a table:
 
 ```
@@ -147,7 +147,7 @@ instead of in a table:
     --path export/parquet \
     --preview 10 \
     --preview-drop job_title,department \
-    --preview-vertical
+    --preview-list
 ```
 
 Note that in the case of previewing an import, Flux will show the data as it has been read, which consists of a set of

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/Preview.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/Preview.java
@@ -18,8 +18,8 @@ public class Preview {
     @CommandLine.Option(names = "--preview-drop", description = "Specify one or more columns to drop when using --preview.", arity = "*")
     private List<String> columnsToDrop;
 
-    @CommandLine.Option(names = "--preview-vertical", description = "Preview the data in a vertical format instead of in a table.")
-    private boolean vertical;
+    @CommandLine.Option(names = "--preview-list", description = "Preview the data in a list instead of in a table.")
+    private boolean displayAsList;
 
     @CommandLine.Option(names = "--preview-schema", description = "Show the schema of the data read by the command.")
     private boolean showSchema;
@@ -34,7 +34,7 @@ public class Preview {
         }
         if (numberRows > 0) {
             // Not truncating at all. For now, users can drop columns if their values are too long.
-            datasetPreview.show(numberRows, Integer.MAX_VALUE, vertical);
+            datasetPreview.show(numberRows, Integer.MAX_VALUE, displayAsList);
         }
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/PreviewTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/PreviewTest.java
@@ -21,7 +21,7 @@ class PreviewTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--limit", "1",
             "--preview", "3",
-            "--preview-vertical",
+            "--preview-list",
             "--collections", "sample"
         );
 
@@ -37,7 +37,7 @@ class PreviewTest extends AbstractTest {
             "--path", "src/test/resources/mixed-files",
             "--preview", "2",
             "--preview-drop", "content", "modificationTime",
-            "--preview-vertical",
+            "--preview-list",
             "--collections", "sample"
         );
 


### PR DESCRIPTION
"list" seems more accurate - it's a list of each row. Also shorter.
