### PR TITLE
MLE-17142 Added docs for gzip streaming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 name: flux
 
 services:
@@ -17,7 +15,7 @@ services:
       - 8007:8007
 
   marklogic:
-    image: "marklogicdb/marklogic-db:11.2.0-centos-1.1.2"
+    image: "progressofficial/marklogic-db:latest"
     platform: linux/amd64
     environment:
       - MARKLOGIC_INIT=true

--- a/docs/export/export-archives.md
+++ b/docs/export/export-archives.md
@@ -57,21 +57,21 @@ combination of those options as well, with the exception that `--query` will be 
 
 You must then use the `--path` option to specify a directory to write archive files to.
 
-### Windows-specific issues with zip files
+### Windows-specific issues with ZIP files
 
-In the likely event that you have one or more URIs with a forward slash - `/` - in them, then creating a zip file
+In the likely event that you have one or more URIs with a forward slash - `/` - in them, then creating a ZIP file
 with those URIs - which are used as the zip entry names - will produce confusing behavior on Windows. If you open the
-zip file via Windows Explorer, Windows will erroneously think the zip file is empty. If you open the zip file using
+ZIP file via Windows Explorer, Windows will erroneously think the file is empty. If you open the file using
 7-Zip, you will see a top-level entry named `_` if one or more of your URIs begin with a forward slash. These are
 effectively issues that only occur when viewing the file within Windows and do not reflect the actual contents of the
-zip file. The contents of the file are correct and if you were to import them with Flux via the `import-archive-files`
+ZIP file. The contents of the file are correct and if you were to import them with Flux via the `import-archive-files`
 command, you will get the expected results.
 
 
 ## Controlling document metadata
 
 Each exported document will have all of its associated metadata - collections, permissions, quality, properties, and 
-metadata values - included in an XML document in the archive zip file. You can control which types of metadata are
+metadata values - included in an XML document in the archive ZIP file. You can control which types of metadata are
 included with the `--categories` option. This option accepts a comma-delimited sequence of the following metadata types:
 
 - `collections`
@@ -120,13 +120,13 @@ bin\flux export-archives ^
 {% endtabs %}
 
 
-The encoding will be used for both document and metadata entries in each archive zip file. 
+The encoding will be used for both document and metadata entries in each archive ZIP file. 
 
 ## Exporting large binary files 
 
 Similar to [exporting large binary documents as files](export-documents.md), you can include large binary documents
 in archives by including the `--streaming` option introduced in Flux 1.1.0. When this option is set, Flux will stream 
-each document from MarkLogic directly to a zip file, thereby avoiding reading the contents of a file into memory.
+each document from MarkLogic directly to a ZIP file, thereby avoiding reading the contents of a file into memory.
 
 As streaming to an archive requires Flux to retrieve one document at a time from MarkLogic, you should not use this option
 when exporting smaller documents that can easily fit into the memory available to Flux.

--- a/docs/export/export-documents.md
+++ b/docs/export/export-documents.md
@@ -157,22 +157,22 @@ To use the above transform, verify that your user has been granted the MarkLogic
 
 ## Compressing content
 
-The `--compression` option is used to write files either to Gzip or ZIP files. 
+The `--compression` option is used to write files either to gzip or ZIP files. 
 
-To Gzip each file, include `--compression GZIP`. 
+To gzip each file, include `--compression GZIP`. 
 
-To write multiple files to one or more ZIP files, include `--compression ZIP`. A zip file will be created for each 
+To write multiple files to one or more ZIP files, include `--compression ZIP`. A ZIP file will be created for each 
 partition that was created when reading data via Optic. You can include `--zip-file-count 1` to force all documents to be
 written to a single ZIP file. See the below section on "Understanding partitions" for more information. 
 
-### Windows-specific issues with zip files
+### Windows-specific issues with ZIP files
 
-In the likely event that you have one or more URIs with a forward slash - `/` - in them, then creating a zip file
+In the likely event that you have one or more URIs with a forward slash - `/` - in them, then creating a ZIP file
 with those URIs - which are used as the zip entry names - will produce confusing behavior on Windows. If you open the
-zip file via Windows Explorer, Windows will erroneously think the zip file is empty. If you open the zip file using
+ZIP file via Windows Explorer, Windows will erroneously think the file is empty. If you open the file using
 7-Zip, you will see a top-level entry named `_` if one or more of your URIs begin with a forward slash. These are
 effectively issues that only occur when viewing the file within Windows and do not reflect the actual contents of the
-zip file. The contents of the file are correct and if you were to import them with Flux via the `import-files` 
+ZIP file. The contents of the file are correct and if you were to import them with Flux via the `import-files` 
 command, you will get the expected results.
 
 ## Specifying an encoding
