### PR TITLE
Updated hadoop to 3.3.6 again

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9,10 +9,10 @@ Third Party Notices
 aws-java-sdk-s3 1.12.367 (Apache-2.0)
 hadoop-aws 3.3.6 (Apache-2.0)
 hadoop-client 3.3.6 (Apache-2.0)
-marklogic-spark-connector 2.3 (Apache-2.0)
+marklogic-spark-connector 2.3.0 (Apache-2.0)
 picocli 4.7.6 (Apache-2.0)
-spark-avro_2.12 3.4.1 (Apache-2.0)
-spark-sql_2.12 3.4.1 (Apache-2.0)
+spark-avro_2.12 3.4.3 (Apache-2.0)
+spark-sql_2.12 3.4.3 (Apache-2.0)
 
 Common Licenses
 
@@ -43,11 +43,11 @@ picocli 4.7.6 (Apache-2.0)
 https://repo1.maven.org/maven2/info/picocli/picocli
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 
-spark-avro_2.12 3.4.1 (Apache-2.0)
+spark-avro_2.12 3.4.3 (Apache-2.0)
 https://repo1.maven.org/maven2/org/apache/spark/spark-avro_2.12
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 
-spark-sql_2.12 3.4.1 (Apache-2.0)
+spark-sql_2.12 3.4.3 (Apache-2.0)
 https://repo1.maven.org/maven2/org/apache/spark/spark-sql_2.12
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 

--- a/docs/spark-integration.md
+++ b/docs/spark-integration.md
@@ -62,7 +62,7 @@ Per the [Spark Avro documentation](https://spark.apache.org/docs/latest/sql-data
 dependency is not included in Spark by default. If you wish to run either `import-avro-files` or `export-avro-files`
 with Flux and `spark-submit`, you must include the following line in your `spark-submit` invocation:
 
-    --packages org.apache.spark:spark-avro_2.12:3.4.1
+    --packages org.apache.spark:spark-avro_2.12:3.4.3
 
 You should change the version number of this dependency to match that of your Spark cluster.
 

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -14,27 +14,32 @@ configurations {
 }
 
 dependencies {
-  implementation("org.apache.spark:spark-sql_2.12:3.4.1") {
+  implementation("org.apache.spark:spark-sql_2.12:3.4.3") {
     // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
     exclude module: "rocksdbjni"
   }
   implementation "com.marklogic:marklogic-spark-connector:2.2-SNAPSHOT"
   implementation "info.picocli:picocli:4.7.6"
 
-  // Spark 3.4.1 depends on Hadoop 3.3.4, which depends on AWS SDK 1.12.262.
-  // We don't include the entire aws-java-sdk-bundle, as that clocks in as a single 380mb jar. We only need the S3
-  // portion of the AWS SDK. However, in version 1.12.262, the dynamodb SDK is also needed; otherwise, a
-  // NoClassDefFoundError occurs.
-  implementation("org.apache.hadoop:hadoop-aws:3.3.4") {
+  // Spark 3.4.3 depends on Hadoop 3.3.4, which depends on AWS SDK 1.12.262.
+  // However, hadoop-client 3.3.4 and hadoop-aws 3.3.4 are both flagged with a high security vulnerability -
+  // https://nvd.nist.gov/vuln/detail/CVE-2023-26031 . That CVE notes that the vulnerability is awaiting reanalysis.
+  // Out of the proverbial abundance of caution, 3.3.6 is being used for both hadoop-client and hadoop-aws.
+  // An issue for us though is that we end up mixing hadoop dependencies, as Spark 3.4.x depends on hadoop-client-api
+  // and hadoop-client-runtime 3.3.4. The alternative - forcing Spark 3.4.3 to use Hadoop 3.3.6 across the board -
+  // isn't appealing either as Spark 3.4.3 has Hadoop 3.3.4 as a direct dependency. We are choosing to only use
+  // Hadoop 3.3.6 for hadoop-aws and hadoop-client as that's what we've used for the vast majority of Flux testing.
+  implementation("org.apache.hadoop:hadoop-aws:3.3.6") {
+    // We don't include the entire aws-java-sdk-bundle, as that clocks in as a single 380mb jar. We only need the S3
+    // portion of the AWS SDK.
     exclude module: "aws-java-sdk-bundle"
   }
-  implementation "com.amazonaws:aws-java-sdk-s3:1.12.262"
-  implementation "com.amazonaws:aws-java-sdk-dynamodb:1.12.262"
+  implementation "com.amazonaws:aws-java-sdk-s3:1.12.367"
 
-  implementation "org.apache.hadoop:hadoop-client:3.3.4"
+  implementation "org.apache.hadoop:hadoop-client:3.3.6"
 
   // Spark doesn't include Avro support by default, so need to bring this in.
-  implementation "org.apache.spark:spark-avro_2.12:3.4.1"
+  implementation "org.apache.spark:spark-avro_2.12:3.4.3"
 
   testImplementation("com.marklogic:marklogic-junit5:1.4.0") {
     // Excluding Jackson so that we use whatever Jackson version is required by Spark.


### PR DESCRIPTION
This avoids a high CVE. Added notes to build.gradle to capture exactly what's going on.

Also updated Spark from 3.4.1 to 3.4.3. This has very little impact, which is expected as the bump to 3.4.3 for the connector project did not result in any failed tests.
