### PR TITLE
More docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,8 +273,12 @@ to something you can access :
 ```
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
 --packages org.apache.hadoop:hadoop-aws:3.3.6,org.apache.hadoop:hadoop-client:3.3.6 \
---master spark://NYWHYC3G0W:7077 flux-cli/build/libs/flux-cli-0.1-SNAPSHOT-all.jar \
-import-files --path "s3a://changeme/*.*" --preview 10 --preview-drop content
+--master spark://NYWHYC3G0W:7077 \
+flux-cli/build/libs/flux-1.0-SNAPSHOT-all.jar \
+import-files --path "s3a://changeme/" \
+--connection-string "admin:admin@localhost:8000" \
+--s3-add-credentials \
+--preview 10 --preview-drop content
 ```
 
 ### Testing with AWS EMR

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,31 +16,32 @@ This guide describes how to get started with Flux with some examples demonstrati
 
 The examples in this guide, along with examples found throughout this documentation, depend on a small application in the 
 `./examples/getting-started` directory in this repository. The examples assume that the application will be deployed to 
-a MarkLogic instance and that Flux will be run from the `./examples/getting-started` directory as well. However, you are 
+a MarkLogic instance and that Flux will be run from the `./examples/getting-started/flux` directory as well. However, you are 
 free to install Flux anywhere and use the examples as a reference for running Flux on your own data. 
 
 ### Obtaining Flux
 
