### PR TITLE
Changing Hadoop/AWS version based on spark-submit testing

### DIFF
--- a/docs/spark-integration.md
+++ b/docs/spark-integration.md
@@ -52,9 +52,9 @@ to the Flux jar - the "application jar" - must be globally visible inside your c
 If you wish to run a Flux command that accesses an S3 path, you must use the `--packages` option with `spark-submit`
 to include the necessary dependencies to allow for Spark to access S3, as shown below:
 
-    --packages org.apache.hadoop:hadoop-aws:3.3.6,org.apache.hadoop:hadoop-client:3.3.6
+    --packages org.apache.hadoop:hadoop-aws:3.3.4,org.apache.hadoop:hadoop-client:3.3.4
 
-The above packages are not included in the Flux jar file, as the version required by your Spark cluster may differ. 
+The above packages are not included in the Flux jar file, as the version required by your Spark cluster may differ.
 
 ### Using Avro data with spark-submit
 

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -21,14 +21,17 @@ dependencies {
   implementation "com.marklogic:marklogic-spark-connector:2.2-SNAPSHOT"
   implementation "info.picocli:picocli:4.7.6"
 
-  // hadoop-aws depends on aws-java-sdk-bundle, which clocks in as a single 380mb jar. We only need the S3 portion of
-  // the AWS SDK, so the bundle is excluded in favor of the S3 API in the SDK.
-  implementation("org.apache.hadoop:hadoop-aws:3.3.6") {
+  // Spark 3.4.1 depends on Hadoop 3.3.4, which depends on AWS SDK 1.12.262.
+  // We don't include the entire aws-java-sdk-bundle, as that clocks in as a single 380mb jar. We only need the S3
+  // portion of the AWS SDK. However, in version 1.12.262, the dynamodb SDK is also needed; otherwise, a
+  // NoClassDefFoundError occurs.
+  implementation("org.apache.hadoop:hadoop-aws:3.3.4") {
     exclude module: "aws-java-sdk-bundle"
   }
-  implementation "com.amazonaws:aws-java-sdk-s3:1.12.367"
+  implementation "com.amazonaws:aws-java-sdk-s3:1.12.262"
+  implementation "com.amazonaws:aws-java-sdk-dynamodb:1.12.262"
 
-  implementation "org.apache.hadoop:hadoop-client:3.3.6"
+  implementation "org.apache.hadoop:hadoop-client:3.3.4"
 
   // Spark doesn't include Avro support by default, so need to bring this in.
   implementation "org.apache.spark:spark-avro_2.12:3.4.1"

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFromS3Test.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFromS3Test.java
@@ -15,18 +15,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * ensure that your AWS credentials are set up locally and correctly. This is not an actual test as we don't yet have a
  * way for Jenkins to authenticate with an S3 bucket.
  */
+@Disabled("Only intended for ad hoc testing by using explicit S3 auth values.")
 class ImportFromS3Test extends AbstractTest {
 
-    @Disabled("Only intended for ad hoc testing.")
+    private final static String PATH = "s3a://changeme/";
+
     @Test
     void test() {
-        final String path = "s3a://changeme";
-
         String stdout = runAndReturnStdout(() -> run(
             "import-files",
-            "--path", path,
+            "--path", PATH,
             "--preview", "10",
             "--preview-drop", "content", "modificationTime",
+            "--connection-string", makeConnectionString(),
             "--s3-add-credentials"
         ));
 
@@ -34,14 +35,26 @@ class ImportFromS3Test extends AbstractTest {
         logger.info("Results: {}", stdout);
     }
 
-    @Disabled("Only intended for ad hoc testing by using explicit S3 auth values.")
+    @Test
+    void exportTest() {
+        String stdout = runAndReturnStdout(() -> run(
+            "export-files",
+            "--path", PATH,
+            "--connection-string", makeConnectionString(),
+            "--collections", "author",
+            "--limit", "1",
+            "--s3-add-credentials"
+        ));
+
+        assertNotNull(stdout);
+        logger.info("Results: {}", stdout);
+    }
+
     @Test
     void api() {
-        final String path = "s3a://changeme";
-
         Flux.importGenericFiles()
             .from(options -> options
-                .paths(path)
+                .paths(PATH)
                 .s3AccessKeyId("changeme")
                 .s3SecretAccessKey("changeme"))
             .connectionString(makeConnectionString())


### PR DESCRIPTION
Was getting errors when using Hadoop 3.3.6 instead of 3.3.4 with spark-submit. 3.3.4 ran fine. So changed our version of Hadoop to 3.3.4 and then updated the AWS SDK dependency to match the version expected by Hadoop 3.3.4. 