### PR TITLE
MLE-17429 Added --no-snapshot

### DIFF
--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
     exclude module: "rocksdbjni"
   }
-  implementation "com.marklogic:marklogic-spark-connector:2.4.1"
+  implementation "com.marklogic:marklogic-spark-connector:2.4-SNAPSHOT"
   implementation "info.picocli:picocli:4.7.6"
 
   // Spark 3.4.3 depends on Hadoop 3.3.4, which depends on AWS SDK 1.12.262. As of August 2024, all public releases of

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -279,7 +279,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
     }
 
     @CommandLine.Mixin
-    private CopyReadDocumentsParams readParams = new CopyReadDocumentsParams();
+    protected final CopyReadDocumentsParams readParams = new CopyReadDocumentsParams();
 
     @CommandLine.Mixin
     protected final CopyWriteDocumentsParams writeParams = new CopyWriteDocumentsParams();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
@@ -106,6 +106,12 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
         )
         private int progressInterval = 10000;
 
+        @CommandLine.Option(
+            names = "--no-snapshot",
+            description = "Read data from MarkLogic at multiple points in time instead of using a consistent snapshot."
+        )
+        private boolean noSnapshot;
+
         public Map<String, String> getQueryOptions() {
             return OptionsUtil.makeOptions(
                 Options.READ_TRIPLES_GRAPHS, graphs,
@@ -113,7 +119,8 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
                 Options.READ_TRIPLES_QUERY, query,
                 Options.READ_TRIPLES_STRING_QUERY, stringQuery,
                 Options.READ_TRIPLES_URIS, uris,
-                Options.READ_TRIPLES_DIRECTORY, directory
+                Options.READ_TRIPLES_DIRECTORY, directory,
+                Options.READ_SNAPSHOT, noSnapshot ? "false" : null
             );
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
@@ -65,6 +65,12 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     )
     private int progressInterval = 10000;
 
+    @CommandLine.Option(
+        names = "--no-snapshot",
+        description = "Read data from MarkLogic at multiple points in time instead of using a consistent snapshot."
+    )
+    private boolean noSnapshot;
+
     public void verifyAtLeastOneQueryOptionIsSet(String verbForErrorMessage) {
         if (makeQueryOptions().isEmpty()) {
             throw new FluxException(String.format("Must specify at least one of the following for the documents to %s: " +
@@ -80,7 +86,8 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
             Options.READ_DOCUMENTS_TRANSFORM_PARAMS_DELIMITER, transformParamsDelimiter,
             Options.READ_BATCH_SIZE, OptionsUtil.intOption(batchSize),
             Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST, OptionsUtil.intOption(partitionsPerForest),
-            Options.READ_LOG_PROGRESS, OptionsUtil.intOption(progressInterval)
+            Options.READ_LOG_PROGRESS, OptionsUtil.intOption(progressInterval),
+            Options.READ_SNAPSHOT, noSnapshot ? "false" : null
         );
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
@@ -60,11 +60,11 @@ class ExportRdfFilesTest extends AbstractTest {
     }
 
     @Test
-    void missingQueryInput(@TempDir Path tempDir) {
+    void missingQueryInput() {
         String stderr = runAndReturnStderr(() -> run(
             "export-rdf-files",
             "--connection-string", makeConnectionString(),
-            "--path", tempDir.toFile().getAbsolutePath()
+            "--path", "path-doesnt-matter-for-this-test"
         ));
 
         assertTrue(stderr.contains("Must specify at least one of the following options: " +

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
@@ -30,6 +30,21 @@ class CopyOptionsTest extends AbstractOptionsTest {
     }
 
     @Test
+    void noSnapshot() {
+        CopyCommand command = (CopyCommand) getCommand("copy",
+            "--connection-string", "test:test@test:8000",
+            "--output-connection-string", "user:password@host:8000",
+            "--collections", "anything",
+            "--no-snapshot"
+        );
+
+        assertOptions(
+            command.readParams.makeOptions(),
+            Options.READ_SNAPSHOT, "false"
+        );
+    }
+
+    @Test
     void useRegularConnectionParamsIfNoOutputConnectionParams() {
         CopyCommand command = (CopyCommand) getCommand("copy",
             "--connection-string", "test:test@test:8000",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportFilesOptionsTest.java
@@ -66,11 +66,13 @@ class ExportFilesOptionsTest extends AbstractOptionsTest {
             "--connection-string", "test:test@host:8000",
             "--collections", "anything",
             "--path", "anywhere",
-            "--streaming"
+            "--streaming",
+            "--no-snapshot"
         );
 
         Map<String, String> readOptions = command.buildReadOptions();
         assertEquals("true", readOptions.get(Options.STREAM_FILES));
+        assertEquals("false", readOptions.get(Options.READ_SNAPSHOT));
         assertEquals("anything", readOptions.get(Options.READ_DOCUMENTS_COLLECTIONS));
 
         Map<String, String> writeOptions = command.buildWriteOptions();

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportRdfFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportRdfFilesOptionsTest.java
@@ -30,7 +30,8 @@ class ExportRdfFilesOptionsTest extends AbstractOptionsTest {
             "--partitions-per-forest", "2",
             "--path", "anywhere",
             "--format", "trig",
-            "--graph-override", "use-this-graph"
+            "--graph-override", "use-this-graph",
+            "--no-snapshot"
         );
 
         Map<String, String> options = command.readParams.get();
@@ -44,6 +45,7 @@ class ExportRdfFilesOptionsTest extends AbstractOptionsTest {
         assertEquals("my-base-iri", options.get(Options.READ_TRIPLES_BASE_IRI));
         assertEquals("50", options.get(Options.READ_BATCH_SIZE));
         assertEquals("2", options.get(Options.READ_DOCUMENTS_PARTITIONS_PER_FOREST));
+        assertEquals("false", options.get(Options.READ_SNAPSHOT));
 
         options = command.writeParams.get();
         assertEquals("trig", options.get(Options.WRITE_RDF_FILES_FORMAT));

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.2-SNAPSHOT
+version=1.1-SNAPSHOT
 
 # Define these on the command line to publish to OSSRH
 # See https://central.sonatype.org/publish/publish-gradle/#credentials for more information


### PR DESCRIPTION
For commands that export documents and don't necessarily need a consistent snapshot.