@@ -207,7 +207,8 @@ bin\flux export-files ^
 MarkLogic's [support for large binary documents](https://docs.marklogic.com/guide/app-dev/binaries#id_93203) allows 
 for storing binary files of any size. To ensure that large binary documents can be exported to a file path, consider
 using the `--streaming` option introduced in Flux 1.1.0. When this option is set, Flux will stream each document
-from MarkLogic directly to the file path, thereby avoiding reading the contents of a file into memory.
+from MarkLogic directly to the file path, thereby avoiding reading the contents of a file into memory. This option 
+can be used when exporting documents to gzip or ZIP files as well via the `--compression zip` option. 
 
 As streaming to a file requires Flux to retrieve one document at a time from MarkLogic, you should not use this option
 when exporting smaller documents that can easily fit into the memory available to Flux. 
@@ -257,9 +258,9 @@ bin\flux export-files ^
 {% endtab %}
 {% endtabs %}
 
-The `./export` directory will have 12 zip files in it. This count is due to how Flux reads data from MarkLogic,
+The `./export` directory will have 12 ZIP files in it. This count is due to how Flux reads data from MarkLogic,
 which involves creating 4 partitions by default per forest in the MarkLogic database. The example application has 3
-forests in its content database, and thus 12 partitions are created, resulting in 12 separate zip files.
+forests in its content database, and thus 12 partitions are created, resulting in 12 separate ZIP files.
 
 You can use the `--partitions-per-forest` option to control how many partitions - and thus workers - read documents
 from each forest in your database:
@@ -292,7 +293,7 @@ bin\flux export-files ^
 {% endtabs %}
 
 
-This approach will produce 3 zip files - one per forest.
+This approach will produce 3 ZIP files - one per forest.
 
 You can also use the `--repartition` option, available on every command, to force the number of partitions used when
 writing data, regardless of how many were used to read the data:
@@ -323,7 +324,7 @@ bin\flux export-files ^
 {% endtabs %}
 
 
-This approach will produce a single zip file due to the use of a single partition when writing files. 
+This approach will produce a single ZIP file due to the use of a single partition when writing files. 
 The `--zip-file-count` option is effectively an alias for `--repartition`. Both options produce the same outcome. 
 `--zip-file-count` is included as a more intuitive option for the common case of configuring how many files should
 be written. 

--- a/docs/export/export-rdf.md
+++ b/docs/export/export-rdf.md
@@ -86,6 +86,6 @@ For some use cases involving exporting triples with their graphs to files contai
 reference the graph that each triple belongs to in MarkLogic. You can use `--graph-override` to specify an alternative
 graph value that will then be associated with every triple that Flux writes to a file. 
 
-## GZIP compression
+## gzip compression
 
-To compress each file written by Flux using GZIP, simply include `--gzip` as an option.
+To compress each file written by Flux using gzip, simply include `--gzip` as an option.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ application that can be deployed to your own instance of MarkLogic server. The a
 `marklogic-flux-getting-started-1.0.0.zip`. To use Flux with this example application, perform the following steps:
 
 1. Extract the `marklogic-flux-getting-started-1.0.0.zip` file to any location on your local filesystem.
-2. Run `cd marklogic-flux-getting-started-1.0.0` to change to the directory created by extracting the zip file.
+2. Run `cd marklogic-flux-getting-started-1.0.0` to change to the directory created by extracting the ZIP file.
 3. Create a file named `gradle-local.properties` and add `mlPassword=your MarkLogic admin user password` to it.
 4. Examine the contents of the `gradle.properties` file to ensure that the value of `mlHost` points to your MarkLogic 
 server and that the value of `mlRestPort` is a port available for a new MarkLogic app server to use.
