### PR TITLE
Removing stacktrace from exception message

### DIFF
--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -130,7 +130,11 @@ application {
     '--add-opens', 'java.base/sun.util.calendar=ALL-UNNAMED',
 
     // For Spark's SerializationDebugger when using Java 17.
-    '--add-opens', 'java.base/sun.security.action=ALL-UNNAMED'
+    '--add-opens', 'java.base/sun.security.action=ALL-UNNAMED',
+
+    // Allows a reflective access by org.apache.spark.serializer.SerializationDebugger$ObjectStreamClassReflection .
+    // This warning otherwise shows on Java 11 but not Java 17.
+    "--add-opens", "java.base/java.io=ALL-UNNAMED"
   ]
 }
 


### PR DESCRIPTION
Spark sometimes includes the stacktrace in the exception message, which is a bad UX for a user that hasn't asked to see a stacktrace. Doing a pretty basic check to detect this scenario and only print the actual error message.
