### PR TITLE
Can now include URI in file path

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
@@ -22,6 +22,8 @@ public interface AggregateJsonFilesImporter extends Executor<AggregateJsonFilesI
 
         ReadJsonFilesOptions encoding(String encoding);
 
+        ReadJsonFilesOptions uriIncludeFilePath(boolean value);
+
         ReadJsonFilesOptions additionalOptions(Map<String, String> additionalOptions);
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
@@ -29,5 +29,7 @@ public interface DelimitedFilesImporter extends Executor<DelimitedFilesImporter>
         ReadDelimitedFilesOptions aggregateColumns(String newColumnName, String... columns);
 
         ReadDelimitedFilesOptions encoding(String encoding);
+
+        ReadDelimitedFilesOptions uriIncludeFilePath(boolean value);
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadTabularFilesOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadTabularFilesOptions.java
@@ -16,4 +16,6 @@ public interface ReadTabularFilesOptions extends ReadFilesOptions<ReadTabularFil
     ReadTabularFilesOptions groupBy(String columnName);
 
     ReadTabularFilesOptions aggregateColumns(String newColumnName, String... columns);
+
+    ReadTabularFilesOptions uriIncludeFilePath(boolean value);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
@@ -4,6 +4,9 @@
 package com.marklogic.flux.impl;
 
 import com.marklogic.flux.api.SaveMode;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
 public class SparkUtil {
@@ -44,5 +47,13 @@ public class SparkUtil {
             return org.apache.spark.sql.SaveMode.Overwrite;
         }
         return null;
+    }
+
+    public static Dataset<Row> addFilePathColumn(Dataset<Row> dataset) {
+        // The MarkLogic Spark connector has special processing for this column. If it's found by the writer, the
+        // value of this column will be used to construct an initial URI for the associated document. The column
+        // will then have its value set to null so that the value is not included in the JSON or XML
+        // serialization of the row.
+        return dataset.withColumn("marklogic_spark_file_path", new Column("_metadata.file_path"));
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -6,6 +6,7 @@ package com.marklogic.flux.impl.importdata;
 import com.marklogic.flux.api.AvroFilesImporter;
 import com.marklogic.flux.api.ReadTabularFilesOptions;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
+import com.marklogic.flux.impl.SparkUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -46,6 +47,12 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
     public static class ReadAvroFilesParams extends ReadFilesParams<ReadTabularFilesOptions> implements ReadTabularFilesOptions {
 
         @CommandLine.Option(
+            names = "--uri-include-file-path",
+            description = "If true, each document URI will include the path of the originating file."
+        )
+        private boolean uriIncludeFilePath;
+
+        @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark Avro data source option defined at " +
                 "%nhttps://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true. " +
@@ -80,10 +87,19 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
             aggregationParams.addAggregationExpression(newColumnName, columns);
             return this;
         }
+
+        @Override
+        public ReadTabularFilesOptions uriIncludeFilePath(boolean value) {
+            this.uriIncludeFilePath = value;
+            return this;
+        }
     }
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
+        if (readParams.uriIncludeFilePath) {
+            dataset = SparkUtil.addFilePathColumn(dataset);
+        }
         return readParams.aggregationParams.applyGroupBy(dataset);
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -6,6 +6,7 @@ package com.marklogic.flux.impl.importdata;
 import com.marklogic.flux.api.OrcFilesImporter;
 import com.marklogic.flux.api.ReadTabularFilesOptions;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
+import com.marklogic.flux.impl.SparkUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -46,6 +47,12 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
     public static class ReadOrcFilesParams extends ReadFilesParams<ReadTabularFilesOptions> implements ReadTabularFilesOptions {
 
         @CommandLine.Option(
+            names = "--uri-include-file-path",
+            description = "If true, each document URI will include the path of the originating file."
+        )
+        private boolean uriIncludeFilePath;
+
+        @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark ORC data source option defined at " +
                 "%nhttps://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -PmergeSchema=true. " +
@@ -80,10 +87,19 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
             aggregationParams.addAggregationExpression(newColumnName, columns);
             return this;
         }
+
+        @Override
+        public ReadTabularFilesOptions uriIncludeFilePath(boolean value) {
+            this.uriIncludeFilePath = value;
+            return this;
+        }
     }
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
+        if (readParams.uriIncludeFilePath) {
+            dataset = SparkUtil.addFilePathColumn(dataset);
+        }
         return readParams.aggregationParams.applyGroupBy(dataset);
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
@@ -48,6 +48,24 @@ class ImportAggregateJsonFilesTest extends AbstractTest {
     }
 
     @Test