-Flux can either be downloaded from [its GitHub releases page](https://github.com/marklogic/flux/releases), 
-from the [internal Wiki](https://wiki.marklogic.com/display/PM/Spark+ETL+0.1+Release), or built locally. 
-If you wish to build it locally, please see the `CONTRIBUTING.md` file in this repository for instructions.
+If you would like to use Flux to run the examples below, 
+follow these steps:
 
-After downloading or building Flux, extract it into the `./examples/getting-started` directory in this repository to 
-test it with the examples. 
+1. Download the `flux-1.0.0.zip` file from the [GitHub releases page](https://github.com/marklogic/flux/releases/tag/1.0.0).
+2. Clone this repository using git. 
+3. Extract the `flux-1.0.0.zip` file into the `./examples/getting-started` directory in the cloned repository directory.
+This should result in an `./examples/getting-started/flux` directory that contains the Flux software.
 
 ### Deploying the example application
 
 Follow these steps to run the examples in this guide:
 
-1. Clone this repository if you have not already.
-2. `cd examples/getting-started`
+1. Clone this repository using git if you have not already.
+2. Run `cd examples/getting-started`.
 3. Create the file `gradle-local.properties` and add `mlPassword=your admin user password` to it.
 4. Change `mlHost` and `mlRestPort` as needed based on your MarkLogic installation.
 5. Run `./gradlew -i mlDeploy` to deploy the example application.
 
-This will create a new REST API app server on port 8004 in your local MarkLogic installation, unless you modified the
-values of `mlHost` and `mlRestPort`. It also creates a "flux-example-user" MarkLogic user that has the necessary MarkLogic roles
-and privileges for running the examples in this guide. Finally, the application includes a 
+The example application consists of a REST API app server on port 8004 in your MarkLogic installation, unless you modified the
+values of `mlHost` and `mlRestPort`. The application also includes a "flux-example-user" MarkLogic user that has the 
+necessary MarkLogic roles and privileges for running the examples in this guide. Finally, the application includes a 
 [MarkLogic TDE template](https://docs.marklogic.com/guide/app-dev/TDE) that creates a view in MarkLogic for the purpose
 of demonstrating commands that utilize a [MarkLogic Optic query](https://docs.marklogic.com/guide/app-dev/OpticAPI).
 

--- a/docs/import/common-import-features.md
+++ b/docs/import/common-import-features.md
@@ -105,6 +105,13 @@ The following shows an example of each option:
 --temporal-collection my-temporal-data
 ```
 
+## Logging progress
+
+Flux will log a message at the `INFO` level stating how many documents it has written as a form of showing progress. 
+It defaults to logging this message every time approximately 10,000 documents are written. You can adjust this value by 
+using the `--log-progress` option. For example, for more frequent logging, you could include `--log-progress 1000` to 
+configure Flux to log a message every time it writes 1,000 documents.
+
 ## Transforming content
 
 For each import command, you can apply a [MarkLogic REST transform](https://docs.marklogic.com/guide/rest-dev/transforms)

--- a/docs/import/handling-errors.md
+++ b/docs/import/handling-errors.md
@@ -1,9 +1,8 @@
 ---
 layout: default
 title: Handling errors
-parent: Importing files
-grand_parent: Importing Data
-nav_order: 10
+parent: Importing Data
+nav_order: 7
 ---
 
 ## Table of contents

--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -26,6 +26,10 @@ MarkLogic database you wish to write to:
     --connection-string "user:password@localhost:8000"
 ```
 
+The URI of each document will default to a UUID followed by `.json`. To include the file path at the start of the URI,
+include the `--uri-include-file-path` option. You can also make use of the
+[common import features](../common-import-features.md) for controlling document URIs.
+
 ## Specifying a JSON root name
 
 By default, each column in an Avro file will become a top-level field in the JSON document written to

--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -33,6 +33,10 @@ The command uses a comma as the default delimiter. You can override this via `--
     --connection-string "user:password@localhost:8000" etc...
 ```
 
+The URI of each document will default to a UUID followed by `.json`. To include the file path at the start of the URI,
+include the `--uri-include-file-path` option. You can also make use of the
+[common import features](../common-import-features.md) for controlling document URIs.
+
 ## Specifying a JSON root name
 
 By default, each column in a delimited text file will become a top-level field in a JSON document written to 

--- a/docs/import/import-files/json.md
+++ b/docs/import/import-files/json.md
@@ -31,6 +31,10 @@ you wish to write to:
     --connection-string "user:password@localhost:8000"
 ```
 
+The URI of each document will default to a UUID followed by `.json`. To include the file path at the start of the URI,
+include the `--uri-include-file-path` option. You can also make use of the
+[common import features](../common-import-features.md) for controlling document URIs.
+
 ## Importing JSON Lines files
 
 If your files conform to the [JSON Lines format](https://jsonlines.org/), 

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -26,6 +26,10 @@ MarkLogic database you wish to write to:
     --connection-string "user:password@localhost:8000"
 ```
 
+The URI of each document will default to a UUID followed by `.json`. To include the file path at the start of the URI,
+include the `--uri-include-file-path` option. You can also make use of the
+[common import features](../common-import-features.md) for controlling document URIs.
+
 ## Specifying a JSON root name
 
 By default, each column in an ORC file will become a top-level field in the JSON document written to

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -26,6 +26,10 @@ MarkLogic database you wish to write to:
     --connection-string "user:password@localhost:8000"
 ```
 
+The URI of each document will default to a UUID followed by `.json`. To include the file path at the start of the URI,
+include the `--uri-include-file-path` option. You can also make use of the 
+[common import features](../common-import-features.md) for controlling document URIs.
+
 ## Specifying a JSON root name
 
 By default, each column in a Parquet file will become a top-level field in the JSON document written to

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,4 +25,8 @@ Flux has the following system requirements:
 Earlier versions of MarkLogic 9 and 10 will support any features not involving Optic queries.
 Additionally, the latest version of MarkLogic 11 is recommended if possible.
 
+Flux is built on top of [Apache Spark](https://spark.apache.org/), but you do not need to know anything about Spark
+to use Flux. If you are already making use of Spark for other use cases, see the 
+[Spark Integration guide](spark-integration.md) for information on using Flux with your existing Spark cluster.
+
 Please see the [Getting Started guide](getting-started.md) to begin using Flux.  

--- a/docs/reprocess.md
+++ b/docs/reprocess.md
@@ -101,3 +101,10 @@ In the above example, the code defined by `--read-javascript` will be invoked on
 defined by `--read-partitions-javascript`. The value of `PARTITION` - a forest ID - is then passed to the 
 [cts.uris](https://docs.marklogic.com/cts.uris) function to constrain it to a particular forest. With this approach, 
 the query is broken up into N queries that run in parallel, with N equalling the number of forests in the database.
+
+## Logging progress
+
+Flux will log a message at the `INFO` level stating how many items it has processed as a form of showing progress.
+It defaults to logging this message every time 10,000 items are processed. You can adjust this value by using
+the `--log-progress` option. For example, for more frequent logging, you could include `--log-progress 1000` to
+configure Flux to log a message every time it processes 1,000 items.

--- a/docs/spark-integration.md
+++ b/docs/spark-integration.md
@@ -1,0 +1,74 @@
+---
+layout: default
+title: Spark Integration
+nav_order: 8
+---
+
+Flux can be used with an existing [Apache Spark](https://spark.apache.org/) cluster to support large workloads that
+require more system resources than what are available when running Flux as a command line application. 
+
+## Table of contents
+{: .no_toc .text-delta }
+
+- TOC
+{:toc}
+
+## Submitting Flux commands
+
+Flux integrates with [spark-submit](https://spark.apache.org/docs/latest/submitting-applications.html) to allow you to 
+submit a Flux command invocation to a remote Spark cluster. Every Flux command is a Spark application, and thus every
+Flux command, along with all of its option, can be invoked via `spark-submit`. 
+
+To use Flux with `spark-submit`, first download the `flux-1.0.0-all.jar` file from the 
+[GitHub release page](https://github.com/marklogic/flux/releases/tag/1.0.0). This jar file includes Flux and all of 
+its dependencies, excluding those of Spark itself, which will be provided via the Spark cluster that you connect to 
+via `spark-submit`. 
+
+You can now run any Flux command with `spark-submit`.  
+The following shows a notional example of running the Flux `import-files` command:
+
+```
+$SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
+    --master spark://changeme:7077 \
+    flux-1.0.0-all.jar \
+    import-files \
+    --path path/to/data
+    --connection-string user:password@host:8000
+    --preview 10
+```
+
+Key points on the above example:
+
+1. You must provide a value of `com.marklogic.flux.spark.Submit` for the required `--class` option. This class 
+provides the entry point that allows for a Flux command to be run.
+2. Set the value of `--master` to the master URL of your Spark cluster.
+3. As noted in the [Spark documentation](https://spark.apache.org/docs/latest/submitting-applications.html), the path
+to the Flux jar - the "application jar" - must be globally visible inside your cluster.
+4. The "application arguments" consist of the name of the Flux command and the options you provide to that command. 
+
+
+### Accessing S3 with spark-submit
+
+If you wish to run a Flux command that accesses an S3 path, you must use the `--packages` option with `spark-submit`
+to include the necessary dependencies to allow for Spark to access S3, as shown below:
+
+    --packages org.apache.hadoop:hadoop-aws:3.3.6,org.apache.hadoop:hadoop-client:3.3.6
+
+The above packages are not included in the Flux jar file, as the version required by your Spark cluster may differ. 
+
+### Using Avro data with spark-submit
+
+Per the [Spark Avro documentation](https://spark.apache.org/docs/latest/sql-data-sources-avro.html), the `spark-avro`
+dependency is not included in Spark by default. If you wish to run either `import-avro-files` or `export-avro-files`
+with Flux and `spark-submit`, you must include the following line in your `spark-submit` invocation:
+
+    --packages org.apache.spark:spark-avro_2.12:3.4.1
+
+You should change the version number of this dependency to match that of your Spark cluster.
+
+## Configuring Spark for local usage
+
+When Flux is run via the command line, it creates a temporary local Spark cluster with a Spark master URL of 
+`local[*]`. You can adjust this via the `--spark-master-url` option. Typically, this will involve still creating a 
+local Spark cluster but with different settings. If you wish to connect to a remote Spark cluster, you will most likely
+want to use `spark-submit` as described above. 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -38,7 +38,7 @@ public class CommonParams {
     // Hidden for now since showing it for every command in its "help" seems confusing for most users that will likely
     // never need to know about this.
     @CommandLine.Option(
-        names = "--master-url",
+        names = "--spark-master-url",
         description = "Specify the Spark master URL for configuring the local Spark cluster created by Flux."
     )
     private String sparkMasterUrl = "local[*]";

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ConfigureSparkMasterUrlTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ConfigureSparkMasterUrlTest.java
@@ -26,7 +26,7 @@ class ConfigureSparkMasterUrlTest extends AbstractTest {
     void validMasterUrl() {
         run(
             "import-parquet-files",
-            "--master-url", "local[2]",
+            "--spark-master-url", "local[2]",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
@@ -41,7 +41,7 @@ class ConfigureSparkMasterUrlTest extends AbstractTest {
     void invalidMasterUrl() {
         run(
             "import-parquet-files",
-            "--master-url", "just-not-valid-at-all",
+            "--spark-master-url", "just-not-valid-at-all",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS
@@ -49,7 +49,7 @@ class ConfigureSparkMasterUrlTest extends AbstractTest {
 
         assertStderrContains(() -> run(
             "import-parquet-files",
-            "--master-url", "just-not-valid-at-all",
+            "--spark-master-url", "just-not-valid-at-all",
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS


### PR DESCRIPTION
1. --log-progress
2. --uri-include-file-path
3. Cleaning up the index page.
4. Added docs for using spark-submit.
5. Renamed `--master-url` to `--spark-master-url` to make it more obvious as to what it's for.
