### PR TITLE
Added note about running updateJavadoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,11 +151,10 @@ You can then go to http://localhost:4000 to view the docs.
 ## Updating the published Javadoc
 
 This project's Javadocs are being published via inclusion in the `docs/assets/javadoc` directory. To update these
-files after changing any of the classes in the `com.marklogic.flux.api` package, run the following:
+files after changing any of the classes in the `com.marklogic.flux.api` package, run the following, 
+**being sure to use Java 17** (Java 11 will include a JavaScript file that has a security vulnerability against it):
 
     ./gradlew updateJavadoc
-
-We will hopefully have this automated in the future so that this does not need to be done manually.
 
 ## Examining error reports
 

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -88,6 +88,8 @@ tasks.register("copyJavadoc", Copy) {
   rename { filename -> filename.endsWith(".md") ? filename.replace(".md", ".txt") : filename }
 }
 copyJavadoc.mustRunAfter deleteJavadoc, javadoc
+
+// Must run this task with Java 17.
 tasks.register("updateJavadoc")
 updateJavadoc.dependsOn deleteJavadoc, javadoc, copyJavadoc
 


### PR DESCRIPTION
Haven't found a way to force the use of Java 17 yet, and we only need it here, not for the whole project. It is possible that we could require Java 17 for all tasks, with Java 11 still being the level that the code is compiled at.
