### PR TITLE
Making splitter available on all import commands

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -118,9 +118,6 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
 
         private DocumentType documentType;
 
-        @CommandLine.Mixin
-        private SplitterParams splitterParams = new SplitterParams();
-
         @Override
         @CommandLine.Option(
             names = "--document-type",
@@ -133,11 +130,9 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
 
         @Override
         public Map<String, String> makeOptions() {
-            Map<String, String> options = OptionsUtil.addOptions(super.makeOptions(),
+            return OptionsUtil.addOptions(super.makeOptions(),
                 Options.WRITE_DOCUMENT_TYPE, documentType != null ? documentType.name() : null
             );
-            options.putAll(splitterParams.makeOptions());
-            return options;
         }
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParams.java
@@ -120,10 +120,13 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
     )
     private String uriTemplate;
 
+    @CommandLine.Mixin
+    private SplitterParams splitterParams = new SplitterParams();
+
     private boolean streaming;
 
     public Map<String, String> makeOptions() {
-        return OptionsUtil.makeOptions(
+        Map<String, String> options = OptionsUtil.makeOptions(
             Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
             Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
             Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
@@ -142,6 +145,9 @@ public class WriteDocumentParams<T extends WriteDocumentsOptions> implements Wri
             Options.WRITE_URI_TEMPLATE, uriTemplate,
             Options.STREAM_FILES, streaming ? "true" : null
         );
+
+        options.putAll(splitterParams.makeOptions());
+        return options;
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParamsImpl.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteDocumentParamsImpl.java
@@ -3,19 +3,10 @@
  */
 package com.marklogic.flux.impl.importdata;
 
-import picocli.CommandLine;
-
-import java.util.Map;
-
+/**
+ * Class exists solely to avoid Sonar warnings of "Provide the parametrized type for this generic" when command
+ * classes use WriteDocumentParams directly. There's probably a better way to avoid that warning (without suppressing
+ * it) but don't know it yet.
+ */
 public class WriteDocumentParamsImpl extends WriteDocumentParams<WriteDocumentParamsImpl> {
-
-    @CommandLine.Mixin
-    private SplitterParams splitterParams = new SplitterParams();
-
-    @Override
-    public Map<String, String> makeOptions() {
-        Map<String, String> options = super.makeOptions();
-        options.putAll(splitterParams.makeOptions());
-        return options;
-    }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
@@ -39,16 +39,12 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
     )
     private boolean ignoreNullFields;
 
-    @CommandLine.Mixin
-    private SplitterParams splitterParams = new SplitterParams();
-
     @Override
     public Map<String, String> makeOptions() {
         Map<String, String> options = super.makeOptions();
         if (ignoreNullFields) {
             options.put(Options.WRITE_JSON_SERIALIZATION_OPTION_PREFIX + "ignoreNullFields", "true");
         }
-        options.putAll(splitterParams.makeOptions());
         return OptionsUtil.addOptions(options,
             Options.WRITE_JSON_ROOT_NAME, jsonRootName,
             Options.WRITE_XML_ROOT_NAME, xmlRootName,

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
@@ -142,4 +142,27 @@ class ImportRdfFilesTest extends AbstractTest {
             "Unexpected stderr: " + stderr);
         assertCollectionSize("my-triples", 0);
     }
+
+    /**
+     * The splitter capability is not expected to be useful on managed triples documents. But allowing for splitter
+     * options to be set greatly simplifies both the set of import commands and the import API interfaces - i.e. putting
+     * SplitterParams in WriteDocumentParams is much easier to maintain. It's also a little simpler to say that
+     * splitting is supported on all import commands instead of all import commands except RDF.
+     */
+    @Test
+    void splitterSmokeTest() {
+        run(
+            "import-rdf-files",
+            "--path", "src/test/resources/rdf/englishlocale.ttl",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "my-triples",
+            "--splitter-xml-path", "/text"
+        );
+
+        assertCollectionSize(
+            "The default MarkLogic graph collection should contain a sem:graph document and a single managed " +
+                "triples document containing the imported triples.", DEFAULT_MARKLOGIC_GRAPH, 2
+        );
+    }
 }


### PR DESCRIPTION
This is more to simplify the import command hierarchy and also the import API hierarchy. There's no technical issue with splitting on managed triples documents, it just won't likely be used, but that's fine.
