### PR TITLE
MLE-15663 Improved docs for reprocessing

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -263,6 +263,20 @@ customize this file to meet your needs for logging.
 Flux is built on top of [Apache Spark](https://spark.apache.org/) and provides a number of command line options for 
 configuring the underlying Spark runtime environment used by Flux. 
 
+### Configuring the number of partitions 
+
+Flux uses Spark partitions to allow for data to be read and written in parallel. Each partition can be thought of as 
+a separate worker, operating in parallel with each other worker. 
+
+A number of partitions will be determined by the command that you run before it reads data. The nature of the data 
+source directly impacts the number of partitions that will be created. 
+
+If you find that an insufficient number of partitions are created - i.e. the writer phase of your Flux command is not
+sending as much data to MarkLogic as it could - consider using the `--repartition` option to force a number of 
+partitions to be created after the data has been read. The downside to using `--repartition` is that all the data must
+be read first. Generally, this option will help when data can be read quickly and the performance of writing can be 
+improved by using more partitions than were created when reading data.
+
 ### Configuring a Spark URL
 
 By default, Flux creates a Spark session with a master URL of `local[*]`. You can change this via the 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
@@ -37,6 +37,24 @@ class ReprocessTest extends AbstractTest {
         }
     }
 
+    @Test
+    void processBatchOfItems() {
+        run(
+            "reprocess",
+            "--connection-string", makeConnectionString(),
+            "--read-javascript", "var collection; cts.uris(null, null, cts.collectionQuery('author'))",
+            "--write-invoke", "/writeBatch.sjs",
+            "--batch-size", "10"
+        );
+
+        // reprocess-batch-test is used by writeBatch.sjs.
+        assertCollectionSize(
+            "writeBatch.sjs is expected to receive a comma-delimited list of URIs. This approach typically offers " +
+                "much better performance as it allows for the writer module to handle multiple items in a single call " +
+                "to MarkLogic as opposed to making one call per item.",
+            "reprocess-batch-test", 15);
+    }
+
     /**
      * This is used primarily for manual inspection of the progress messages. We don't yet have a reliable way of
      * asserting on log messages, so using manual inspection for now.

--- a/test-app/src/main/ml-modules/root/writeBatch.sjs
+++ b/test-app/src/main/ml-modules/root/writeBatch.sjs
@@ -1,0 +1,10 @@
+declareUpdate();
+
+for (var uri of URI.split(",")) {
+  xdmp.documentInsert(`/reprocess-test${uri}`, cts.doc(uri),
+    {
+      "collections": ["reprocess-batch-test"],
+      "permissions": [xdmp.permission("flux-test-role", "read"), xdmp.permission("flux-test-role", "update")]
+    }
+  )
+}


### PR DESCRIPTION
Added a test for writing a batch of URIs. We know it works already via the connector, but wanted to have it handy for reference here. 