### PR TITLE
MLE-17733 Providing additional context for JDBC error messages

### DIFF
--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ConfigureSparkMasterUrlTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ConfigureSparkMasterUrlTest.java
@@ -53,6 +53,6 @@ class ConfigureSparkMasterUrlTest extends AbstractTest {
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS
-        ), "Command failed, cause: Could not parse Master URL: 'just-not-valid-at-all'");
+        ), "Error: Could not parse Master URL: 'just-not-valid-at-all'");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -71,7 +71,7 @@ class HandleErrorTest extends AbstractTest {
                 "--path", "/not/valid",
                 "--connection-string", makeConnectionString()
             ),
-            "Command failed, cause: AnalysisException: [PATH_NOT_FOUND] Path does not exist: file:/not/valid."
+            "Error: AnalysisException: [PATH_NOT_FOUND] Path does not exist: file:/not/valid."
         );
     }
 
@@ -89,7 +89,7 @@ class HandleErrorTest extends AbstractTest {
                 // via a logger.
                 "--stacktrace"
             ),
-            "Command failed, cause: Local message: failed to apply resource at documents"
+            "Command failed, error: Local message: failed to apply resource at documents"
         );
     }
 
@@ -105,7 +105,7 @@ class HandleErrorTest extends AbstractTest {
                 "--stacktrace",
                 "--abort-on-write-failure"
             ),
-            "Command failed, cause: Local message: failed to apply resource at documents"
+            "Command failed, error: Local message: failed to apply resource at documents"
         );
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportAvroFilesTest.java
@@ -58,7 +58,7 @@ class ExportAvroFilesTest extends AbstractTest {
             "-PavroSchema=intentionally-invalid"
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: SchemaParseException: com.fasterxml.jackson.core.JsonParseException"),
+        assertTrue(stderr.contains("Error: SchemaParseException: com.fasterxml.jackson.core.JsonParseException"),
             "This test is verifying that -P params are passed to the Avro data source. Since an invalid " +
                 "Avro schema is being set, this test expects an error. Unexpected stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcTest.java
@@ -90,8 +90,23 @@ class ExportJdbcTest extends AbstractExportJdbcTest {
             "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
             "--jdbc-driver", "not.valid.driver.name",
             "--table", EXPORTED_TABLE_NAME
-        ), "Command failed, cause: Unable to load class: not.valid.driver.name; " +
+        ), "Error: Unable to load class: not.valid.driver.name; " +
             "for a JDBC driver, ensure you are specifying the fully-qualified class name for your JDBC driver.");
+    }
+
+    @Test
+    void databaseSpecificErrorMessage() {
+        // JDBC drivers may provide cryptic error messages. For any SQLException-based exception coming from a JDBC
+        // driver, we want to make it clear that the error is specific to the user's external database and point them
+        // in the right direction of trying to understand the error message.
+        assertStderrContains(() -> run(
+            "export-jdbc",
+            "--connection-string", makeConnectionString(),
+            "--query", READ_AUTHORS_OPTIC_QUERY,
+            "--jdbc-url", PostgresUtil.URL_WITH_AUTH,
+            "--jdbc-driver", PostgresUtil.DRIVER,
+            "--table", "hyphens-are-not-allowed-by-postgres"
+        ), "The error is from the database you are connecting to via the configured JDBC driver.");
     }
 
     private void exportFifteenAuthors() {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesTest.java
@@ -267,7 +267,7 @@ class ImportAggregateJsonFilesTest extends AbstractTest {
         ));
 
         assertCollectionSize("delimited-json-test", 0);
