### PR TITLE
Allowing for newline symbols in values in options files

### DIFF
--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -67,6 +67,21 @@ You then reference the file via the `@` symbol followed by a filename:
 
 You can reference multiple files this way and also include additional options on the command line.
 
+Values in an options file can have whitespace in them, including newline symbols. If your values have whitespace, 
+put double or single quotes around them. Within quoted values, backslashes must be escaped with another backslash. 
+Newlines must then be represented by the same character you would use for a newline symbol in a normal value on the 
+command line. For example, most Unix shells require a `\` for allowing a value to continue onto the next line.
+
+As an example, MarkLogic Optic queries are often easier to read when stretched across multiple lines. 
+The following shows an example of such a query in an options file, using a `\` to let the query continue 
+to the next line:
+
+```
+--query
+"op.fromView('Example', 'Employees', '')\
+   .limit(10)"
+```
+
 ## Connecting to MarkLogic
 
 Every command in Flux will need to connect to a MarkLogic database, either for reading data or writing data or both. 

--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -84,7 +84,8 @@ public class Main {
             .setCaseInsensitiveEnumValuesAllowed(true)
             .setParameterExceptionHandler(new ShortErrorMessageHandler())
             .setExecutionStrategy(this::executeCommand)
-            .setUseSimplifiedAtFiles(true);
+            // Allows for values like Optic and serialized CTS queries to have newline symbols in them.
+            .setUseSimplifiedAtFiles(false);
     }
 
     private int executeCommand(CommandLine.ParseResult parseResult) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommandTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommandTest.java
@@ -41,7 +41,7 @@ class ExportDelimitedFilesCommandTest extends AbstractTest {
      * @throws IOException
      */
     @Test
-    void optionsFileWithSpacesInIt(@TempDir Path tempDir) throws IOException {
+    void optionsFileWithWhitespaceInValues(@TempDir Path tempDir) throws IOException {
         run(
             "export-delimited-files",
             "--connection-string", makeConnectionString(),

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -134,7 +134,7 @@ class ImportFilesTest extends AbstractTest {
             "--connection-string\n" +
             makeConnectionString() + "\n" +
             "--uri-replace\n" +
-            ".*/mixed-files,''";
+            "\".*/mixed-files,''\"";
         FileCopyUtils.copy(options.getBytes(), optionsFile);
 
         run(

--- a/flux-cli/src/test/resources/options-files/export-rows.txt
+++ b/flux-cli/src/test/resources/options-files/export-rows.txt
@@ -1,5 +1,6 @@
 --query
-op.fromView("Medical", "Authors", "").orderBy(op.asc(op.col("LastName")))
+"op.fromView('Medical', 'Authors', '')\
+   .orderBy(op.asc(op.col('LastName')))"
 --file-count
 1
 --partitions


### PR DESCRIPTION
Not sure why I had this set to the "simple" format before, as we absolutely want to allow newline symbols.
