### PR TITLE
Bumped to Spark 3.5.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,7 @@ Set `SPARK_HOME` to the location of Spark - e.g. `/Users/myname/.sdkman/candidat
 
 Next, start a Spark master node:
 
-    cd $SPARK_HOME/bin
+    cd $SPARK_HOME/sbin
     start-master.sh
 
 You will need the address at which the Spark master node can be reached. To find it, open the log file that Spark
@@ -264,7 +264,7 @@ cluster:
 
 ```
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
---master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.0.0-all.jar \
+--master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.1.0-SNAPSHOT-all.jar \
 import-files --path /Users/rudin/workspace/flux/flux-cli/src/test/resources/mixed-files \
 --connection-string "admin:admin@localhost:8000" \
 --preview 5 --preview-drop content
@@ -281,7 +281,7 @@ to something you can access):
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
 --packages org.apache.hadoop:hadoop-aws:3.3.4,org.apache.hadoop:hadoop-client:3.3.4 \
 --master spark://NYWHYC3G0W:7077 \
-flux-cli/build/libs/marklogic-flux-1.0.0-all.jar \
+flux-cli/build/libs/marklogic-flux-1.1.0-SNAPSHOT-all.jar \
 import-files --path "s3a://changeme/" \
 --connection-string "admin:admin@localhost:8000" \
 --s3-add-credentials \

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -13,7 +13,7 @@ configurations {
 }
 
 dependencies {
-  implementation("org.apache.spark:spark-sql_2.12:3.4.3") {
+  implementation("org.apache.spark:spark-sql_2.12:3.5.3") {
     // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
     exclude module: "rocksdbjni"
   }
@@ -44,7 +44,7 @@ dependencies {
   implementation "org.apache.hadoop:hadoop-client:3.3.4"
 
   // Spark doesn't include Avro support by default, so need to bring this in.
-  implementation "org.apache.spark:spark-avro_2.12:3.4.3"
+  implementation "org.apache.spark:spark-avro_2.12:3.5.3"
 
   testImplementation("com.marklogic:marklogic-junit5:1.4.0") {
     // Excluding Jackson so that we use whatever Jackson version is required by Spark.

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -241,9 +241,9 @@ class ImportDelimitedFilesTest extends AbstractTest {
         ));
 
         assertCollectionSize("delimited-test", 0);
-        assertTrue(stderr.contains("Command failed, cause: [MALFORMED_RECORD_IN_PARSING]"), "The command should " +
+        assertTrue(stderr.contains("Command failed, cause: [MALFORMED_RECORD_IN_PARSING"), "The command should " +
             "have failed due to --abort-on-read-failure being included. This should result in the 'mode' option being " +
-            "set to FAILFAST.");
+            "set to FAILFAST. Actual stderr: " + stderr);
     }
 
     @Test


### PR DESCRIPTION
All tests passing in both the connector project and Flux repo. Verified manually with spark-submit too.
