### PR TITLE
MLE-15766 Fixing issues with executable on Windows

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -258,6 +258,17 @@ Flux uses a [Log4J2 properties file](https://logging.apache.org/log4j/2.x/manual
 configure its logging. The file is located in a Flux installation at `./conf/log4j2.properties`. You are free to 
 customize this file to meet your needs for logging.
 
+## Configuring JVM options
+
+The `./bin/flux` and `./bin/flux.bat` executables both apply JVM options defined by the `JAVA_OPTS` and `FLUX_OPTS`
+environment variables. The [Java documentation](https://docs.oracle.com/en/java/javase/11/tools/java.html) provides
+a list of standard and extra options that affect how the JVM performs. 
+
+As a simple example, you could run the following on a Unix OS to configure the JVM to print its version information each
+time you run Flux:
+
+    export FLUX_OPTS=--show-version
+
 ## Advanced Spark options
 
 Flux is built on top of [Apache Spark](https://spark.apache.org/) and provides a number of command line options for 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,8 +48,7 @@ of demonstrating commands that utilize a [MarkLogic Optic query](https://docs.ma
 
 ## Usage
 
-You can run Flux without any options to see the list of available commands (all examples will assume the use of
-Unix; if you are on Windows, substitute `./bin/flux` with `bin/flux`). If you are using Flux to run these examples, 
+You can run Flux without any options to see the list of available commands. If you are using Flux to run these examples, 
 first change your current directory to where you extract Flux:
 
     cd flux-1.0.0.ea1
@@ -57,6 +56,13 @@ first change your current directory to where you extract Flux:
 And then run the Flux executable without any options:
 
     ./bin/flux
+
+If you are on Windows, run the following instead:
+
+    bin\flux
+
+This guide and the rest of the documentation at this site will assume the use of Unix and thus show `./bin/flux`. For
+Windows users, just change that to `bin\flux`.
 
 As shown in the usage, every command is invoked by specifying its name and one or more options required to run the
 command. To see the usage for a particular command, such as `import-files`, run:

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -117,6 +117,7 @@ application {
 // Modifies the application's start script to use our modified one that adds jars in the "./ext" folder to the classpath.
 startScripts {
   unixStartScriptGenerator.template = resources.text.fromFile('scripts/start-script.txt')
+  windowsStartScriptGenerator.template = resources.text.fromFile('scripts/start-script-windows.txt')
   applicationName = "flux"
 }
 

--- a/flux-cli/scripts/README.md
+++ b/flux-cli/scripts/README.md
@@ -1,1 +1,2 @@
-The modified `start-script.txt` file includes all jars in the ./ext folder in the CLI classpath.
+The modified script files use a wildcard to reference all jars in "lib" to avoid long
+classpath issues on Windows. They also include all user-provided jars in the "ext" folder.

--- a/flux-cli/scripts/original-start-script-windows.txt
+++ b/flux-cli/scripts/original-start-script-windows.txt
@@ -1,0 +1,99 @@
+@rem This is copied from Gradle 8.9.
+@rem Source: https://github.com/gradle/gradle/blob/97b759216ec04081be8f66fc6b0c50a27031f052/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt#L4
+@rem Original content follows.
+
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
+
+@if "%DEBUG%"=="" @echo off
+@rem ##########################################################################
+@rem
+@rem  ${applicationName} startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.\
+
+@rem This is normally unused
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%${appHomeRelativePath}
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=$classpath
+<% if ( mainClassName.startsWith('--module ') ) { %>set MODULE_PATH=$modulePath<% } %>
+
+@rem Execute ${applicationName}
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath "%CLASSPATH%" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>${mainClassName} %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if %ERRORLEVEL% equ 0 goto mainEnd
+
+:fail
+rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%${exitEnvironmentVar}%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/flux-cli/scripts/start-script-windows.txt
+++ b/flux-cli/scripts/start-script-windows.txt
@@ -1,0 +1,94 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
+
+@if "%DEBUG%"=="" @echo off
+@rem ##########################################################################
+@rem
+@rem  ${applicationName} startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.\
+
+@rem This is normally unused
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%${appHomeRelativePath}
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\\lib\\*;%APP_HOME%\\ext\\*;%APP_HOME%\\conf
+
+@rem Execute ${applicationName}
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath "%CLASSPATH%" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "%MODULE_PATH%" <% } %>${mainClassName} %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if %ERRORLEVEL% equ 0 goto mainEnd
+
+:fail
+rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%${exitEnvironmentVar}%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/flux-cli/scripts/start-script.txt
+++ b/flux-cli/scripts/start-script.txt
@@ -147,24 +147,7 @@ case "\$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$classpath
-<% if ( mainClassName.startsWith('--module ') ) { %>
-MODULE_PATH=$modulePath
-<% } %>
-
-# Add conf directory so user can edit the files in it.
-CLASSPATH=\${CLASSPATH}":\$APP_HOME/conf"
-
-# Add user stuff; we'll say "/ext" for now.
-for file in "\${APP_HOME}"/ext/*.jar
-do
-  if [ ! -z "\$CLASSPATH" ]; then
-    CLASSPATH=\${CLASSPATH}":"\$file
-  else
-    CLASSPATH=\$file
-  fi
-done
-
+CLASSPATH="lib/*:ext/*:conf"
 
 # Determine the Java command to use to start the JVM.
 if [ -n "\$JAVA_HOME" ] ; then


### PR DESCRIPTION
Using a wildcard for the classpath both fixes the issue with an overly long classpath on Windows and also makes it easy to include everything in "ext".

Also added a missing docs section for JVM options. 
