### PR TITLE
MLE-19129 Flux now returns the exit code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ are all synonyms):
 
     ./gradlew shadowJar
 
-This will produce an assembly jar at `./flux-cli/build/libs/marklogic-flux-1.1-SNAPSHOT-all.jar`.
+This will produce an assembly jar at `./flux-cli/build/libs/marklogic-flux-1.2-SNAPSHOT-all.jar`.
 
 You can now run any CLI command via spark-submit. This is an example of previewing an import of files - change the value
 of `--path`, as an absolute path is needed, and of course change the value of `--master` to match that of your Spark
@@ -290,7 +290,7 @@ cluster:
 
 ```
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
---master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.1-SNAPSHOT-all.jar \
+--master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.2-SNAPSHOT-all.jar \
 import-files --path /Users/rudin/workspace/flux/flux-cli/src/test/resources/mixed-files \
 --connection-string "admin:admin@localhost:8000" \
 --preview 5 --preview-drop content
@@ -307,7 +307,7 @@ to something you can access):
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
 --packages org.apache.hadoop:hadoop-aws:3.3.4,org.apache.hadoop:hadoop-client:3.3.4 \
 --master spark://NYWHYC3G0W:7077 \
-flux-cli/build/libs/marklogic-flux-1.1-SNAPSHOT-all.jar \
+flux-cli/build/libs/marklogic-flux-1.2-SNAPSHOT-all.jar \
 import-files --path "s3a://changeme/" \
 --connection-string "admin:admin@localhost:8000" \
 --s3-add-credentials \

--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -63,7 +63,13 @@ public class Main {
 
     private static final Logger logger = LoggerFactory.getLogger("com.marklogic.flux");
 
+    // Intended to be invoked solely by the application script. Tests should invoke "run" instead to avoid the
+    // System.exit call.
     public static void main(String[] args) {
+        System.exit(run(args));
+    }
+
+    public static int run(String[] args) {
         if (args.length == 0 || args[0].trim().equals("")) {
             args = new String[]{"help"};
         } else if (args[0].equals("help") && args.length == 1) {
@@ -75,8 +81,9 @@ public class Main {
                 .setUsageHelpWidth(120)
                 .setAbbreviatedSubcommandsAllowed(true)
                 .execute(args);
+            return CommandLine.ExitCode.USAGE;
         } else {
-            new Main().newCommandLine().execute(args);
+            return new Main().newCommandLine().execute(args);
         }
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/AbstractTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/AbstractTest.java
@@ -28,8 +28,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 public abstract class AbstractTest extends AbstractMarkLogicTest {
@@ -93,8 +92,14 @@ public abstract class AbstractTest extends AbstractMarkLogicTest {
         return String.format("%s:%s@%s:%d", DEFAULT_USER, DEFAULT_PASSWORD, databaseClient.getHost(), databaseClient.getPort());
     }
 
-    protected final void run(String... args) {
-        Main.main(args);
+    protected final int run(int expectedReturnCode, String... args) {
+        int code = run(args);
+        assertEquals(expectedReturnCode, code);
+        return code;
+    }
+
+    protected final int run(String... args) {
+        return Main.run(args);
     }
 
     /**

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -5,6 +5,7 @@ package com.marklogic.flux.impl;
 
 import com.marklogic.flux.AbstractTest;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -18,7 +19,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void invalidCommand() {
         assertStderrContains(
-            () -> run("not_a_real_command", "--connection-string", makeConnectionString()),
+            () -> run(CommandLine.ExitCode.USAGE, "not_a_real_command", "--connection-string", makeConnectionString()),
             "Unmatched arguments from index 0: 'not_a_real_command'"
         );
     }
@@ -26,7 +27,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void invalidParam() {
         assertStderrContains(
-            () -> run("import-files", "--not-a-real-param", "--path", "anywhere"),
+            () -> run(CommandLine.ExitCode.USAGE, "import-files", "--not-a-real-param", "--path", "anywhere"),
             "Unknown option: '--not-a-real-param'"
         );
     }
@@ -34,7 +35,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void invalidParamWithSingleQuotesInIt() {
         assertStderrContains(
-            () -> run("import-files", "-not-a-'real'-param", "--path", "anywhere"),
+            () -> run(CommandLine.ExitCode.USAGE, "import-files", "-not-a-'real'-param", "--path", "anywhere"),
             "Unknown option: '-not-a-'real'-param'"
         );
     }
@@ -42,7 +43,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void badDynamicOption() {
         assertStderrContains(
-            () -> run("import-files", "-CnoValue"),
+            () -> run(CommandLine.ExitCode.USAGE, "import-files", "-CnoValue"),
             "Value for option '-C' (<String=String>) should be in KEY=VALUE format but was noValue"
         );
     }
@@ -50,7 +51,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void missingRequiredParam() {
         assertStderrContains(
-            () -> run("import-files", "--connection-string", makeConnectionString()),
+            () -> run(CommandLine.ExitCode.USAGE, "import-files", "--connection-string", makeConnectionString()),
             "Missing required option: '--path <path>'"
         );
 
@@ -67,6 +68,7 @@ class HandleErrorTest extends AbstractTest {
     void sparkFailure() {
         assertStderrContains(
             () -> run(
+                CommandLine.ExitCode.SOFTWARE,
                 "import-files",
                 "--path", "/not/valid",
                 "--connection-string", makeConnectionString()
@@ -79,6 +81,7 @@ class HandleErrorTest extends AbstractTest {
     void abortOnWriteFailure() {
         assertStderrContains(
             () -> run(
+                CommandLine.ExitCode.SOFTWARE,
                 "import-files",
                 "--path", "src/test/resources/mixed-files/hello*",
                 "--repartition", "2",
@@ -97,6 +100,7 @@ class HandleErrorTest extends AbstractTest {
     void abortOnWriteFailureAndShowStacktrace() {
         assertStderrContains(
             () -> run(
+                CommandLine.ExitCode.SOFTWARE,
                 "import-files",
                 "--path", "src/test/resources/mixed-files/hello*",
                 "--repartition", "2",
@@ -112,6 +116,7 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void dontAbortOnWriteFailure() {
         String stderr = runAndReturnStderr(() -> run(
+            CommandLine.ExitCode.OK,
             "import-files",
             "--path", "src/test/resources/mixed-files/hello*",
             // Using two partitions to verify that both partition writers log an error.

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HelpTest.java
@@ -5,11 +5,17 @@ package com.marklogic.flux.impl;
 
 import com.marklogic.flux.AbstractTest;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class HelpTest extends AbstractTest {
+
+    @Test
+    void returnCode() {
+        assertEquals(CommandLine.ExitCode.USAGE, run());
+        assertEquals(CommandLine.ExitCode.USAGE, run("help", "import-files"));
+    }
 
     @Test
     void summaryUsage() {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -8,6 +8,7 @@ import com.marklogic.junit5.XmlNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.util.FileCopyUtils;
+import picocli.CommandLine;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ class ImportFilesTest extends AbstractTest {
     @Test
     void multiplePaths() {
         run(
+            CommandLine.ExitCode.OK,
             "import-files",
             "--path", "src/test/resources/mixed-files/hello*txt*",
             "--path", "src/test/resources/mixed-files/hello.json",
@@ -244,6 +246,7 @@ class ImportFilesTest extends AbstractTest {
     @Test
     void invalidGzippedFile() {
         run(
+            CommandLine.ExitCode.OK,
             "import-files",
             "--path", "src/test/resources/json-files/aggregates/array-of-objects.json",
             "--path", "src/test/resources/mixed-files/hello2.txt.gz",
@@ -262,6 +265,7 @@ class ImportFilesTest extends AbstractTest {
     @Test
     void abortOnReadFailure() {
         String stderr = runAndReturnStderr(() -> run(
+            CommandLine.ExitCode.SOFTWARE,
             "import-files",
             "--path", "src/test/resources/json-files/aggregates/array-of-objects.json",
             "--abort-on-read-failure",


### PR DESCRIPTION
Added a public `run` method that returns the code for tests to call, while `main` actually makes the `System.exit` call.

Manually verified that spark-submit still works too (we don't want to call System.exit there).