@@ -192,7 +192,7 @@ thus producing hierarchical documents with nested data structures.
 Flux supports several commands for exporting data from MarkLogic, either as documents or rows, to a variety of 
 destinations. Commands that export documents support a variety of queries, while commands that export rows use the
 [MarkLogic Optic API](https://docs.marklogic.com/guide/app-dev/OpticAPI)
-to select rows. The following shows an example of exporting the 1000 employee documents to a single zip file:
+to select rows. The following shows an example of exporting the 1000 employee documents to a single ZIP file:
 
 {% tabs log %}
 {% tab log Unix %}

--- a/docs/import/common-import-features.md
+++ b/docs/import/common-import-features.md
@@ -45,7 +45,7 @@ reads from its associated data source. This option is supported for the followin
 - `import-aggregate-json-files`
 - `import-avro-files`
 - `import-delimited-files`
-- `import-files`, but only for JSON files and JSON entries in zip files.
+- `import-files`, but only for JSON files and JSON entries in ZIP files.
 - `import-jdbc`
 - `import-orc-files`
 - `import-parquet-files`

--- a/docs/import/import-files/aggregate-xml.md
+++ b/docs/import/import-files/aggregate-xml.md
@@ -107,7 +107,7 @@ example, adding the following would result in URIs of `/person/1.xml` and `/pers
 
 ## Compressed XML files
 
-Flux supports Gzip and ZIP aggregate XML files. Simply include the `--compression` option with a value of `GZIP` or 
+Flux supports gzip and ZIP aggregate XML files. Simply include the `--compression` option with a value of `GZIP` or 
 `ZIP`.
 
 ## Specifying an encoding

--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -117,7 +117,7 @@ The `import-avro-files` command supports aggregating related rows together to pr
 
 ## Reading compressed files
 
-Flux will automatically read files compressed with GZIP when they have a filename ending in `.gz`; you do not need to
+Flux will automatically read files compressed with gzip when they have a filename ending in `.gz`; you do not need to
 specify a compression option. As noted in the "Advanced options" section below, you can use `-Pcompression=` to
 explicitly specify a compression algorithm if Flux is not able to read your compressed files automatically.
 

--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -166,7 +166,7 @@ The `import-delimited-files` command supports aggregating related rows together 
 
 ## Reading compressed files
 
-Flux will automatically read files compressed with GZIP when they have a filename ending in `.gz`; you do not need to
+Flux will automatically read files compressed with gzip when they have a filename ending in `.gz`; you do not need to
 specify a compression option. As noted in the "Advanced options" section below, you can use `-Pcompression=` to
 explicitly specify a compression algorithm if Flux is not able to read your compressed files automatically.
 

--- a/docs/import/import-files/generic-files.md
+++ b/docs/import/import-files/generic-files.md
@@ -110,15 +110,18 @@ will result in a URI of `/my%20file.json`. This is due to an
 [issue in the MarkLogic REST API endpoint](https://docs.marklogic.com/REST/PUT/v1/documents) that will be resolved in 
 a future server release. 
 
-## Importing Gzip files
+## Importing gzip files
 
-To import Gzip files with each file being decompressed before written to MarkLogic, include the `--compression` option
-with a value of `GZIP`. You can also import Gzip files as-is - i.e. without decompressing them - by not including the
-`--compression` option.
- 
+To import gzip files with each file being decompressed before written to MarkLogic, include the `--compression` option
+with a value of `GZIP`. You can also import gzip files as-is - i.e. without decompressing them - by not including the
+`--compression` option. The `--streaming` option introduced in Flux 1.1.0 can also be used for very large gzip files
+that may not fit into the memory available to Flux or to MarkLogic.
+
 ## Importing ZIP files
 
 To import each entry in a ZIP file as a separate document, include the `--compression` option with a value of `ZIP`.
 Each document will have an initial URI based on both the absolute path of the ZIP file and the name of the ZIP entry. 
 You can also use the `--document-type` option as described above to force a document type for any entry that has a file
-extension not recognized by MarkLogic.
+extension not recognized by MarkLogic. The `--streaming` option introduced in Flux 1.1.0 can also be used for ZIP files
+containing very large binary files that may not fit into the memory available to Flux or to MarkLogic.
+

--- a/docs/import/import-files/json.md
+++ b/docs/import/import-files/json.md
@@ -128,7 +128,7 @@ bin\flux import-aggregate-json-files ^
 
 ## Reading compressed files
 
-Flux will automatically read files compressed with GZIP when they have a filename ending in `.gz`; you do not need to
+Flux will automatically read files compressed with gzip when they have a filename ending in `.gz`; you do not need to
 specify a compression option. As noted in the "Advanced options" section below, you can use `-Pcompression=` to
 explicitly specify a compression algorithm if Flux is not able to read your compressed files automatically.
 

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -117,7 +117,7 @@ The `import-orc-files` command supports aggregating related rows together to pro
 
 ## Reading compressed files
 
-Flux will automatically read files compressed with GZIP when they have a filename ending in `.gz`; you do not need to
+Flux will automatically read files compressed with gzip when they have a filename ending in `.gz`; you do not need to
 specify a compression option. As noted in the "Advanced options" section below, you can use `-Pcompression=` to
 explicitly specify a compression algorithm if Flux is not able to read your compressed files automatically.
 

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -117,7 +117,7 @@ The `import-parquet-files` command supports aggregating related rows together to
 
 ## Reading compressed files
 
-Flux will automatically read files compressed with GZIP when they have a filename ending in `.gz`; you do not need to
+Flux will automatically read files compressed with gzip when they have a filename ending in `.gz`; you do not need to
 specify a compression option. As noted in the "Advanced options" section below, you can use `-Pcompression=` to
 explicitly specify a compression algorithm if Flux is not able to read your compressed files automatically.
 

--- a/docs/import/import-files/rdf.md
+++ b/docs/import/import-files/rdf.md
@@ -78,4 +78,4 @@ are free to specify as many collections as you want in addition to the graph you
 
 ## Compressed files
 
-Flux supports Gzip and ZIP RDF files. Simply include the `--compression` option with a value of `GZIP` or `ZIP`. 
+Flux supports gzip and ZIP RDF files. Simply include the `--compression` option with a value of `GZIP` or `ZIP`. 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
@@ -97,8 +97,8 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
         @CommandLine.Mixin
         private S3Params s3Params = new S3Params();
 
-        @CommandLine.Option(names = "--compression", description = "Set to 'ZIP' to write one zip file per partition, " +
-            "or to 'GZIP' to GZIP each document file. " + OptionsUtil.VALID_VALUES_DESCRIPTION)
+        @CommandLine.Option(names = "--compression", description = "Set to 'ZIP' to write one ZIP file per partition, " +
+            "or to 'GZIP' to gzip each document file. " + OptionsUtil.VALID_VALUES_DESCRIPTION)
         private CompressionType compressionType;
 
         @CommandLine.Option(names = "--pretty-print", description = "Pretty-print the contents of JSON and XML files.")

--- a/flux-cli/src/test/java/com/marklogic/flux/api/GenericFilesExporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/GenericFilesExporterTest.java
@@ -29,7 +29,7 @@ class GenericFilesExporterTest extends AbstractTest {
             .execute();
 
         File dir = tempDir.toFile();
-        assertEquals(1, dir.listFiles().length, "Expecting 1 zip file due to the use of zipFileCount(1).");
+        assertEquals(1, dir.listFiles().length, "Expecting 1 ZIP file due to the use of zipFileCount(1).");
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesTest.java
@@ -93,10 +93,10 @@ class ExportFilesTest extends AbstractTest {
         );
 
         File dir = tempDir.toFile();
-        assertEquals(3, dir.listFiles().length, "Expecting 3 zip files - 1 for each forest in the test database, " +
+        assertEquals(3, dir.listFiles().length, "Expecting 3 ZIP files - 1 for each forest in the test database, " +
             "which is expected to have 3 forests.");
 
-        // Use our connector to read the 3 zip files, can then verify the dataset.
+        // Use our connector to read the 3 ZIP files, can then verify the dataset.
         List<Row> rows = newSparkSession().read().format("marklogic")
             .option(Options.READ_FILES_COMPRESSION, "zip")
             .load(dir.getAbsolutePath())
@@ -128,7 +128,7 @@ class ExportFilesTest extends AbstractTest {
         );
 
         File dir = tempDir.toFile();
-        assertEquals(5, dir.listFiles().length, "Should have 5 zip files instead of 3 due to the use of --zip-file-count.");
+        assertEquals(5, dir.listFiles().length, "Should have 5 ZIP files instead of 3 due to the use of --zip-file-count.");
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
@@ -183,12 +183,12 @@ class ImportAggregateJsonFilesTest extends AbstractTest {
     }
 
     /**
-     * This documents that if a user has a zip file, and we would normally use a Spark data source to read the type files
-     * inside the zip, we unfortunately cannot do that as Spark doesn't have any support for zip files. Databricks
+     * This documents that if a user has a ZIP file, and we would normally use a Spark data source to read the type files
+     * inside the ZIP, we unfortunately cannot do that as Spark doesn't have any support for ZIP files. Databricks
      * documentation - https://docs.databricks.com/en/files/unzip-files.html - confirms this, noting that if a user has
-     * a zip file, they should first expand it.
+     * a ZIP file, they should first expand it.
      * <p>
-     * So for zip files, the best we can do is use our own reader, which is limited to reading each file as a "file row"
+     * So for ZIP files, the best we can do is use our own reader, which is limited to reading each file as a "file row"
      * and then writing it as a document to MarkLogic. Which means that a user cannot use a feature like
      * "--uri-template", as that depends on having values in columns that can be referenced by the template. We will
      * hopefully be enhancing this in a future story - specifically, by enhancing the URI template feature to work on


### PR DESCRIPTION
Also made use of "ZIP" and "gzip" consistent in the docs and the tests.

And bumped the docker-compose file to use the official MarkLogic images.

Otherwise, no functional changes here, just docs.
