### PR TITLE
Can now ignore null fields

### DIFF
--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -64,6 +64,23 @@ documents with the following format:
 </Customer>
 ```
 
+## Ignoring null fields
+
+By default, Flux will include any fields in an Avro file that have a null value 
+when creating JSON or XML documents. You can instead ignore fields with a null value
+via the `--ignore-null-fields` option:
+
+```
+./bin/flux import-avro-files \
+    --path /path/to/files \
+    --ignore-null-fields \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The decision on whether to include null fields will depend on your application requirements. For example, if your
+documents have large numbers of null fields, you may find them to be noise and decide to ignore them. In another case,
+it may be important to query for documents that have a particular field with a value of null.
+
 ## Aggregating rows
 
 The `import-avro-files` command supports aggregating related rows together to produce hierarchical documents. See

--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -71,6 +71,23 @@ documents with the following format:
 </Customer>
 ```
 
+## Ignoring null fields
+
+By default, Flux will include any fields in a delimited text file that have a null value (this does not include
+a value that has whitespace) when creating JSON or XML documents. You can instead ignore fields with a null value
+via the `--ignore-null-fields` option:
+
+```
+./bin/flux import-delimited-files \
+    --path /path/to/files --delimiter ; \
+    --ignore-null-fields \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The decision on whether to include null fields will depend on your application requirements. For example, if your
+documents have large numbers of null fields, you may find them to be noise and decide to ignore them. In another case,
+it may be important to query for documents that have a particular field with a value of null.
+
 ## Specifying an encoding
 
 MarkLogic stores all content [in the UTF-8 encoding](https://docs.marklogic.com/guide/search-dev/encodings_collations#id_87576).

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -64,6 +64,23 @@ documents with the following format:
 </Customer>
 ```
 
+## Ignoring null fields
+
+By default, Flux will include any fields in an ORC file that have a null value
+when creating JSON or XML documents. You can instead ignore fields with a null value
+via the `--ignore-null-fields` option:
+
+```
+./bin/flux import-orc-files \
+    --path /path/to/files \
+    --ignore-null-fields \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The decision on whether to include null fields will depend on your application requirements. For example, if your
+documents have large numbers of null fields, you may find them to be noise and decide to ignore them. In another case,
+it may be important to query for documents that have a particular field with a value of null.
+
 ## Aggregating rows
 
 The `import-orc-files` command supports aggregating related rows together to produce hierarchical documents. See

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -64,6 +64,23 @@ documents with the following format:
 </Customer>
 ```
 
+## Ignoring null fields
+
+By default, Flux will include any fields in a Parquet file that have a null value
+when creating JSON or XML documents. You can instead ignore fields with a null value
+via the `--ignore-null-fields` option:
+
+```
+./bin/flux import-parquet-files \
+    --path /path/to/files \
+    --ignore-null-fields \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The decision on whether to include null fields will depend on your application requirements. For example, if your
+documents have large numbers of null fields, you may find them to be noise and decide to ignore them. In another case,
+it may be important to query for documents that have a particular field with a value of null.
+
 ## Aggregating rows
 
 The `import-parquet-files` command supports aggregating related rows together to produce hierarchical documents. See

--- a/docs/import/import-jdbc.md
+++ b/docs/import/import-jdbc.md
@@ -53,6 +53,22 @@ To create an XML document for each row instead of a JSON document, include the `
 option to specify the name of the root element in each XML document. You can optionally include `--xml-namespace` to
 specify a namespace for the root element that will then be inherited by every child element as well.
 
+## Ignoring null fields
+
+By default, Flux will include any fields in a data source that have a null value 
+when creating JSON or XML documents. You can instead ignore fields with a null value
+via the `--ignore-null-fields` option:
+
+```
+./bin/flux import-jdbc \
+    --ignore-null-fields \
+    --connection-string "user:password@localhost:8000" etc...
+```
+
+The decision on whether to include null fields will depend on your application requirements. For example, if your
+documents have large numbers of null fields, you may find them to be noise and decide to ignore them. In another case,
+it may be important to query for documents that have a particular field with a value of null.
+
 ## Aggregating rows
 
 The `import-jdbc` command supports aggregating related rows together to produce hierarchical documents. See

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   implementation "org.apache.spark:spark-avro_2.12:3.4.1"
 
   testImplementation("com.marklogic:marklogic-junit5:1.4.0") {
+    // Excluding Jackson so that we use whatever Jackson version is required by Spark.
     exclude group: "com.fasterxml.jackson.core"
     exclude group: "com.fasterxml.jackson.dataformat"
   }
@@ -49,7 +50,11 @@ dependencies {
   testImplementation "com.databricks:spark-xml_2.12:0.18.0"
 
   // For configuring two-way SSL in tests.
-  testImplementation "com.marklogic:ml-app-deployer:4.7.0"
+  testImplementation ("com.marklogic:ml-app-deployer:4.7.0") {
+    // Excluding Jackson so that we use whatever Jackson version is required by Spark.
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
+  }
 
   shadowDependencies "com.marklogic:marklogic-spark-connector:2.2-SNAPSHOT"
   shadowDependencies "info.picocli:picocli:4.7.6"

--- a/flux-cli/src/main/java/com/marklogic/flux/api/WriteStructuredDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/WriteStructuredDocumentsOptions.java
@@ -14,4 +14,11 @@ public interface WriteStructuredDocumentsOptions extends WriteDocumentsOptions<W
     WriteStructuredDocumentsOptions xmlRootName(String xmlRootName);
 
     WriteStructuredDocumentsOptions xmlNamespace(String xmlNamespace);
+
+    /**
+     * @param value Ignore fields with null values in the data source when writing JSON or XML documents to MarkLogic.
+     *              Fields with null values are included by default.
+     * @return an instance of these options.
+     */
+    WriteStructuredDocumentsOptions ignoreNullFields(boolean value);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
@@ -33,10 +33,19 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
     )
     private String xmlNamespace;
 
+    @CommandLine.Option(
+        names = "--ignore-null-fields",
+        description = "Ignore fields with null values in the data source when writing JSON or XML documents to MarkLogic."
+    )
+    private boolean ignoreNullFields;
+
     @Override
     public Map<String, String> makeOptions() {
-        return OptionsUtil.addOptions(
-            super.makeOptions(),
+        Map<String, String> options = super.makeOptions();
+        if (ignoreNullFields) {
+            options.put(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "true");
+        }
+        return OptionsUtil.addOptions(options,
             Options.WRITE_JSON_ROOT_NAME, jsonRootName,
             Options.WRITE_XML_ROOT_NAME, xmlRootName,
             Options.WRITE_XML_NAMESPACE, xmlNamespace
@@ -58,6 +67,12 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
     @Override
     public WriteStructuredDocumentsOptions xmlNamespace(String xmlNamespace) {
         this.xmlNamespace = xmlNamespace;
+        return this;
+    }
+
+    @Override
+    public WriteStructuredDocumentsOptions ignoreNullFields(boolean value) {
+        this.ignoreNullFields = value;
         return this;
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -244,6 +244,39 @@ class ImportDelimitedFilesTest extends AbstractTest {
         assertEquals(true, objects.get(1).get("flag").asBoolean());
     }
 
+    @Test
+    void emptyValuesIncluded() {
+        run(
+            "import-delimited-files",
+            "--path", "src/test/resources/delimited-files/empty-values.csv",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--uri-template", "/delimited/{number}.json"
+        );
+
+        JsonNode doc = readJsonDocument("/delimited/1.json");
+        assertEquals(3, doc.size(), "With null fields included, 'flag' should be present.");
+        assertEquals(JsonNodeType.NULL, doc.get("flag").getNodeType());
+    }
+
+    @Test
+    void emptyValuesIgnored() {
+        run(
+            "import-delimited-files",
+            "--path", "src/test/resources/delimited-files/empty-values.csv",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--uri-template", "/delimited/{number}.json",
+            "--ignore-null-fields"
+        );
+
+        JsonNode doc = readJsonDocument("/delimited/1.json");
+        assertEquals(2, doc.size(), "The doc should only have 'number' and 'color' since 'flag' is null.");
+        assertEquals(1, doc.get("number").asInt());
+        assertEquals("blue", doc.get("color").asText());
+    }
+
+
     private void verifyDoc(String uri, int expectedNumber, String expectedColor, boolean expectedFlag) {
         JsonNode doc = readJsonDocument(uri);
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -218,7 +218,7 @@ class ImportParquetFilesTest extends AbstractTest {
             assertEquals(expectedNumber, doc.get("number").asText());
             assertEquals(JsonNodeType.STRING, doc.get("number").getNodeType());
         } else {
-            assertFalse(doc.has("number"));
+            assertEquals(JsonNodeType.NULL, doc.get("number").getNodeType());
         }
 
         assertEquals(expectedColor, doc.get("color").asText());
@@ -227,7 +227,7 @@ class ImportParquetFilesTest extends AbstractTest {
             assertEquals(expectedHex, doc.get("hex").asText());
             assertEquals(JsonNodeType.STRING, doc.get("hex").getNodeType());
         } else {
-            assertFalse(doc.has("hex"));
+            assertEquals(JsonNodeType.NULL, doc.get("hex").getNodeType());
         }
     }
 

--- a/flux-cli/src/test/resources/delimited-files/empty-values.csv
+++ b/flux-cli/src/test/resources/delimited-files/empty-values.csv
@@ -1,0 +1,3 @@
+number,color,flag
+1,blue,
+2,,false

--- a/mlcp-testing/build.gradle
+++ b/mlcp-testing/build.gradle
@@ -38,6 +38,21 @@ task mlcpImportMixed(type: JavaExec) {
   ]
 }
 
+task mlcpImportDelimited(type: JavaExec) {
+  classpath = configurations.mlcp
+  mainClass = "com.marklogic.contentpump.ContentPump"
+  args = [
+    "IMPORT",
+    "-host", mlHost,
+    "-port", mlRestPort,
+    "-username", mlUsername,
+    "-password", mlPassword,
+    "-input_file_path", "../flux-cli/src/test/resources/delimited-files/empty-values.csv",
+    "-output_permissions", "rest-reader,read,rest-writer,update",
+    "-input_file_type", "delimited_text"
+  ]
+}
+
 task mlcpImportAggregateXml(type: Exec) {
   workingDir = "."
   commandLine "mlcp.sh", "IMPORT",


### PR DESCRIPTION
The default of our connector is to retain null fields when using a Spark data source. So the user now has a `--ignore-null-fields` option. 