### PR TITLE
MLE-17497 Wrapped up splitter docs

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -81,3 +81,11 @@ The `copy` command supports many of the same options as the [import commands](im
 writing documents. Similar to the output connection options, each option for controlling how documents are written
 is prefixed with `output`. For example, to specify collections for the documents, `--output-collections` is used instead
 of `--collections`.
+
+## Splitting text in documents
+
+While writing documents during the `copy` operation, Flux supports splitting the text in a document into chunks. This
+can be very useful for supporting
+[retrieval-augmented generation, or RAG](https://en.wikipedia.org/wiki/Retrieval-augmented_generation) use cases with
+MarkLogic, particularly when you have already imported the data that you now wish to split. 
+Please see [the guide on splitting](import/splitting.md) for more information.

--- a/docs/import/common-import-features.md
+++ b/docs/import/common-import-features.md
@@ -107,6 +107,12 @@ The following shows an example of each option:
 --temporal-collection my-temporal-data
 ```
 
+## Splitting content
+
+Flux supports splitting the text in a document into chunks, which can be very useful for supporting 
+[retrieval-augmented generation, or RAG](https://en.wikipedia.org/wiki/Retrieval-augmented_generation) use cases with
+MarkLogic. Please see [the guide on splitting](splitting.md) for more information.
+
 ## Transforming content
 
 For each import command, you can apply a [MarkLogic REST transform](https://docs.marklogic.com/guide/rest-dev/transforms)

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SplitterParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SplitterParams.java
@@ -67,52 +67,52 @@ public class SplitterParams implements SplitterOptions {
     private Map<String, String> customClassOptions = new HashMap<>();
 
     @CommandLine.Option(
-        names = "--splitter-output-max-chunks",
+        names = "--splitter-sidecar-max-chunks",
         description = "Maximum number of chunks to write to a chunk document. If not specified or set to zero, " +
             "chunks will be written to the source document."
     )
     private int maxChunks;
 
     @CommandLine.Option(
-        names = "--splitter-output-document-type",
+        names = "--splitter-sidecar-document-type",
         description = "Type of chunk documents to write."
     )
     private ChunkDocumentType documentType;
 
     @CommandLine.Option(
-        names = "--splitter-output-collections",
+        names = "--splitter-sidecar-collections",
         description = "Comma-delimited sequence of collection names to add to each chunk document - e.g. collection1,collection2."
     )
     private String collections;
 
     @CommandLine.Option(
-        names = "--splitter-output-permissions",
+        names = "--splitter-sidecar-permissions",
         description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to each chunk document - e.g. role1,read,role2,update,role3,execute."
     )
     private String permissions;
 
     @CommandLine.Option(
-        names = "--splitter-output-root-name",
+        names = "--splitter-sidecar-root-name",
         description = "Name of a root field to add to each JSON chunks document, or name of the root element for each XML chunks document."
     )
     private String rootName;
 
     @CommandLine.Option(
-        names = "--splitter-output-uri-prefix",
+        names = "--splitter-sidecar-uri-prefix",
         description = "String to prepend to each chunks document URI. If set, a UUID will be generated and appended " +
             "to this prefix."
     )
     private String uriPrefix;
 
     @CommandLine.Option(
-        names = "--splitter-output-uri-suffix",
+        names = "--splitter-sidecar-uri-suffix",
         description = "String to append to each chunks document URI. If set, a UUID will be generated and prepended " +
             "to this suffix."
     )
     private String uriSuffix;
 
     @CommandLine.Option(
-        names = "--splitter-output-xml-namespace",
+        names = "--splitter-sidecar-xml-namespace",
         description = "Namespace for the root element of chunk XML documents."
     )
     private String xmlNamespace;

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesOptionsTest.java
@@ -85,14 +85,14 @@ class ImportFilesOptionsTest extends AbstractOptionsTest {
             "--splitter-regex", "word",
             "--splitter-join-delimiter", "aaa",
             "--splitter-text",
-            "--splitter-output-max-chunks", "10",
-            "--splitter-output-document-type", "xml",
-            "--splitter-output-collections", "c1,c2",
-            "--splitter-output-permissions", "role1,read,role2,update",
-            "--splitter-output-root-name", "root1",
-            "--splitter-output-uri-prefix", "/prefix",
-            "--splitter-output-uri-suffix", ".json",
-            "--splitter-output-xml-namespace", "org:example"
+            "--splitter-sidecar-max-chunks", "10",
+            "--splitter-sidecar-document-type", "xml",
+            "--splitter-sidecar-collections", "c1,c2",
+            "--splitter-sidecar-permissions", "role1,read,role2,update",
+            "--splitter-sidecar-root-name", "root1",
+            "--splitter-sidecar-uri-prefix", "/prefix",
+            "--splitter-sidecar-uri-suffix", ".json",
+            "--splitter-sidecar-xml-namespace", "org:example"
         );
 
         assertOptions(command.getWriteParams().makeOptions(),


### PR DESCRIPTION
Decided to rename "splitter-output" to "splitter-sidecar" since all the options are specific to sidecar documents. Probably going to rename the options in the connector too, which will then force changes here too. 