### PR TITLE
MLE-19164 Defaulting Spark master URL based on reprocessor threads

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/Executor.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/Executor.java
@@ -51,6 +51,13 @@ public interface Executor<T extends Executor> {
     T limit(int limit);
 
     /**
+     * @param partitionCount the number of partitions to use for writing or processing the data that has been read.
+     * @return instance of this executor
+     * @since 1.2.0
+     */
+    T repartition(int partitionCount);
+
+    /**
      * @return the count of rows to be read by this executor from its data source.
      */
     long count();

--- a/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/Reprocessor.java
@@ -59,6 +59,14 @@ public interface Reprocessor extends Executor<Reprocessor> {
         WriteOptions batchSize(int batchSize);
 
         WriteOptions logProgress(int interval);
+
+        /**
+         * @param threadCount the number of threads, which equates to the number of Spark partitions, to use for
+         *                    reprocessing items.
+         * @return instance of this executor
+         * @since 1.2.0
+         */
+        WriteOptions threadCount(int threadCount);
     }
 
     Reprocessor from(Consumer<ReadOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -3,7 +3,10 @@
  */
 package com.marklogic.flux.cli;
 
-import com.marklogic.flux.impl.*;
+import com.marklogic.flux.impl.AbstractCommand;
+import com.marklogic.flux.impl.Command;
+import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.VersionCommand;
 import com.marklogic.flux.impl.copy.CopyCommand;
 import com.marklogic.flux.impl.custom.CustomExportDocumentsCommand;
 import com.marklogic.flux.impl.custom.CustomExportRowsCommand;
@@ -117,10 +120,8 @@ public class Main {
     protected SparkSession buildSparkSession(Command selectedCommand) {
         String masterUrl = null;
         if (selectedCommand instanceof AbstractCommand) {
-            CommonParams commonParams = ((AbstractCommand) selectedCommand).getCommonParams();
-            masterUrl = commonParams.getSparkMasterUrl();
+            masterUrl = ((AbstractCommand) selectedCommand).determineSparkMasterUrl();
         }
-
         return masterUrl != null && masterUrl.trim().length() > 0 ?
             SparkUtil.buildSparkSession(masterUrl) :
             SparkUtil.buildSparkSession();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -29,6 +29,18 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
 
     private SparkSession sparkSession;
 
+    public String determineSparkMasterUrl() {
+        if (commonParams != null) {
+            if (commonParams.getSparkMasterUrl() != null) {
+                return commonParams.getSparkMasterUrl();
+            }
+            if (commonParams.getRepartition() > 0) {
+                return String.format("local[%d]", commonParams.getRepartition());
+            }
+        }
+        return "local[*]";
+    }
+
     @Override
     public void validateCommandLineOptions(CommandLine.ParseResult parseResult) {
         new ConnectionParamsValidator(false).validate(connectionParams);
@@ -194,6 +206,12 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
     @Override
     public T limit(int limit) {
         commonParams.setLimit(limit);
+        return (T) this;
+    }
+
+    @Override
+    public T repartition(int partitionCount) {
+        commonParams.setRepartition(partitionCount);
         return (T) this;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -39,7 +39,7 @@ public class CommonParams {
         names = "--spark-master-url",
         description = "Specify the Spark master URL for configuring the local Spark cluster created by Flux."
     )
-    private String sparkMasterUrl = "local[*]";
+    private String sparkMasterUrl;
 
     @CommandLine.Option(
         names = "-C",
@@ -79,5 +79,9 @@ public class CommonParams {
 
     public Preview getPreview() {
         return preview;
+    }
+
+    public int getRepartition() {
+        return repartition;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcUtil.java
@@ -5,16 +5,13 @@ package com.marklogic.flux.impl;
 
 import com.marklogic.flux.api.FluxException;
 
-public abstract class JdbcUtil {
+public interface JdbcUtil {
 
-    public static Exception massageException(Exception ex) {
+    static Exception massageException(Exception ex) {
         if (ex instanceof ClassNotFoundException) {
             return new FluxException(String.format("Unable to load class: %s; for a JDBC driver, ensure you " +
                 "are specifying the fully-qualified class name for your JDBC driver.", ex.getMessage()), ex);
         }
         return ex;
-    }
-
-    private JdbcUtil() {
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
@@ -8,8 +8,12 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SparkUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger("com.marklogic.flux");
 
     private SparkUtil() {
         // Required by Sonar.
@@ -20,6 +24,9 @@ public class SparkUtil {
     }
 
     public static SparkSession buildSparkSession(String masterUrl) {
+        if (logger.isInfoEnabled()) {
+            logger.info("Spark URL: {}", masterUrl);
+        }
         SparkSession.Builder builder = SparkSession.builder()
             .master(masterUrl)
 

--- a/flux-cli/src/test/java/com/marklogic/flux/api/ReprocessorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/api/ReprocessorTest.java
@@ -20,6 +20,10 @@ class ReprocessorTest extends AbstractTest {
             .from(options -> options
                 .javascript("var collection; cts.uris(null, null, cts.collectionQuery(collection))")
                 .vars(Map.of("collection", "author")))
+
+            // Has no functional impact, just ensuring it doesn't cause a break.
+            .repartition(32)
+            
             .to(options -> options
                 .invoke("/writeDocument.sjs")
                 .vars(Map.of("theValue", "my value")))

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/reprocess/ReprocessTest.java
@@ -25,7 +25,11 @@ class ReprocessTest extends AbstractTest {
             "--read-javascript", "var collection; cts.uris(null, null, cts.collectionQuery(collection))",
             "--read-var", "collection=author",
             "--write-invoke", "/writeDocument.sjs",
-            "--write-var", "theValue=my value"
+            "--write-var", "theValue=my value",
+
+            // Included to ensure it doesn't cause any failures. This is only done for performance reasons, and we
+            // don't have any assertions to make on the effect of using multiple threads/partitions.
+            "--thread-count", "8"
         );
 
         // reprocess-test is the collection used by writeDocument.sjs.


### PR DESCRIPTION
Added `--thread-count` as an alias for `--repartitions` so a user can just think about threads. Both have the same effect now, which is to set the Spark master URL to have a number of threads equivalent to the number of partitions.
