### PR TITLE
MLE-17915 Using a "true query" if user does not specify a query

### DIFF
--- a/docs/export/export-archives.md
+++ b/docs/export/export-archives.md
@@ -52,8 +52,11 @@ The following options control which documents are selected to be exported:
 | `--string-query` | A string query utilizing MarkLogic's search grammar. |
 | `--uris` | Newline-delimited sequence of document URIs to retrieve.  |
 
-You must specify at least one of `--collections`, `--directory`, `--query`, `--string-query`, or `--uris`. You may specify any
-combination of those options as well, with the exception that `--query` will be ignored if `--uris` is specified.
+You may specify any combination of these options, with the exception that `--query` will be ignored if `--uris` is specified.
+
+Prior to Flux 1.2.0, Flux required at least one of `--collections`, `--directory`, `--query`,
+`--string-query`, or `--uris` to be specified. Starting in Flux 1.2.0, if you do not specify any of those options, then
+Flux will select all documents that the configured MarkLogic user is able to read.  
 
 You must then use the `--path` option to specify a directory to write archive files to.
 

--- a/docs/export/export-documents.md
+++ b/docs/export/export-documents.md
@@ -50,8 +50,11 @@ The following options control which documents are selected to be exported:
 | `--string-query` | A string query utilizing MarkLogic's search grammar. |
 | `--uris` | Newline-delimited sequence of document URIs to retrieve. |
 
-You must specify at least one of `--collections`, `--directory`, `--query`, `--string-query`, or `--uris`. You may specify any
-combination of those options as well, with the exception that `--query` will be ignored if `--uris` is specified.
+You may specify any combination of these options, with the exception that `--query` will be ignored if `--uris` is specified.
+
+Prior to Flux 1.2.0, Flux required at least one of `--collections`, `--directory`, `--query`, 
+`--string-query`, or `--uris` to be specified. Starting in Flux 1.2.0, if you do not specify any of those options, then 
+Flux will select all documents that the configured MarkLogic user is able to read.  
 
 ## Specifying a query
 

--- a/docs/export/export-rdf.md
+++ b/docs/export/export-rdf.md
@@ -51,9 +51,11 @@ options for selecting the documents that contain the triples you wish to export:
 | `--string-query` | A string query utilizing MarkLogic's search grammar. |
 | `--uris` | Newline-delimited sequence of document URIs to retrieve.  |
 
-You must specify at least one of `--collections`, `--directory`, `--graphs`, `--query`, `--string-query`, or `--uris`. 
-You may specify any combination of those options as well, with the exception that `--query` will be ignored 
-if `--uris` is specified.
+You may specify any combination of these options, with the exception that `--query` will be ignored if `--uris` is specified.
+
+Prior to Flux 1.2.0, Flux required at least one of `--collections`, `--directory`, `--graphs`, `--query`,
+`--string-query`, or `--uris` to be specified. Starting in Flux 1.2.0, if you do not specify any of those options, then
+Flux will select all documents that the configured MarkLogic user is able to read.  
 
 For each document matching the query specified by your options above, Flux will retrieve the triples from the document 
 and write them to a file. You must specify a `--path` option for where files should be written. See 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/OptionsUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/OptionsUtil.java
@@ -4,9 +4,7 @@
 package com.marklogic.flux.impl;
 
 import com.marklogic.flux.api.FluxException;
-import picocli.CommandLine;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,22 +50,6 @@ public abstract class OptionsUtil {
                 throw new FluxException(optionNamesAndMessages[i + 1]);
             }
         }
