### PR TITLE
Refactor boxed types into primitives

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
@@ -18,7 +18,7 @@ public interface AggregateJsonFilesImporter extends Executor<AggregateJsonFilesI
          * @param value set to true to read JSON Lines files. Defaults to reading files that either contain an array
          *              of JSON objects or a single JSON object.
          */
-        ReadJsonFilesOptions jsonLines(Boolean value);
+        ReadJsonFilesOptions jsonLines(boolean value);
 
         ReadJsonFilesOptions encoding(String encoding);
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/AggregateXmlFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AggregateXmlFilesImporter.java
@@ -23,7 +23,7 @@ public interface AggregateXmlFilesImporter extends Executor<AggregateXmlFilesImp
 
         ReadXmlFilesOptions encoding(String encoding);
 
-        ReadXmlFilesOptions partitions(Integer partitions);
+        ReadXmlFilesOptions partitions(int partitions);
     }
 
     AggregateXmlFilesImporter from(Consumer<ReadXmlFilesOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ArchiveFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ArchiveFilesImporter.java
@@ -13,7 +13,7 @@ public interface ArchiveFilesImporter extends Executor<ArchiveFilesImporter> {
     interface ReadArchiveFilesOptions extends ReadFilesOptions<ReadArchiveFilesOptions> {
         ReadArchiveFilesOptions categories(String... categories);
 
-        ReadArchiveFilesOptions partitions(Integer partitions);
+        ReadArchiveFilesOptions partitions(int partitions);
 
         ReadArchiveFilesOptions encoding(String encoding);
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ConnectionOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ConnectionOptions.java
@@ -19,7 +19,7 @@ public interface ConnectionOptions {
 
     ConnectionOptions connectionType(String connectionType);
 
-    ConnectionOptions disableGzippedResponses(Boolean value);
+    ConnectionOptions disableGzippedResponses(boolean value);
 
     ConnectionOptions username(String username);
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesExporter.java
@@ -15,11 +15,11 @@ public interface GenericFilesExporter extends Executor<GenericFilesExporter> {
 
         WriteGenericFilesOptions compressionType(CompressionType compressionType);
 
-        WriteGenericFilesOptions prettyPrint(Boolean value);
+        WriteGenericFilesOptions prettyPrint(boolean value);
 
         WriteGenericFilesOptions encoding(String encoding);
 
-        WriteGenericFilesOptions zipFileCount(Integer zipFileCount);
+        WriteGenericFilesOptions zipFileCount(int zipFileCount);
 
         WriteGenericFilesOptions s3AddCredentials();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesImporter.java
@@ -17,7 +17,7 @@ public interface GenericFilesImporter extends Executor<GenericFilesImporter> {
     interface ReadGenericFilesOptions extends ReadFilesOptions<ReadGenericFilesOptions> {
         ReadGenericFilesOptions compressionType(CompressionType compressionType);
 
-        ReadGenericFilesOptions partitions(Integer partitions);
+        ReadGenericFilesOptions partitions(int partitions);
 
         ReadGenericFilesOptions encoding(String encoding);
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/MlcpArchiveFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/MlcpArchiveFilesImporter.java
@@ -13,7 +13,7 @@ public interface MlcpArchiveFilesImporter extends Executor<MlcpArchiveFilesImpor
     interface ReadMlcpArchiveFilesOptions extends ReadFilesOptions<ReadMlcpArchiveFilesOptions> {
         ReadMlcpArchiveFilesOptions categories(String... categories);
         ReadMlcpArchiveFilesOptions encoding(String encoding);
-        ReadMlcpArchiveFilesOptions partitions(Integer partitions);
+        ReadMlcpArchiveFilesOptions partitions(int partitions);
     }
 
     MlcpArchiveFilesImporter from(Consumer<ReadMlcpArchiveFilesOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesExporter.java
@@ -28,9 +28,9 @@ public interface RdfFilesExporter extends Executor<RdfFilesExporter> {
 
         ReadTriplesDocumentsOptions baseIri(String baseIri);
 
-        ReadTriplesDocumentsOptions batchSize(Integer batchSize);
+        ReadTriplesDocumentsOptions batchSize(int batchSize);
 
-        ReadTriplesDocumentsOptions partitionsPerForest(Integer partitionsPerForest);
+        ReadTriplesDocumentsOptions partitionsPerForest(int partitionsPerForest);
     }
 
     interface WriteRdfFilesOptions extends WriteFilesOptions<WriteRdfFilesOptions> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesImporter.java
@@ -12,7 +12,7 @@ public interface RdfFilesImporter extends Executor<RdfFilesImporter> {
 
     interface ReadRdfFilesOptions extends ReadFilesOptions<ReadRdfFilesOptions> {
         ReadRdfFilesOptions compressionType(CompressionType compressionType);
-        ReadRdfFilesOptions partitions(Integer partitions);
+        ReadRdfFilesOptions partitions(int partitions);
     }
 
     interface WriteTriplesDocumentsOptions extends WriteDocumentsOptions<WriteTriplesDocumentsOptions> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadDocumentsOptions.java
@@ -23,7 +23,7 @@ public interface ReadDocumentsOptions<T extends ReadDocumentsOptions> {
 
     T transformParamsDelimiter(String delimiter);
 
-    T batchSize(Integer batchSize);
+    T batchSize(int batchSize);
 
-    T partitionsPerForest(Integer partitionsPerForest);
+    T partitionsPerForest(int partitionsPerForest);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadFilesOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadFilesOptions.java
@@ -9,9 +9,9 @@ public interface ReadFilesOptions<T extends ReadFilesOptions> {
 
     T filter(String filter);
 
-    T recursiveFileLookup(Boolean value);
+    T recursiveFileLookup(boolean value);
 
-    T abortOnReadFailure(Boolean value);
+    T abortOnReadFailure(boolean value);
 
     T s3AddCredentials();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadRowsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadRowsOptions.java
@@ -7,9 +7,9 @@ public interface ReadRowsOptions {
 
     ReadRowsOptions opticQuery(String opticQuery);
 
-    ReadRowsOptions disableAggregationPushDown(Boolean value);
+    ReadRowsOptions disableAggregationPushDown(boolean value);
 
-    ReadRowsOptions batchSize(Integer batchSize);
+    ReadRowsOptions batchSize(int batchSize);
 
-    ReadRowsOptions partitions(Integer partitions);
+    ReadRowsOptions partitions(int partitions);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
@@ -52,11 +52,11 @@ public interface Reprocessor extends Executor<Reprocessor> {
 
         WriteOptions vars(Map<String, String> namesAndValues);
 
-        WriteOptions abortOnWriteFailure(Boolean value);
+        WriteOptions abortOnWriteFailure(boolean value);
 
-        WriteOptions batchSize(Integer batchSize);
+        WriteOptions batchSize(int batchSize);
 
-        WriteOptions logProgress(Integer numberOfItems);
+        WriteOptions logProgress(int numberOfItems);
     }
 
     Reprocessor from(Consumer<ReadOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
@@ -5,7 +5,7 @@ package com.marklogic.flux.api;
 
 public interface WriteDocumentsOptions<T extends WriteDocumentsOptions> {
 
-    T abortOnWriteFailure(Boolean value);
+    T abortOnWriteFailure(boolean value);
 
     T batchSize(int batchSize);
 
@@ -15,7 +15,7 @@ public interface WriteDocumentsOptions<T extends WriteDocumentsOptions> {
 
     T failedDocumentsPath(String path);
 
-    T logProgress(Integer numberOfDocuments);
+    T logProgress(int numberOfDocuments);
 
     T permissionsString(String rolesAndCapabilities);
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/WriteFilesOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/WriteFilesOptions.java
@@ -7,7 +7,7 @@ public interface WriteFilesOptions<T extends WriteFilesOptions> {
 
     T path(String path);
 
-    T fileCount(Integer fileCount);
+    T fileCount(int fileCount);
 
     T s3AddCredentials();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class CommonParams {
 
     @CommandLine.Option(names = "--limit", description = "Number of records to read from the data source.")
-    private Integer limit;
+    private int limit;
 
     @CommandLine.Option(names = "--count", description = "Show a count of records to be read from the data source without writing any of the data.")
     private boolean count;
@@ -28,12 +28,12 @@ public class CommonParams {
     private Preview preview = new Preview();
 
     @CommandLine.Option(names = "--repartition", description = "Specify the number of partitions to be used for writing data.")
-    private Integer repartition;
+    private int repartition;
 
     // This is declared here so a user will see it in when viewing command usage, but the Main program does not need
     // it as it can easily check for it in the list of arguments it receives.
     @CommandLine.Option(names = "--stacktrace", description = "Print the stacktrace when a command fails.")
-    private Boolean showStacktrace;
+    private boolean showStacktrace;
 
     // Hidden for now since showing it for every command in its "help" seems confusing for most users that will likely
     // never need to know about this.
@@ -50,10 +50,10 @@ public class CommonParams {
     private Map<String, String> configParams = new HashMap<>();
 
     public Dataset<Row> applyParams(Dataset<Row> dataset) {
-        if (limit != null) {
+        if (limit > 0) {
             dataset = dataset.limit(limit);
         }
-        if (repartition != null && repartition > 0) {
+        if (repartition > 0) {
             dataset = dataset.repartition(repartition);
         }
         return dataset;
@@ -63,11 +63,11 @@ public class CommonParams {
         return count;
     }
 
-    public void setLimit(Integer limit) {
+    public void setLimit(int limit) {
         this.limit = limit;
     }
 
-    public void setRepartition(Integer repartition) {
+    public void setRepartition(int repartition) {
         this.repartition = repartition;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionInputs.java
@@ -36,11 +36,11 @@ public abstract class ConnectionInputs {
 
     protected String connectionString;
     protected String host;
-    protected Integer port;
+    protected int port;
     protected String basePath;
     protected String database;
     protected DatabaseClient.ConnectionType connectionType;
-    protected Boolean disableGzippedResponses;
+    protected boolean disableGzippedResponses;
     protected AuthenticationType authType;
     protected String username;
     protected String password;
@@ -84,8 +84,8 @@ public abstract class ConnectionInputs {
         return OptionsUtil.makeOptions(
             Options.CLIENT_URI, connectionString,
             Options.CLIENT_HOST, host,
-            Options.CLIENT_PORT, port != null ? port.toString() : null,
-            "spark.marklogic.client.disableGzippedResponses", disableGzippedResponses != null ? Boolean.toString(disableGzippedResponses) : null,
+            Options.CLIENT_PORT, OptionsUtil.intOption(port),
+            "spark.marklogic.client.disableGzippedResponses", disableGzippedResponses ? "true" : null,
             "spark.marklogic.client.basePath", basePath,
             Options.CLIENT_DATABASE, database,
             Options.CLIENT_CONNECTION_TYPE, connectionType != null ? connectionType.name() : null,

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
@@ -81,7 +81,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
         names = "--disable-gzipped-responses",
         description = "If included, responses from MarkLogic will not be gzipped. May improve performance when responses are very small."
     )
-    public ConnectionOptions disableGzippedResponses(Boolean disableGzippedResponses) {
+    public ConnectionOptions disableGzippedResponses(boolean disableGzippedResponses) {
         this.disableGzippedResponses = disableGzippedResponses;
         return this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParamsValidator.java
@@ -23,7 +23,7 @@ public class ConnectionParamsValidator {
             throw new FluxException(String.format("Must specify a MarkLogic host via %s or %s.",
                 paramNames.host, paramNames.connectionString));
         }
-        if (connectionInputs.port == null) {
+        if (connectionInputs.port <= 0) {
             throw new FluxException(String.format("Must specify a MarkLogic app server port via %s or %s.",
                 paramNames.port, paramNames.connectionString));
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/OptionsUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/OptionsUtil.java
@@ -31,6 +31,10 @@ public abstract class OptionsUtil {
         return options;
     }
 
+    public static String intOption(int value) {
+        return value > 0 ? Integer.toString(value) : null;
+    }
+
     public static Map<String, String> addOptions(Map<String, String> options, String... keysAndValues) {
         options.putAll(makeOptions(keysAndValues));
         return options;

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -57,13 +57,13 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             names = "--output-abort-on-write-failure",
             description = "Causes the command to fail when a batch of documents cannot be written to MarkLogic."
         )
-        private Boolean abortOnWriteFailure;
+        private boolean abortOnWriteFailure;
 
         @CommandLine.Option(
             names = "--output-batch-size",
             description = "The maximum number of documents written in a single call to MarkLogic."
         )
-        private Integer batchSize = 100;
+        private int batchSize = 100;
 
         @CommandLine.Option(
             names = "--output-collections",
@@ -82,7 +82,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             names = "--log-progress",
             description = "Log a count of documents written every time this many documents are written."
         )
-        private Integer logProgress;
+        private int logProgress;
 
         @CommandLine.Option(
             names = "--output-permissions",
@@ -100,13 +100,13 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             names = "--output-thread-count",
             description = "The number of threads used by each partition worker when writing batches of documents to MarkLogic."
         )
-        private Integer threadCount = 4;
+        private int threadCount = 4;
 
         @CommandLine.Option(
             names = "--output-total-thread-count",
             description = "The total number of threads used across all partitions when writing batches of documents to MarkLogic."
         )
-        private Integer totalThreadCount;
+        private int totalThreadCount;
 
         @CommandLine.Option(
             names = "--output-transform",
@@ -155,15 +155,15 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
 
         protected Map<String, String> makeOptions() {
             return OptionsUtil.makeOptions(
-                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure != null ? Boolean.toString(abortOnWriteFailure) : "false",
+                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true": null,
                 Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
-                Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
+                Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
                 Options.WRITE_COLLECTIONS, collections,
-                Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null,
+                Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(logProgress),
                 Options.WRITE_PERMISSIONS, permissions,
                 Options.WRITE_TEMPORAL_COLLECTION, temporalCollection,
-                Options.WRITE_THREAD_COUNT, threadCount != null ? threadCount.toString() : null,
-                Options.WRITE_TOTAL_THREAD_COUNT, totalThreadCount != null ? totalThreadCount.toString() : null,
+                Options.WRITE_THREAD_COUNT, OptionsUtil.intOption(threadCount),
+                Options.WRITE_TOTAL_THREAD_COUNT, OptionsUtil.intOption(totalThreadCount),
                 Options.WRITE_TRANSFORM_NAME, transform,
                 Options.WRITE_TRANSFORM_PARAMS, transformParams,
                 Options.WRITE_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
@@ -175,7 +175,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         }
 
         @Override
-        public CopyWriteDocumentsParams abortOnWriteFailure(Boolean value) {
+        public CopyWriteDocumentsParams abortOnWriteFailure(boolean value) {
             this.abortOnWriteFailure = value;
             return this;
         }
@@ -205,7 +205,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         }
 
         @Override
-        public CopyWriteDocumentsParams logProgress(Integer numberOfDocuments) {
+        public CopyWriteDocumentsParams logProgress(int numberOfDocuments) {
             this.logProgress = numberOfDocuments;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/OutputConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/OutputConnectionParams.java
@@ -103,7 +103,7 @@ public class OutputConnectionParams extends ConnectionInputs implements Connecti
     }
 
     @Override
-    public ConnectionOptions disableGzippedResponses(Boolean value) {
+    public ConnectionOptions disableGzippedResponses(boolean value) {
         // disableGzippedResponses doesn't apply for the output connection for a COPY procedure.
         return this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
@@ -41,8 +41,8 @@ public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExpor
 
     @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
-        final Integer fileCount = writeParams.getFileCount();
-        if (fileCount != null && fileCount > 0) {
+        final int fileCount = writeParams.getFileCount();
+        if (fileCount > 0) {
             getCommonParams().setRepartition(fileCount);
         }
         return reader.format(MARKLOGIC_CONNECTOR)

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
@@ -44,8 +44,8 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
 
     @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
-        final Integer zipFileCount = writeParams.zipFileCount;
-        if (zipFileCount != null && zipFileCount > 0) {
+        final int zipFileCount = writeParams.zipFileCount;
+        if (zipFileCount > 0) {
             getCommonParams().setRepartition(zipFileCount);
         }
         return reader.format(MARKLOGIC_CONNECTOR)
@@ -77,19 +77,19 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         private CompressionType compressionType;
 
         @CommandLine.Option(names = "--pretty-print", description = "Pretty-print the contents of JSON and XML files.")
-        private Boolean prettyPrint;
+        private boolean prettyPrint;
 
         @CommandLine.Option(names = "--encoding", description = "Specify an encoding for writing files.")
         private String encoding;
 
         @CommandLine.Option(names = "--zip-file-count", description = "Specifies how many ZIP files should be written when --compression is set to 'ZIP'; also an alias for '--repartition'.")
-        private Integer zipFileCount;
+        private int zipFileCount;
 
         @Override
         public Map<String, String> get() {
             return OptionsUtil.makeOptions(
                 Options.WRITE_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null,
-                Options.WRITE_FILES_PRETTY_PRINT, prettyPrint != null ? prettyPrint.toString() : null,
+                Options.WRITE_FILES_PRETTY_PRINT, prettyPrint ? "true": null,
                 Options.WRITE_FILES_ENCODING, encoding
             );
         }
@@ -107,7 +107,7 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         }
 
         @Override
-        public WriteGenericFilesOptions prettyPrint(Boolean value) {
+        public WriteGenericFilesOptions prettyPrint(boolean value) {
             this.prettyPrint = value;
             return this;
         }
@@ -119,7 +119,7 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         }
 
         @Override
-        public WriteGenericFilesOptions zipFileCount(Integer zipFileCount) {
+        public WriteGenericFilesOptions zipFileCount(int zipFileCount) {
             this.zipFileCount = zipFileCount;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
@@ -46,8 +46,8 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
 
     @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
-        final Integer fileCount = writeParams.getFileCount();
-        if (fileCount != null && fileCount > 0) {
+        final int fileCount = writeParams.getFileCount();
+        if (fileCount > 0) {
             getCommonParams().setRepartition(fileCount);
         }
         return reader.format(MARKLOGIC_CONNECTOR)
@@ -95,10 +95,10 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
         private String baseIri;
 
         @CommandLine.Option(names = "--batch-size", description = "Number of documents to retrieve in each call to MarkLogic.")
-        private Integer batchSize = 100;
+        private int batchSize = 100;
 
         @CommandLine.Option(names = "--partitions-per-forest", description = "Number of partition readers to create for each forest.")
-        private Integer partitionsPerForest = 4;
+        private int partitionsPerForest = 4;
 
         public Map<String, String> getQueryOptions() {
             return OptionsUtil.makeOptions(
@@ -116,8 +116,8 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
             return OptionsUtil.addOptions(getQueryOptions(),
                 Options.READ_TRIPLES_OPTIONS, options,
                 Options.READ_TRIPLES_BASE_IRI, baseIri,
-                Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, partitionsPerForest.toString(),
-                Options.READ_BATCH_SIZE, batchSize.toString()
+                Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest),
+                Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize)
             );
         }
 
@@ -170,13 +170,13 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
         }
 
         @Override
-        public RdfFilesExporter.ReadTriplesDocumentsOptions batchSize(Integer batchSize) {
+        public RdfFilesExporter.ReadTriplesDocumentsOptions batchSize(int batchSize) {
             this.batchSize = batchSize;
             return this;
         }
 
         @Override
-        public RdfFilesExporter.ReadTriplesDocumentsOptions partitionsPerForest(Integer partitionsPerForest) {
+        public RdfFilesExporter.ReadTriplesDocumentsOptions partitionsPerForest(int partitionsPerForest) {
             this.partitionsPerForest = partitionsPerForest;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
@@ -54,10 +54,10 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     private String transformParamsDelimiter;
 
     @CommandLine.Option(names = "--batch-size", description = "Number of documents to retrieve in each call to MarkLogic.")
-    private Integer batchSize = 500;
+    private int batchSize = 500;
 
     @CommandLine.Option(names = "--partitions-per-forest", description = "Number of partition readers to create for each forest.")
-    private Integer partitionsPerForest = 4;
+    private int partitionsPerForest = 4;
 
     public void verifyAtLeastOneQueryOptionIsSet(String verbForErrorMessage) {
         if (makeQueryOptions().isEmpty()) {
@@ -72,8 +72,8 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
             Options.READ_DOCUMENTS_TRANSFORM, transform,
             Options.READ_DOCUMENTS_TRANSFORM_PARAMS, transformParams,
             Options.READ_DOCUMENTS_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
-            Options.READ_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
-            Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, partitionsPerForest != null ? partitionsPerForest.toString() : null
+            Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
+            Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest)
         );
     }
 
@@ -142,13 +142,13 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     }
 
     @Override
-    public T batchSize(Integer batchSize) {
+    public T batchSize(int batchSize) {
         this.batchSize = batchSize;
         return (T) this;
     }
 
     @Override
-    public T partitionsPerForest(Integer partitionsPerForest) {
+    public T partitionsPerForest(int partitionsPerForest) {
         this.partitionsPerForest = partitionsPerForest;
         return (T) this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
@@ -23,24 +23,24 @@ public class ReadRowsParams implements ReadRowsOptions {
     private String query;
 
     @CommandLine.Option(names = "--batch-size", description = "Approximate number of rows to retrieve in each call to MarkLogic; defaults to 100000.")
-    private Integer batchSize;
+    private int batchSize;
 
     // Not yet showing this in usage as it is confusing for a typical user to understand and would only need to be
     // set if push down aggregation is producing incorrect results. See the MarkLogic Spark connector documentation
     // for more information.
     @CommandLine.Option(names = "--disable-aggregation-push-down", hidden = true)
-    private Boolean disableAggregationPushDown;
+    private boolean disableAggregationPushDown;
 
     @CommandLine.Option(names = "--partitions", description = "Number of partitions to create when reading rows from MarkLogic. " +
         "Increasing this may improve performance as the number of rows to read increases.")
-    private Integer partitions;
+    private int partitions;
 
     public Map<String, String> makeOptions() {
         return OptionsUtil.makeOptions(
             Options.READ_OPTIC_QUERY, query,
-            Options.READ_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
-            Options.READ_PUSH_DOWN_AGGREGATES, disableAggregationPushDown != null ? Boolean.toString(!disableAggregationPushDown) : null,
-            Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
+            Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
+            Options.READ_PUSH_DOWN_AGGREGATES, disableAggregationPushDown ? "true" : null,
+            Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions)
         );
     }
 
@@ -51,19 +51,19 @@ public class ReadRowsParams implements ReadRowsOptions {
     }
 
     @Override
-    public ReadRowsOptions disableAggregationPushDown(Boolean value) {
+    public ReadRowsOptions disableAggregationPushDown(boolean value) {
         this.disableAggregationPushDown = value;
         return this;
     }
 
     @Override
-    public ReadRowsOptions batchSize(Integer batchSize) {
+    public ReadRowsOptions batchSize(int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public ReadRowsOptions partitions(Integer partitions) {
+    public ReadRowsOptions partitions(int partitions) {
         this.partitions = partitions;
         return this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteFilesParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteFilesParams.java
@@ -20,7 +20,7 @@ public abstract class WriteFilesParams<T extends WriteFilesOptions> implements S
     private S3Params s3Params = new S3Params();
 
     @CommandLine.Option(names = "--file-count", description = "Specifies how many files should be written; also an alias for '--repartition'.")
-    protected Integer fileCount;
+    protected int fileCount;
 
     public String getPath() {
         return path;
@@ -30,7 +30,7 @@ public abstract class WriteFilesParams<T extends WriteFilesOptions> implements S
         return s3Params;
     }
 
-    public Integer getFileCount() {
+    public int getFileCount() {
         return fileCount;
     }
 
@@ -76,7 +76,7 @@ public abstract class WriteFilesParams<T extends WriteFilesOptions> implements S
     }
 
     @Override
-    public T fileCount(Integer fileCount) {
+    public T fileCount(int fileCount) {
         this.fileCount = fileCount;
         return (T) this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
@@ -50,7 +50,7 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
             names = "--json-lines",
             description = "Specifies that the file contains one JSON object per line, per the JSON Lines format defined at https://jsonlines.org/ ."
         )
-        private Boolean jsonLines;
+        private boolean jsonLines;
 
         @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
@@ -73,7 +73,7 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
             Map<String, String> options = super.makeOptions();
             // Spark JSON defaults to JSON Lines format. This commands assumes the opposite, so it defaults to including
             // multiLine=true (i.e. not JSON Lines) unless the user has included the option requesting JSON Lines support.
-            if (jsonLines == null || !jsonLines.booleanValue()) {
+            if (!jsonLines) {
                 options.put("multiLine", "true");
             }
             if (encoding != null) {
@@ -84,7 +84,7 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
         }
 
         @Override
-        public ReadJsonFilesOptions jsonLines(Boolean value) {
+        public ReadJsonFilesOptions jsonLines(boolean value) {
             this.jsonLines = value;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesCommand.java
@@ -73,14 +73,14 @@ public class ImportAggregateXmlFilesCommand extends AbstractImportFilesCommand<A
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
-        private Integer partitions;
+        private int partitions;
 
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(
                 super.makeOptions(),
                 Options.READ_FILES_ENCODING, encoding,
-                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null,
+                Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions),
                 Options.READ_AGGREGATES_XML_ELEMENT, element,
                 Options.READ_AGGREGATES_XML_NAMESPACE, namespace,
                 Options.READ_AGGREGATES_XML_URI_ELEMENT, uriElement,
@@ -126,7 +126,7 @@ public class ImportAggregateXmlFilesCommand extends AbstractImportFilesCommand<A
         }
 
         @Override
-        public ReadXmlFilesOptions partitions(Integer partitions) {
+        public ReadXmlFilesOptions partitions(int partitions) {
             this.partitions = partitions;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesCommand.java
@@ -50,7 +50,7 @@ public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<Archiv
         private String categories;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
-        private Integer partitions;
+        private int partitions;
 
         @CommandLine.Option(names = "--encoding", description = "Specify an encoding when reading files.")
         private String encoding;
@@ -61,7 +61,7 @@ public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<Archiv
                 Options.READ_FILES_TYPE, "archive",
                 Options.READ_FILES_ENCODING, encoding,
                 Options.READ_ARCHIVES_CATEGORIES, categories,
-                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
+                Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions)
             );
         }
 
@@ -78,7 +78,7 @@ public class ImportArchiveFilesCommand extends AbstractImportFilesCommand<Archiv
         }
 
         @Override
-        public ReadArchiveFilesOptions partitions(Integer partitions) {
+        public ReadArchiveFilesOptions partitions(int partitions) {
             this.partitions = partitions;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -67,7 +67,7 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
-        private Integer partitions;
+        private int partitions;
 
         @Override
         public ReadGenericFilesOptions compressionType(CompressionType compressionType) {
@@ -84,14 +84,14 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
-                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null,
+                Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions),
                 Options.READ_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null,
                 Options.READ_FILES_ENCODING, encoding
             );
         }
 
         @Override
-        public ReadGenericFilesOptions partitions(Integer partitions) {
+        public ReadGenericFilesOptions partitions(int partitions) {
             this.partitions = partitions;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesCommand.java
@@ -52,7 +52,7 @@ public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<Ml
         private String encoding;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
-        private Integer partitions;
+        private int partitions;
 
         @Override
         public Map<String, String> makeOptions() {
@@ -60,7 +60,7 @@ public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<Ml
                 Options.READ_FILES_TYPE, "mlcp_archive",
                 Options.READ_ARCHIVES_CATEGORIES, categories,
                 Options.READ_FILES_ENCODING, encoding,
-                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
+                Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions)
             );
         }
 
@@ -77,7 +77,7 @@ public class ImportMlcpArchiveFilesCommand extends AbstractImportFilesCommand<Ml
         }
 
         @Override
-        public ReadMlcpArchiveFilesOptions partitions(Integer partitions) {
+        public ReadMlcpArchiveFilesOptions partitions(int partitions) {
             this.partitions = partitions;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
@@ -48,14 +48,14 @@ public class ImportRdfFilesCommand extends AbstractImportFilesCommand<RdfFilesIm
         private CompressionType compressionType;
 
         @CommandLine.Option(names = "--partitions", description = "Specifies the number of partitions used for reading files.")
-        private Integer partitions;
+        private int partitions;
 
         @Override
         public Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(super.makeOptions(),
                 Options.READ_FILES_TYPE, "rdf",
                 Options.READ_FILES_COMPRESSION, compressionType != null ? compressionType.name() : null,
-                Options.READ_NUM_PARTITIONS, partitions != null ? partitions.toString() : null
+                Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions)
             );
         }
 
@@ -66,7 +66,7 @@ public class ImportRdfFilesCommand extends AbstractImportFilesCommand<RdfFilesIm
         }
 
         @Override
-        public ReadRdfFilesOptions partitions(Integer partitions) {
+        public ReadRdfFilesOptions partitions(int partitions) {
             this.partitions = partitions;
             return this;
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ReadFilesParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ReadFilesParams.java
@@ -20,13 +20,13 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
     private List<String> path = new ArrayList<>();
 
     @CommandLine.Option(names = "--abort-on-read-failure", description = "Causes the command to abort when it fails to read a file.")
-    private Boolean abortOnReadFailure = false;
+    private boolean abortOnReadFailure;
 
     @CommandLine.Option(names = "--filter", description = "A glob filter for selecting only files with file names matching the pattern.")
     private String filter;
 
     @CommandLine.Option(names = "--recursive-file-lookup", arity = "1", description = "If true, files will be loaded recursively from child directories and partition inferring is disabled.")
-    private Boolean recursiveFileLookup = true;
+    private boolean recursiveFileLookup = true;
 
     @CommandLine.Mixin
     private S3Params s3Params = new S3Params();
@@ -37,7 +37,7 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
 
     public Map<String, String> makeOptions() {
         Map<String, String> options = new HashMap<>();
-        if (abortOnReadFailure != null && abortOnReadFailure) {
+        if (abortOnReadFailure) {
             addOptionsToFailOnReadError(options);
         } else {
             addOptionsToNotFailOnReadError(options);
@@ -46,8 +46,8 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
         if (filter != null) {
             options.put("pathGlobFilter", filter);
         }
-        if (recursiveFileLookup != null) {
-            options.put("recursiveFileLookup", recursiveFileLookup.toString());
+        if (recursiveFileLookup) {
+            options.put("recursiveFileLookup", "true");
         }
         return options;
     }
@@ -101,13 +101,13 @@ public class ReadFilesParams<T extends ReadFilesOptions> implements ReadFilesOpt
     }
 
     @Override
-    public T recursiveFileLookup(Boolean value) {
+    public T recursiveFileLookup(boolean value) {
         this.recursiveFileLookup = value;
         return (T) this;
     }
 
     @Override
-    public T abortOnReadFailure(Boolean value) {
+    public T abortOnReadFailure(boolean value) {
         this.abortOnReadFailure = value;
         return (T) this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
@@ -23,13 +23,13 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
         names = "--abort-on-write-failure",
         description = "Causes the command to fail when a batch of documents cannot be written to MarkLogic."
     )
-    private Boolean abortOnWriteFailure;
+    private boolean abortOnWriteFailure;
 
     @CommandLine.Option(
         names = "--batch-size",
         description = "The maximum number of documents written in a single call to MarkLogic."
     )
-    private Integer batchSize = 200;
+    private int batchSize = 200;
 
     @CommandLine.Option(
         names = "--collections",
@@ -48,7 +48,7 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
         names = "--log-progress",
         description = "Log a count of documents written every time this many documents are written."
     )
-    private Integer logProgress;
+    private int logProgress;
 
     @CommandLine.Option(
         names = "--permissions",
@@ -66,14 +66,14 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
         names = "--thread-count",
         description = "The number of threads used by each partition worker when writing batches of documents to MarkLogic."
     )
-    private Integer threadCount = 4;
+    private int threadCount = 4;
 
     @CommandLine.Option(
         names = "--total-thread-count",
         description = "The total number of threads used across all partitions when writing batches of documents to MarkLogic. " +
             "Takes precedence over the '--thread-count' option."
     )
-    private Integer totalThreadCount;
+    private int totalThreadCount;
 
     @CommandLine.Option(
         names = "--transform",
@@ -122,15 +122,15 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
 
     public Map<String, String> makeOptions() {
         return OptionsUtil.makeOptions(
-            Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure != null ? Boolean.toString(abortOnWriteFailure) : "false",
+            Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
             Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
-            Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
+            Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
             Options.WRITE_COLLECTIONS, collections,
-            Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null,
+            Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(logProgress),
             Options.WRITE_PERMISSIONS, permissions,
             Options.WRITE_TEMPORAL_COLLECTION, temporalCollection,
-            Options.WRITE_THREAD_COUNT, threadCount != null ? threadCount.toString() : null,
-            Options.WRITE_TOTAL_THREAD_COUNT, totalThreadCount != null ? totalThreadCount.toString() : null,
+            Options.WRITE_THREAD_COUNT, OptionsUtil.intOption(threadCount),
+            Options.WRITE_TOTAL_THREAD_COUNT, OptionsUtil.intOption(totalThreadCount),
             Options.WRITE_TRANSFORM_NAME, transform,
             Options.WRITE_TRANSFORM_PARAMS, transformParams,
             Options.WRITE_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
@@ -147,7 +147,7 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     }
 
     @Override
-    public T abortOnWriteFailure(Boolean value) {
+    public T abortOnWriteFailure(boolean value) {
         this.abortOnWriteFailure = value;
         return (T) this;
     }
@@ -177,7 +177,7 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     }
 
     @Override
-    public T logProgress(Integer numberOfDocuments) {
+    public T logProgress(int numberOfDocuments) {
         this.logProgress = numberOfDocuments;
         return (T) this;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -345,19 +345,19 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
             names = "--abort-on-write-failure",
             description = "Causes the command to fail when a batch of documents cannot be written to MarkLogic."
         )
-        private Boolean abortOnWriteFailure;
+        private boolean abortOnWriteFailure;
 
         @CommandLine.Option(
             names = "--batch-size",
             description = "The number of values sent to the code for writing data in a single call."
         )
-        private Integer batchSize = 1;
+        private int batchSize = 1;
 
         @CommandLine.Option(
             names = "--log-progress",
             description = "Log a count of items processed every time this many items are processed."
         )
-        private Integer logProgress;
+        private int logProgress;
 
         public void validateWriter() {
             Map<String, String> options = get();
@@ -377,9 +377,9 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
                 Options.WRITE_XQUERY_FILE, writeXqueryFile,
                 Options.WRITE_EXTERNAL_VARIABLE_NAME, externalVariableName,
                 Options.WRITE_EXTERNAL_VARIABLE_DELIMITER, externalVariableDelimiter,
-                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure != null ? Boolean.toString(abortOnWriteFailure) : "false",
-                Options.WRITE_BATCH_SIZE, batchSize != null ? batchSize.toString() : null,
-                Options.WRITE_LOG_PROGRESS, logProgress != null ? logProgress.toString() : null
+                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
+                Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
+                Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(logProgress)
             );
 
             if (writeVars != null) {
@@ -446,19 +446,19 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
         }
 
         @Override
-        public WriteOptions abortOnWriteFailure(Boolean value) {
+        public WriteOptions abortOnWriteFailure(boolean value) {
             this.abortOnWriteFailure = value;
             return this;
         }
 
         @Override
-        public WriteOptions batchSize(Integer batchSize) {
+        public WriteOptions batchSize(int batchSize) {
             this.batchSize = batchSize;
             return this;
         }
 
         @Override
-        public WriteOptions logProgress(Integer numberOfItems) {
+        public WriteOptions logProgress(int numberOfItems) {
             this.logProgress = numberOfItems;
             return this;
         }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -121,6 +121,6 @@ class HandleErrorTest extends AbstractTest {
         ));
 
         assertFalse(stderr.contains("Command failed"), "The command should not have failed since it defaults to not " +
-            "aborting on a write failure.");
+            "aborting on a write failure. Actual stderr: " + stderr);
     }
 }


### PR DESCRIPTION
Had inconsistency with the use of the two, and there's no reason for the boxed types, particularly in the API.