+    void uriIncludeFilePath() {
+        run(
+            "import-aggregate-json-files",
+            "--path", "src/test/resources/json-files/array-of-objects.json",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "array-objects",
+            "--uri-include-file-path",
+            "--uri-replace", ".*resources,''"
+        );
+
+        getUrisInCollection("array-objects", 2).forEach(uri -> {
+            assertTrue(uri.startsWith("/json-files/array-of-objects.json/"), "Actual URI: " + uri);
+            assertTrue(uri.endsWith(".json"), "Actual URI: " + uri);
+        });
+    }
+
+    @Test
     void arrayOfObjects() {
         run(
             "import-aggregate-json-files",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -38,6 +38,25 @@ class ImportAvroFilesTest extends AbstractTest {
     }
 
     @Test
+    void uriIncludeFilePath() {
+        run(
+            "import-avro-files",
+            "--path", "src/test/resources/avro/colors.avro",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--xml-root-name", "myAvroData",
+            "--collections", "avro-test",
+            "--uri-include-file-path",
+            "--uri-replace", ".*/resources,''"
+        );
+
+        getUrisInCollection("avro-test", 3).forEach(uri -> {
+            assertTrue(uri.startsWith("/avro/colors.avro/"), "Actual URI: " + uri);
+            assertTrue(uri.endsWith(".xml"), "Actual URI: " + uri);
+        });
+    }
+
+    @Test
     void jsonRootName() {
         run(
             "import-avro-files",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -38,6 +38,28 @@ class ImportDelimitedFilesTest extends AbstractTest {
     }
 
     @Test
+    void useFilePathInUri() {
+        run(
+            "import-delimited-files",
+            "--path", "src/test/resources/delimited-files/three-rows.csv",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "delimited-test",
+            "--uri-include-file-path",
+            "--uri-replace", ".*resources,''"
+        );
+
+        getUrisInCollection("delimited-test", 3).forEach(uri -> {
+            assertTrue(uri.startsWith("/delimited-files/three-rows.csv/"),
+                "--uri-include-file-path should tell Flux to add a column named 'marklogic_spark_file_path' that " +
+                    "contains the Spark-determined file path from which a row originates. It should then be " +
+                    "prepended onto the initial URI for a row, followed by a UUID to guarantee uniqueness. " +
+                    "Actual URI: " + uri);
+            assertTrue(uri.endsWith(".json"), "Actual URI: " + uri);
+        });
+    }
+
+    @Test
     void jsonRootName() {
         run(
             "import-delimited-files",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
@@ -32,6 +32,24 @@ class ImportOrcFilesTest extends AbstractTest {
     }
 
     @Test
+    void uriIncludeFilePath() {
+        run(
+            "import-orc-files",
+            "--path", "src/test/resources/orc-files/authors.orc",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "orcFile-test",
+            "--uri-include-file-path",
+            "--uri-replace", ".*resources,''"
+        );
+
+        getUrisInCollection("orcFile-test", 15).forEach(uri -> {
+            assertTrue(uri.startsWith("/orc-files/authors.orc/"), "Actual URI: " + uri);
+            assertTrue(uri.endsWith(".json"), "Actual URI: " + uri);
+        });
+    }
+
+    @Test
     void aggregate() {
         run(
             "import-orc-files",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -36,6 +36,24 @@ class ImportParquetFilesTest extends AbstractTest {
     }
 
     @Test
+    void uriIncludeFilePath() {
+        run(
+            "import-parquet-files",
+            "--path", "src/test/resources/parquet/individual/cars.parquet",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "parquet-test",
+            "--uri-include-file-path",
+            "--uri-replace", ".*/individual,''"
+        );
+
+        getUrisInCollection("parquet-test", 32).forEach(uri -> {
+            assertTrue(uri.startsWith("/cars.parquet/"), "Actual URI: " + uri);
+            assertTrue(uri.endsWith(".json"), "Actual URI: " + uri);
+        });
+    }
+
+    @Test
     void aggregate() {
         run(
             "import-parquet-files",


### PR DESCRIPTION
This is for the 5 commands that use Spark data sources and thus don't include the file path automatically. Will add docs for this next, along with `--log-progress`. 