-    }
-
-    /**
-     * For use by the CLI.
-     *
-     * @param parseResult
-     * @param options
-     */
-    public static void verifyHasAtLeastOneOption(CommandLine.ParseResult parseResult, String... options) {
-        for (String option : options) {
-            if (parseResult.subcommand().hasMatchedOption(option)) {
-                return;
-            }
-        }
-        throw new FluxException(String.format(
-            "Must specify at least one of the following options: %s.", Arrays.asList(options)));
     }
 
     private OptionsUtil() {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -165,7 +165,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
 
         protected Map<String, String> makeOptions() {
             return OptionsUtil.addOptions(splitterParams.makeOptions(),
-                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true": null,
+                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : null,
                 Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
                 Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
                 Options.WRITE_COLLECTIONS, collections,
@@ -321,12 +321,6 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             CopyCommand copyCommand = (CopyCommand) parseResult.subcommand().commandSpec().userObject();
             new ConnectionParamsValidator(true).validate(copyCommand.outputConnectionParams);
         }
-        OptionsUtil.verifyHasAtLeastOneOption(parseResult, ReadDocumentParams.REQUIRED_QUERY_OPTIONS);
-    }
-
-    @Override
-    protected void validateDuringApiUsage() {
-        readParams.verifyAtLeastOneQueryOptionIsSet("copy");
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportDocumentsCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportDocumentsCommand.java
@@ -6,8 +6,6 @@ package com.marklogic.flux.impl.custom;
 import com.marklogic.flux.api.CustomDocumentsExporter;
 import com.marklogic.flux.api.CustomExportWriteOptions;
 import com.marklogic.flux.api.ReadDocumentsOptions;
-import com.marklogic.flux.impl.OptionsUtil;
-import com.marklogic.flux.impl.export.ReadDocumentParams;
 import com.marklogic.flux.impl.export.ReadDocumentParamsImpl;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Dataset;
@@ -25,17 +23,6 @@ public class CustomExportDocumentsCommand extends AbstractCustomExportCommand<Cu
 
     @CommandLine.Mixin
     private ReadDocumentParamsImpl readParams = new ReadDocumentParamsImpl();
-
-    @Override
-    public void validateCommandLineOptions(CommandLine.ParseResult parseResult) {
-        super.validateCommandLineOptions(parseResult);
-        OptionsUtil.verifyHasAtLeastOneOption(parseResult, ReadDocumentParams.REQUIRED_QUERY_OPTIONS);
-    }
-
-    @Override
-    protected void validateDuringApiUsage() {
-        readParams.verifyAtLeastOneQueryOptionIsSet("export");
-    }
 
     @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportArchiveFilesCommand.java
@@ -37,13 +37,6 @@ public class ExportArchiveFilesCommand extends AbstractCommand<ArchiveFilesExpor
     @Override
     protected void validateDuringApiUsage() {
         writeParams.validatePath();
-        readParams.verifyAtLeastOneQueryOptionIsSet("export");
-    }
-
-    @Override
-    public void validateCommandLineOptions(CommandLine.ParseResult parseResult) {
-        super.validateCommandLineOptions(parseResult);
-        OptionsUtil.verifyHasAtLeastOneOption(parseResult, ReadDocumentParams.REQUIRED_QUERY_OPTIONS);
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportFilesCommand.java
@@ -39,14 +39,7 @@ public class ExportFilesCommand extends AbstractCommand<GenericFilesExporter> im
 
     @Override
     protected void validateDuringApiUsage() {
-        readParams.verifyAtLeastOneQueryOptionIsSet("export");
         writeParams.validatePath();
-    }
-
-    @Override
-    public void validateCommandLineOptions(CommandLine.ParseResult parseResult) {
-        super.validateCommandLineOptions(parseResult);
-        OptionsUtil.verifyHasAtLeastOneOption(parseResult, ReadDocumentParams.REQUIRED_QUERY_OPTIONS);
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportRdfFilesCommand.java
@@ -38,13 +38,6 @@ public class ExportRdfFilesCommand extends AbstractCommand<RdfFilesExporter> imp
     }
 
     @Override
-    public void validateCommandLineOptions(CommandLine.ParseResult parseResult) {
-        super.validateCommandLineOptions(parseResult);
-        OptionsUtil.verifyHasAtLeastOneOption(parseResult,
-            "--collections", "--directory", "--graphs", "--query", "--string-query", "--uris");
-    }
-
-    @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
         final int fileCount = writeParams.getFileCount();
         if (fileCount > 0) {

--- a/flux-cli/src/test/java/com/marklogic/flux/api/ArchiveFilesExporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/ArchiveFilesExporterTest.java
@@ -62,16 +62,4 @@ class ArchiveFilesExporterTest extends AbstractTest {
         FluxException ex = assertThrowsFluxException(() -> exporter.execute());
         assertEquals("Must specify a file path", ex.getMessage());
     }
-
-    @Test
-    void noQuerySpecified() {
-        ArchiveFilesExporter exporter = Flux.exportArchiveFiles()
-            .connectionString(makeConnectionString())
-            .to(options -> options.path("build/doesnt-matter"));
-
-        FluxException ex = assertThrowsFluxException(() -> exporter.execute());
-        assertEquals("Must specify at least one of the following for the documents to export: " +
-                "collections; a directory; a string query; a structured, serialized, or combined query; or URIs.",
-            ex.getMessage());
-    }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/api/CustomDocumentsExporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/CustomDocumentsExporterTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CustomDocumentsExporterTest extends AbstractTest {
@@ -31,16 +30,5 @@ class CustomDocumentsExporterTest extends AbstractTest {
 
         getUrisInCollection("exported-authors", 15)
             .forEach(uri -> assertTrue(uri.startsWith("/exported/author/"), "Unexpected URI: " + uri));
-    }
-
-    @Test
-    void noQuerySpecified() {
-        CustomDocumentsExporter exporter = Flux.customExportDocuments()
-            .connectionString(makeConnectionString());
-
-        FluxException ex = assertThrowsFluxException(() -> exporter.execute());
-        assertEquals("Must specify at least one of the following for the documents to export: " +
-                "collections; a directory; a string query; a structured, serialized, or combined query; or URIs.",
-            ex.getMessage());
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/api/DocumentCopierTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/DocumentCopierTest.java
@@ -49,17 +49,6 @@ class DocumentCopierTest extends AbstractTest {
     }
 
     @Test
-    void noQuerySpecified() {
-        DocumentCopier copier = Flux.copyDocuments()
-            .connectionString(makeConnectionString());
-
-        FluxException ex = assertThrowsFluxException(() -> copier.execute());
-        assertEquals("Must specify at least one of the following for the documents to copy: " +
-                "collections; a directory; a string query; a structured, serialized, or combined query; or URIs.",
-            ex.getMessage());
-    }
-
-    @Test
     void splitterTest() {
         Flux.importGenericFiles()
             .connectionString(makeConnectionString())

--- a/flux-cli/src/test/java/com/marklogic/flux/api/GenericFilesExporterTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/GenericFilesExporterTest.java
@@ -73,16 +73,4 @@ class GenericFilesExporterTest extends AbstractTest {
         FluxException ex = assertThrowsFluxException(() -> exporter.execute());
         assertEquals("Must specify a file path", ex.getMessage());
     }
-
-    @Test
-    void noQuerySpecified() {
-        GenericFilesExporter exporter = Flux.exportGenericFiles()
-            .connectionString(makeConnectionString())
-            .to(options -> options.path("build/doesnt-matter"));
-
-        FluxException ex = assertThrowsFluxException(() -> exporter.execute());
-        assertEquals("Must specify at least one of the following for the documents to export: " +
-                "collections; a directory; a string query; a structured, serialized, or combined query; or URIs.",
-            ex.getMessage());
-    }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ExportRdfFilesTest.java
@@ -58,17 +58,4 @@ class ExportRdfFilesTest extends AbstractTest {
             "/sem:triples/sem:triple", 32
         );
     }
-
-    @Test
-    void missingQueryInput() {
-        String stderr = runAndReturnStderr(() -> run(
-            "export-rdf-files",
-            "--connection-string", makeConnectionString(),
-            "--path", "path-doesnt-matter-for-this-test"
-        ));
-
-        assertTrue(stderr.contains("Must specify at least one of the following options: " +
-                "[--collections, --directory, --graphs, --query, --string-query, --uris]."),
-            "Unexpected stderr: " + stderr);
-    }
 }


### PR DESCRIPTION
This is specific to export operations and resulted in a number of test cases being removed, as the user no longer gets an error if they don't specify any query.
