### PR TITLE
Can now configure how often progress is shown

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
@@ -55,6 +55,8 @@ public interface Reprocessor extends Executor<Reprocessor> {
         WriteOptions abortOnWriteFailure(Boolean value);
 
         WriteOptions batchSize(Integer batchSize);
+
+        WriteOptions logProgress(Integer numberOfItems);
     }
 
     Reprocessor from(Consumer<ReadOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
@@ -15,6 +15,8 @@ public interface WriteDocumentsOptions<T extends WriteDocumentsOptions> {
 
     T failedDocumentsPath(String path);
 
+    T logProgress(Integer numberOfDocuments);
+
     T permissionsString(String rolesAndCapabilities);
 
     T temporalCollection(String temporalCollection);

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -79,6 +79,12 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         private String failedDocumentsPath;
 
         @CommandLine.Option(
+            names = "--log-progress",
+            description = "Log a count of documents written every time this many documents are written."
+        )
+        private Integer logProgress;
+
+        @CommandLine.Option(
             names = "--output-permissions",
             description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to each document - e.g. role1,read,role2,update,role3,execute."
         )
@@ -153,6 +159,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
                 Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
                 Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
                 Options.WRITE_COLLECTIONS, collections,
+                Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null,
                 Options.WRITE_PERMISSIONS, permissions,
                 Options.WRITE_TEMPORAL_COLLECTION, temporalCollection,
                 Options.WRITE_THREAD_COUNT, threadCount != null ? threadCount.toString() : null,
@@ -194,6 +201,12 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         @Override
         public CopyWriteDocumentsParams failedDocumentsPath(String path) {
             this.failedDocumentsPath = path;
+            return this;
+        }
+
+        @Override
+        public CopyWriteDocumentsParams logProgress(Integer numberOfDocuments) {
+            this.logProgress = numberOfDocuments;
             return this;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
@@ -45,6 +45,12 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     private String failedDocumentsPath;
 
     @CommandLine.Option(
+        names = "--log-progress",
+        description = "Log a count of documents written every time this many documents are written."
+    )
+    private Integer logProgress;
+
+    @CommandLine.Option(
         names = "--permissions",
         description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to each document - e.g. role1,read,role2,update,role3,execute."
     )
@@ -120,6 +126,7 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
             Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
             Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
             Options.WRITE_COLLECTIONS, collections,
+            Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null,
             Options.WRITE_PERMISSIONS, permissions,
             Options.WRITE_TEMPORAL_COLLECTION, temporalCollection,
             Options.WRITE_THREAD_COUNT, threadCount != null ? threadCount.toString() : null,
@@ -166,6 +173,12 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     @Override
     public T failedDocumentsPath(String path) {
         this.failedDocumentsPath = path;
+        return (T) this;
+    }
+
+    @Override
+    public T logProgress(Integer numberOfDocuments) {
+        this.logProgress = numberOfDocuments;
         return (T) this;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -353,6 +353,12 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
         )
         private Integer batchSize = 1;
 
+        @CommandLine.Option(
+            names = "--log-progress",
+            description = "Log a count of items processed every time this many items are processed."
+        )
+        private Integer logProgress;
+
         public void validateWriter() {
             Map<String, String> options = get();
             if (Stream.of(Options.WRITE_INVOKE, Options.WRITE_JAVASCRIPT, Options.WRITE_JAVASCRIPT_FILE,
@@ -372,7 +378,8 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
                 Options.WRITE_EXTERNAL_VARIABLE_NAME, externalVariableName,
                 Options.WRITE_EXTERNAL_VARIABLE_DELIMITER, externalVariableDelimiter,
                 Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure != null ? Boolean.toString(abortOnWriteFailure) : "false",
-                Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null
+                Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
+                Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null
             );
 
             if (writeVars != null) {
@@ -447,6 +454,12 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
         @Override
         public WriteOptions batchSize(Integer batchSize) {
             this.batchSize = batchSize;
+            return this;
+        }
+
+        @Override
+        public WriteOptions logProgress(Integer numberOfItems) {
+            this.logProgress = numberOfItems;
             return this;
         }
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/api/DocumentCopierTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/DocumentCopierTest.java
@@ -18,6 +18,8 @@ class DocumentCopierTest extends AbstractTest {
             .to(options -> options
                 .collections("author-copies")
                 .uriPrefix("/copied")
+                .batchSize(5)
+                .logProgress(5)
                 .permissionsString(DEFAULT_PERMISSIONS))
             .execute();
 

--- a/flux-cli/src/test/java/com/marklogic/flux/api/ParquetFilesImporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/ParquetFilesImporterTest.java
@@ -23,7 +23,9 @@ class ParquetFilesImporterTest extends AbstractTest {
             .to(options -> options
                 .permissionsString(DEFAULT_PERMISSIONS)
                 .collections("parquet-test")
-                .uriTemplate("/parquet/{color}.json"))
+                .uriTemplate("/parquet/{color}.json")
+                .batchSize(3)
+                .logProgress(6))
             .execute();
 
         assertCollectionSize("parquet-test", 6);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
@@ -170,6 +170,10 @@ class CopyOptionsTest extends AbstractOptionsTest {
                 count++;
             }
         }
+        // Add 1 to account for "--log-progress", which does not have the "output" prefix but is still treated as a
+        // "write" param. It does not have "output" prefixed to it since it is considered a "common" option that isn't
+        // yet supported for Export commands.
+        count++;
         return count;
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -22,7 +22,11 @@ class CopyTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--output-collections", "author-copies",
             "--output-uri-prefix", "/copied",
-            "--output-permissions", DEFAULT_PERMISSIONS
+            "--output-permissions", DEFAULT_PERMISSIONS,
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "5",
+            "--log-progress", "5"
         );
 
         assertCollectionSize("author", 15);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
@@ -93,7 +93,11 @@ class ImportAggregateJsonFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-json-test",
-            "--uri-template", "/delimited/{lastName}.json"
+            "--uri-template", "/delimited/{lastName}.json",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         assertCollectionSize("delimited-json-test", 3);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
@@ -44,7 +44,11 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "withElement-test",
-            "--uri-replace", ".*/xml-file,''"
+            "--uri-replace", ".*/xml-file,''",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         assertCollectionSize("withElement-test", 3);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesTest.java
@@ -21,7 +21,11 @@ class ImportArchiveFilesTest extends AbstractTest {
             "import-archive-files",
             "--path", "src/test/resources/archive-files",
             "--uri-replace", ".*archive.zip,''",
-            "--connection-string", makeConnectionString()
+            "--connection-string", makeConnectionString(),
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -21,7 +21,11 @@ class ImportAvroFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "avro-test",
-            "--uri-template", "/avro/{color}.json"
+            "--uri-template", "/avro/{color}.json",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         assertCollectionSize("avro-test", 6);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -24,7 +24,11 @@ class ImportDelimitedFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "delimited-test",
-            "--uri-template", "/delimited/{number}.json"
+            "--uri-template", "/delimited/{number}.json",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         assertCollectionSize("delimited-test", 3);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -32,7 +32,11 @@ class ImportFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "files",
-            "--uri-replace", ".*/mixed-files,''"
+            "--uri-replace", ".*/mixed-files,''",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         verifyDocsWereWritten(uris.length, uris);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
@@ -26,7 +26,11 @@ class ImportJdbcTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--uri-template", "/customer/{customer_id}.json",
-            "--collections", "customer"
+            "--collections", "customer",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "2",
+            "--log-progress", "4"
         );
 
         verifyTenCustomersWereImported();

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesTest.java
@@ -21,7 +21,11 @@ class ImportMlcpArchiveFilesTest extends AbstractTest {
         run(
             "import-mlcp-archive-files",
             "--path", "src/test/resources/mlcp-archives",
-            "--connection-string", makeConnectionString()
+            "--connection-string", makeConnectionString(),
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "2"
         );
 
         for (String uri : getUrisInCollection("collection1", 2)) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
@@ -21,7 +21,11 @@ class ImportOrcFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "orcFile-test",
-            "--uri-template", "/orc-test/{LastName}.json"
+            "--uri-template", "/orc-test/{LastName}.json",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "5",
+            "--log-progress", "5"
         );
 
         getUrisInCollection("orcFile-test", 15).forEach(this::verifyDocContent);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -21,7 +21,12 @@ class ImportParquetFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
             "--collections", "parquet-test",
-            "--uri-template", "/parquet/{model}.json"
+            "--total-thread-count", "1",
+            "--uri-template", "/parquet/{model}.json",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "5",
+            "--log-progress", "10"
         );
 
         assertCollectionSize("parquet-test", 32);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
@@ -19,7 +19,11 @@ class ImportRdfFilesTest extends AbstractTest {
             "--path", "src/test/resources/rdf/englishlocale.ttl",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
-            "--collections", "my-triples"
+            "--collections", "my-triples",
+
+            // Including these for manual verification of progress logging.
+            "--batch-size", "1",
+            "--log-progress", "1"
         );
 
         assertCollectionSize(

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
@@ -37,6 +37,24 @@ class ReprocessTest extends AbstractTest {
         }
     }
 
+    /**
+     * This is used primarily for manual inspection of the progress messages. We don't yet have a reliable way of
+     * asserting on log messages, so using manual inspection for now.
+     */
+    @Test
+    void logProgressTest() {
+        run(
+            "reprocess",
+            "--connection-string", makeConnectionString(),
+            "--read-xquery", "for $i in 1 to 100 return $i",
+            "--write-invoke", "/writeDocument.sjs",
+            "--write-var", "theValue=my value",
+            "--log-progress", "10"
+        );
+
+        assertCollectionSize("reprocess-test", 100);
+    }
+
     @Test
     void missingReadParam() {
         String stderr = runAndReturnStderr(() -> run(


### PR DESCRIPTION
Works for import, copy, and reprocess. Not yet supported for Export as for most export commands, we don't have control over the data source to know when stuff has been written. 