-        assertTrue(stderr.contains("Command failed, cause: Invalid UTF-8 start"), "The command should have failed " +
+        assertTrue(stderr.contains("Error: Invalid UTF-8 start"), "The command should have failed " +
             "due to the invalid single-xml.zip file being included along with --abort-on-read-failure being " +
             "included as well; actual stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesTest.java
@@ -211,7 +211,7 @@ class ImportAggregateXmlFilesTest extends AbstractTest {
             "--collections", "agg-xml"
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: Unable to read XML from file"),
+        assertTrue(stderr.contains("Error: Unable to read XML from file"),
             "With --abort-on-read-failure included, the command should fail if it cannot read a file; stderr: " + stderr);
         assertCollectionSize("agg-xml", 0);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesTest.java
@@ -111,7 +111,7 @@ class ImportArchiveFilesTest extends AbstractTest {
         ));
 
         assertTrue(
-            stderr.contains("Command failed, cause: Could not find metadata entry for entry test/1.xml in file"),
+            stderr.contains("Error: Could not find metadata entry for entry test/1.xml in file"),
             "Unexpected stderr: " + stderr
         );
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -176,7 +176,7 @@ class ImportAvroFilesTest extends AbstractTest {
         ));
 
         System.out.println(stderr);
-        assertTrue(stderr.contains("Command failed, cause: Not an Avro data file"), "Actual stderr: " + stderr);
+        assertTrue(stderr.contains("Error: Not an Avro data file"), "Actual stderr: " + stderr);
     }
 
     private void verifyColorDoc(String uri, String expectedNumber, String expectedColor, boolean expectedFlag) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesTest.java
@@ -256,7 +256,7 @@ class ImportDelimitedFilesTest extends AbstractTest {
         ));
 
         assertCollectionSize("delimited-test", 0);
-        assertTrue(stderr.contains("Command failed, cause: [MALFORMED_RECORD_IN_PARSING"), "The command should " +
+        assertTrue(stderr.contains("Error: [MALFORMED_RECORD_IN_PARSING"), "The command should " +
             "have failed due to --abort-on-read-failure being included. This should result in the 'mode' option being " +
             "set to FAILFAST. Actual stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -271,7 +271,7 @@ class ImportFilesTest extends AbstractTest {
             "--compression", "gzip"
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: Unable to read file at"), "With --abort-read-on-failure, " +
+        assertTrue(stderr.contains("Error: Unable to read file at"), "With --abort-read-on-failure, " +
             "the command should fail when it encounters an invalid gzipped file.");
         assertCollectionSize("files", 0);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcTest.java
@@ -116,7 +116,7 @@ class ImportJdbcTest extends AbstractTest {
             "--jdbc-driver", "not.valid.driver.value",
             "--connection-string", makeConnectionString(),
             "--query", "select * from customer"
-        ), "Command failed, cause: Unable to load class: not.valid.driver.value; " +
+        ), "Error: Unable to load class: not.valid.driver.value; " +
             "for a JDBC driver, ensure you are specifying the fully-qualified class name for your JDBC driver.");
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesTest.java
@@ -103,7 +103,7 @@ class ImportMlcpArchiveFilesTest extends AbstractTest {
             "--connection-string", makeConnectionString()
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: Unable to read metadata for entry: goodbye.json"),
+        assertTrue(stderr.contains("Error: Unable to read metadata for entry: goodbye.json"),
             "Unexpected stderr: " + stderr);
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -167,7 +167,7 @@ class ImportParquetFilesTest extends AbstractTest {
         );
 
         assertTrue(
-            stderr.contains("Command failed, cause: [CANNOT_READ_FILE_FOOTER]"),
+            stderr.contains("Error: [CANNOT_READ_FILE_FOOTER]"),
             "Sometimes Spark will throw a SparkException that wraps a SparkException, and it's the wrapped exception " +
                 "that has the useful message in it. This test verifies that we use the message from the wrapped " +
                 "SparkException, which is far more helpful for this particular failure. Unexpected stderr: " + stderr

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesTest.java
@@ -138,7 +138,7 @@ class ImportRdfFilesTest extends AbstractTest {
             "--collections", "my-triples"
         ));
 
-        assertTrue(stderr.contains("Command failed, cause: Unable to read file at"),
+        assertTrue(stderr.contains("Error: Unable to read file at"),
             "Unexpected stderr: " + stderr);
         assertCollectionSize("my-triples", 0);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/splitter/ImportAndSplitFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/splitter/ImportAndSplitFilesTest.java
@@ -151,7 +151,7 @@ class ImportAndSplitFilesTest extends AbstractTest {
             "--permissions", DEFAULT_PERMISSIONS,
             "--splitter-json-pointer", "/text",
             "--splitter-custom-class", "doesnt.exist.ClassName"
-        ), "Command failed, cause: Cannot find custom splitter with class name: doesnt.exist.ClassName");
+        ), "Error: Cannot find custom splitter with class name: doesnt.exist.ClassName");
     }
 
     @Test


### PR DESCRIPTION
Changed the formatting of generic errors, which affected a lot of tests in a small way.
