### PR TITLE
Renamed --splitter-custom-option to -S

### DIFF
--- a/docs/import/splitting.md
+++ b/docs/import/splitting.md
@@ -179,7 +179,7 @@ to the Flux classpath.
 Finally, to use your custom splitter, use the following command line options:
 
 1. `--splitter-custom-class` must specify the full class name of your splitter implementation - e.g. `org.example.MySplitter`.
-2. Use `--splitter-custom-option key=value` as many times as you wish to pass key/value pairs to the constructor of your splitter. 
+2. Use `-Skey=value` as many times as you wish to pass key/value pairs to the constructor of your splitter. 
 
 ## Configuring how chunks are stored
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SplitterParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SplitterParams.java
@@ -72,9 +72,9 @@ public class SplitterParams implements SplitterOptions {
     private String customClass;
 
     @CommandLine.Option(
-        names = "--splitter-custom-option",
+        names = "-S",
         description = "Key/value pairs, delimited by an equals sign, that are passed to the constructor of the " +
-            "class specified by --splitter-custom-class - e.g. --splitter-custom-option key=value."
+            "class specified by --splitter-custom-class - e.g. -Skey=value."
     )
     private Map<String, String> customClassOptions = new HashMap<>();
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/splitter/ImportAndSplitFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/splitter/ImportAndSplitFilesTest.java
@@ -131,12 +131,14 @@ class ImportAndSplitFilesTest extends AbstractTest {
             "--uri-replace", ".*/json-files,''",
             "--splitter-json-pointer", "/text",
             "--splitter-custom-class", "com.marklogic.flux.impl.importdata.splitter.CustomSplitter",
-            "--splitter-custom-option", "textToReturn=just testing"
+            // This also shows how a map param can have an equals symbol in the value; picocli only looks for the first
+            // equals symbol to use as a key/value separator.
+            "-StextToReturn=just=testing"
         );
 
         ArrayNode chunks = (ArrayNode) readJsonDocument("/java-client-intro.json").get("chunks");
         assertEquals(1, chunks.size());
-        assertEquals("just testing", chunks.get(0).get("text").asText(), "Verifying that the custom " +
+        assertEquals("just=testing", chunks.get(0).get("text").asText(), "Verifying that the custom " +
             "splitter is used; it should return the text specified by the 'textToReturn' custom class option.");
     }
 
@@ -161,11 +163,11 @@ class ImportAndSplitFilesTest extends AbstractTest {
                 "--permissions", DEFAULT_PERMISSIONS,
                 "--splitter-json-pointer", "/text",
                 "--splitter-custom-class", "com.marklogic.flux.impl.importdata.splitter.CustomSplitter",
-                "--splitter-custom-option", "missing an equals"
+                "-Smissing an equals"
             ),
             // This is the default picocli error message for an invalid map option. It's a little technical, but seems
             // reasonable enough for a user to be able to fix their mistake.
-            "Value for option '--splitter-custom-option' (<String=String>) should be in KEY=VALUE format but was missing an equals"
+            "Value for option '-S' (<String=String>) should be in KEY=VALUE format but was missing an equals"
         );
     }
 }


### PR DESCRIPTION
This is consistent with other map params that accept custom key/value pairs.
