### PR TITLE
Added log-progress for export commands

### DIFF
--- a/caddy/config/Caddyfile
+++ b/caddy/config/Caddyfile
@@ -1,7 +1,7 @@
 # See https://caddyserver.com/docs/caddyfile-tutorial for more information.
 
 :8006 {
-  reverse_proxy mlperfr-009.bedford.progress.com:8015 mlperfr-010.bedford.progress.com:8015 mlperfr-011.bedford.progress.com:8015 {
+  reverse_proxy marklogic:8000 {
     transport http {
       dial_timeout 31s
     }
@@ -12,7 +12,7 @@
 }
 
 :8007 {
-  reverse_proxy mlperfr-009.bedford.progress.com:8016 mlperfr-010.bedford.progress.com:8016 mlperfr-011.bedford.progress.com:8016 {
+  reverse_proxy marklogic:8004 {
     transport http {
       dial_timeout 31s
     }

--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -225,22 +225,25 @@ Flux will then log the count:
 [main] INFO com.marklogic.flux: Count: 1000
 ```
 
+The performance of using `--count` is dependent on how quickly data can be read from the command's data source. For 
+example, commands that export documents from MarkLogic must read every document to be exported in order to calculate 
+a count. For a scenario like that, you can likely much more quickly determine a count by running your query in 
+MarkLogic's qconsole application.
+
 ## Viewing progress
 
-For commands that write data to MarkLogic - which includes all import, copy, and reprocess commands - Flux will log
-messages at the `INFO` level showing progress in terms of how much data has been sent to MarkLogic. For import and 
-copy commands, Flux defaults to logging a message every time approximately 10,000 documents are written. For the 
-reprocess command, Flux defaults to logging a message every time approximately 10,000 items are reprocessed by 
-MarkLogic. These values can be adjusted via the `--log-progress` option. The guides on import, copy, and reprocess
-provide further details on logging progress. 
+Each Flux command supports a `--log-progress` option that you can use to specify how often you want a message logged
+indicating progress. Import commands will show progress in terms of writing data to MarkLogic, while export 
+commands will show progress in terms of reading data from MarkLogic. The `copy` command can show both types of progress, 
+with `--log-progress` specifying an interval for logging data that has been read and `--output-log-progress` 
+specifying an interval for logging data that has been written. The `reprocess` command is similar to import commands
+in that it shows progress in terms of processing data that has been read from MarkLogic.
 
-For export commands, Flux does not log progress as it does not always have visibility into how much data has been 
-written to an external data source (whereas it does have visibility into how much data has been written to 
-MarkLogic). You can instead include the `--spark-show-progress-bar` option to enable the progress bar provided
-by the underlying [Apache Spark software](https://spark.apache.org/). The Spark progress bar provides details at a
-lower level that may not provide visibility into the amount of data that has been exported, but it will at least avoid
-the impression that Flux is stuck. Typically, the best approach for monitoring progress for export commands 
-will be to examine the target destination to see how much data has been written. 
+The `--log-progress` option defaults to a value of 10,000, with one exception - export commands that read rows from 
+MarkLogic defaults `--log-progress` to a value of 100,000. For an import command with a value of 10,000, 
+Flux will log a message at the `INFO` level every time it reads 10,000 documents - so at 10,000, 20,000, etc. 
+You can change this value to suit your needs, though you typically will want it to be significantly larger than 
+the value of `--batch-size` if the command supports that option.
 
 ## Viewing a stacktrace
 

--- a/docs/import/common-import-features.md
+++ b/docs/import/common-import-features.md
@@ -105,13 +105,6 @@ The following shows an example of each option:
 --temporal-collection my-temporal-data
 ```
 
-## Logging progress
-
-Flux will log a message at the `INFO` level stating how many documents it has written as a form of showing progress. 
-It defaults to logging this message every time approximately 10,000 documents are written. You can adjust this value by 
-using the `--log-progress` option. For example, for more frequent logging, you could include `--log-progress 1000` to 
-configure Flux to log a message every time it writes 1,000 documents.
-
 ## Transforming content
 
 For each import command, you can apply a [MarkLogic REST transform](https://docs.marklogic.com/guide/rest-dev/transforms)

--- a/docs/reprocess.md
+++ b/docs/reprocess.md
@@ -101,10 +101,3 @@ In the above example, the code defined by `--read-javascript` will be invoked on
 defined by `--read-partitions-javascript`. The value of `PARTITION` - a forest ID - is then passed to the 
 [cts.uris](https://docs.marklogic.com/cts.uris) function to constrain it to a particular forest. With this approach, 
 the query is broken up into N queries that run in parallel, with N equalling the number of forests in the database.
-
-## Logging progress
-
-Flux will log a message at the `INFO` level stating how many items it has processed as a form of showing progress.
-It defaults to logging this message every time 10,000 items are processed. You can adjust this value by using
-the `--log-progress` option. For example, for more frequent logging, you could include `--log-progress 1000` to
-configure Flux to log a message every time it processes 1,000 items.

--- a/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesExporter.java
@@ -31,6 +31,8 @@ public interface RdfFilesExporter extends Executor<RdfFilesExporter> {
         ReadTriplesDocumentsOptions batchSize(int batchSize);
 
         ReadTriplesDocumentsOptions partitionsPerForest(int partitionsPerForest);
+
+        ReadTriplesDocumentsOptions logProgress(int interval);
     }
 
     interface WriteRdfFilesOptions extends WriteFilesOptions<WriteRdfFilesOptions> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadDocumentsOptions.java
@@ -17,6 +17,8 @@ public interface ReadDocumentsOptions<T extends ReadDocumentsOptions> {
 
     T directory(String directory);
 
+    T logProgress(int interval);
+
     T transform(String transform);
 
     T transformParams(String delimitedNamesAndValues);

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ReadRowsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ReadRowsOptions.java
@@ -12,4 +12,6 @@ public interface ReadRowsOptions {
     ReadRowsOptions batchSize(int batchSize);
 
     ReadRowsOptions partitions(int partitions);
+
+    ReadRowsOptions logProgress(int interval);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/WriteDocumentsOptions.java
@@ -15,7 +15,7 @@ public interface WriteDocumentsOptions<T extends WriteDocumentsOptions> {
 
     T failedDocumentsPath(String path);
 
-    T logProgress(int numberOfDocuments);
+    T logProgress(int interval);
 
     T permissionsString(String rolesAndCapabilities);
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -79,8 +79,8 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         private String failedDocumentsPath;
 
         @CommandLine.Option(
-            names = "--log-progress",
-            description = "Log a count of documents written every time this many documents are written."
+            names = "--output-log-progress",
+            description = "Log a count of total documents written every time this many documents are written."
         )
         private int logProgress = 10000;
 
@@ -206,8 +206,8 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
         }
 
         @Override
-        public CopyWriteDocumentsParams logProgress(int numberOfDocuments) {
-            this.logProgress = numberOfDocuments;
+        public CopyWriteDocumentsParams logProgress(int interval) {
+            this.logProgress = interval;
             return this;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
@@ -100,6 +100,12 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
         @CommandLine.Option(names = "--partitions-per-forest", description = "Number of partition readers to create for each forest.")
         private int partitionsPerForest = 4;
 
+        @CommandLine.Option(
+            names = "--log-progress",
+            description = "Log a count of total triples read every time this many triples are read."
+        )
+        private int progressInterval = 10000;
+
         public Map<String, String> getQueryOptions() {
             return OptionsUtil.makeOptions(
                 Options.READ_TRIPLES_GRAPHS, graphs,
@@ -117,7 +123,8 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
                 Options.READ_TRIPLES_OPTIONS, options,
                 Options.READ_TRIPLES_BASE_IRI, baseIri,
                 Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest),
-                Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize)
+                Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
+                Options.READ_LOG_PROGRESS, OptionsUtil.intOption(progressInterval)
             );
         }
 
@@ -178,6 +185,12 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
         @Override
         public RdfFilesExporter.ReadTriplesDocumentsOptions partitionsPerForest(int partitionsPerForest) {
             this.partitionsPerForest = partitionsPerForest;
+            return this;
+        }
+
+        @Override
+        public ReadTriplesDocumentsOptions logProgress(int interval) {
+            this.progressInterval = interval;
             return this;
         }
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
@@ -59,6 +59,12 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     @CommandLine.Option(names = "--partitions-per-forest", description = "Number of partition readers to create for each forest.")
     private int partitionsPerForest = 4;
 
+    @CommandLine.Option(
+        names = "--log-progress",
+        description = "Log a count of total documents read every time this many documents are read."
+    )
+    private int progressInterval = 10000;
+
     public void verifyAtLeastOneQueryOptionIsSet(String verbForErrorMessage) {
         if (makeQueryOptions().isEmpty()) {
             throw new FluxException(String.format("Must specify at least one of the following for the documents to %s: " +
@@ -73,7 +79,8 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
             Options.READ_DOCUMENTS_TRANSFORM_PARAMS, transformParams,
             Options.READ_DOCUMENTS_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
             Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
-            Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest)
+            Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest),
+            Options.READ_LOG_PROGRESS, OptionsUtil.intOption(progressInterval)
         );
     }
 
@@ -120,6 +127,12 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     @Override
     public T directory(String directory) {
         this.directory = directory;
+        return (T) this;
+    }
+
+    @Override
+    public T logProgress(int interval) {
+        this.progressInterval = interval;
         return (T) this;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
@@ -35,12 +35,19 @@ public class ReadRowsParams implements ReadRowsOptions {
         "Increasing this may improve performance as the number of rows to read increases.")
     private int partitions;
 
+    @CommandLine.Option(
+        names = "--log-progress",
+        description = "Log a count of total rows read every time this many rows are read."
+    )
+    private int progressInterval = 100000;
+
     public Map<String, String> makeOptions() {
         return OptionsUtil.makeOptions(
             Options.READ_OPTIC_QUERY, query,
             Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
             Options.READ_PUSH_DOWN_AGGREGATES, disableAggregationPushDown ? "true" : null,
-            Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions)
+            Options.READ_NUM_PARTITIONS, OptionsUtil.intOption(partitions),
+            Options.READ_LOG_PROGRESS, OptionsUtil.intOption(progressInterval)
         );
     }
 
@@ -65,6 +72,12 @@ public class ReadRowsParams implements ReadRowsOptions {
     @Override
     public ReadRowsOptions partitions(int partitions) {
         this.partitions = partitions;
+        return this;
+    }
+
+    @Override
+    public ReadRowsOptions logProgress(int interval) {
+        this.progressInterval = interval;
         return this;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
@@ -46,9 +46,9 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
 
     @CommandLine.Option(
         names = "--log-progress",
-        description = "Log a count of documents written every time this many documents are written."
+        description = "Log a count of total documents written every time this many documents are written."
     )
-    private int logProgress = 10000;
+    private int progressInterval = 10000;
 
     @CommandLine.Option(
         names = "--permissions",
@@ -126,7 +126,7 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
             Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
             Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
             Options.WRITE_COLLECTIONS, collections,
-            Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(logProgress),
+            Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(progressInterval),
             Options.WRITE_PERMISSIONS, permissions,
             Options.WRITE_TEMPORAL_COLLECTION, temporalCollection,
             Options.WRITE_THREAD_COUNT, OptionsUtil.intOption(threadCount),
@@ -177,8 +177,8 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     }
 
     @Override
-    public T logProgress(int numberOfDocuments) {
-        this.logProgress = numberOfDocuments;
+    public T logProgress(int interval) {
+        this.progressInterval = interval;
         return (T) this;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -355,9 +355,9 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
 
         @CommandLine.Option(
             names = "--log-progress",
-            description = "Log a count of items processed every time this many items are processed."
+            description = "Log a count of total items processed every time this many items are processed."
         )
-        private int logProgress = 10000;
+        private int progressInterval = 10000;
 
         public void validateWriter() {
             Map<String, String> options = get();
@@ -379,7 +379,7 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
                 Options.WRITE_EXTERNAL_VARIABLE_DELIMITER, externalVariableDelimiter,
                 Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
                 Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
-                Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(logProgress)
+                Options.WRITE_LOG_PROGRESS, OptionsUtil.intOption(progressInterval)
             );
 
             if (writeVars != null) {
@@ -459,7 +459,7 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
 
         @Override
         public WriteOptions logProgress(int numberOfItems) {
-            this.logProgress = numberOfItems;
+            this.progressInterval = numberOfItems;
             return this;
         }
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
@@ -32,7 +32,9 @@ class ExportRdfFilesTest extends AbstractTest {
             "--graphs", "my-triples",
             "--path", tempDir.toFile().getAbsolutePath(),
             "--format", "nq",
-            "--file-count", "1"
+            "--file-count", "1",
+            "--batch-size", "5",
+            "--log-progress", "10"
         );
 
         File[] files = tempDir.toFile().listFiles();

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
@@ -170,10 +170,6 @@ class CopyOptionsTest extends AbstractOptionsTest {
                 count++;
             }
         }
-        // Add 1 to account for "--log-progress", which does not have the "output" prefix but is still treated as a
-        // "write" param. It does not have "output" prefixed to it since it is considered a "common" option that isn't
-        // yet supported for Export commands.
-        count++;
         return count;
     }
 }


### PR DESCRIPTION
log-progress is now discussed in the "Common Options" section. 

Next PR will remove the Spark progress bar as an option. 