### PR TITLE
MLE-19164 Configuring Spark master URL based on partition count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,5 @@ flux/ext
 flux/bin
 flux/conf
 flux-cli/src/dist/ext/*.jar
-flux/export
-export
 flux-version.properties
 docker/sonarqube

--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -489,27 +489,46 @@ time you run Flux:
 Flux is built on top of [Apache Spark](https://spark.apache.org/) and provides a number of command line options for 
 configuring the underlying Spark runtime environment used by Flux. 
 
-### Configuring the number of partitions 
+### Configuring Spark worker threads
 
-Flux uses Spark partitions to allow for data to be read and written in parallel. Each partition can be thought of as 
-a separate worker, operating in parallel with each other worker. 
-
-A number of partitions will be determined by the command that you run before it reads data. The nature of the data 
-source directly impacts the number of partitions that will be created. 
-
-If you find that an insufficient number of partitions are created - i.e. the writer phase of your Flux command is not
-sending as much data to MarkLogic as it could - consider using the `--repartition` option to force a number of 
-partitions to be created after the data has been read. The downside to using `--repartition` is that all the data must
-be read first. Generally, this option will help when data can be read quickly and the performance of writing can be 
-improved by using more partitions than were created when reading data.
-
-### Configuring a Spark URL
-
-By default, Flux creates a Spark session with a master URL of `local[*]`. You can change this via the 
-`--spark-master-url` option; please see 
+By default, Flux creates a Spark runtime with a master URL of `local[*]`, which runs Spark with as many worker 
+threads as logical cores on the machine running Flux. The number of worker threads affects how many partitions can be
+processed in parallel. You can change this setting via the`--spark-master-url` option; please see 
 [the Spark documentation](https://spark.apache.org/docs/latest/submitting-applications.html#master-urls) for examples
 of valid values. If you are looking to run a Flux command on a remote Spark cluster, please instead see the 
 [Spark Integration guide](spark-integration.md) for details on integrating Flux with `spark-submit`.
+
+For import commands, you typically will not need to adjust this as a partition writer in an import command supports its
+own pool of threads via the [MarkLogic data movement library](https://docs.marklogic.com/guide/java/data-movement). However,
+depending on the data source, additional worker threads may help with reading data in parallel. 
+
+For the [`reprocess` command](reprocess.md), setting the number of worker threads is critical to achieving optimal 
+performance. As of Flux 1.2.0, the `--thread-count` option will adjust the Spark master URL based on the number of 
+threads you specify. Prior to Flux 1.2.0, you can use `--repartition` to achieve the same effect. 
+
+For exporting data, please see the [exporting guide](export/export.md) for information on how to adjust the worker 
+threads depending on whether you are reading documents or rows from MarkLogic.
+
+### Configuring the number of Spark partitions
+
+Flux uses Spark partitions to allow for data to be read and written in parallel. Each partition can be thought of as
+a separate worker, operating in parallel with each other worker.
+
+A number of partitions will be determined by the command that you run before it reads data. The nature of the data
+source directly impacts the number of partitions that will be created.
+
+For some commands, you may find improved performance by changing the number of partitions used to write data to the
+target associated with the command. For example, an `export-jdbc` command may only need a small number of partitions to 
+read data from MarkLogic, but performance will be improved by using a far higher number of partitions to write data to
+the JDBC destination. You can use the `--repartition` option to force the number of partitions to use for writing data. 
+The downside to this option is that it forces Flux to read all the data from the data source before writing any to the
+target. Generally, this option will help when data can be read quickly and the performance of writing can be
+improved by using more partitions than were created when reading data - this is almost always the case for the 
+`reprocess` command.
+
+As of Flux 1.2.0, setting `--repartition` will default the value of the `--spark-master-url` option to be `local[N]`, 
+where `N` is the value of `--repartition`. This ensure that each partition writer has a Spark worker thread available
+to it. You can still override `--spark-master-url` if you wish.
 
 ### Configuring the Spark runtime
 

--- a/docs/export/export-documents.md
+++ b/docs/export/export-documents.md
@@ -330,8 +330,21 @@ bin\flux export-files ^
 
 This approach will produce 3 ZIP files - one per forest.
 
+To ensure that each partition reader can work in parallel with the others, you should consider setting the 
+`--spark-master-url` option to a value of `local[N]`, where `N` is the total number of partition readers. For example,
+if your database has 4 forests and you want 4 partitions per forest, you would use the following options:
+
+```
+--partitions-per-forest 4
+--spark-master-url local[16]
+```
+
+A future release of Flux may automatically set the `--spark-master-url` option based on the database configuration. 
+
 You can also use the `--repartition` option, available on every command, to force the number of partitions used when
-writing data, regardless of how many were used to read the data:
+writing data, regardless of how many were used to read the data. As of Flux 1.2.0, if you do use `--repartition`, 
+Flux will automatically set the `--spark-master-url` option based on the value you provide for `--repartition`. 
+For example:
 
 {% tabs log %}
 {% tab log Unix %}

--- a/docs/export/export-rows.md
+++ b/docs/export/export-rows.md
@@ -348,3 +348,15 @@ The above options will result in the query being executed in a single call to Ma
 for queries with joins and aggregations, as trying to partition that query may result in either duplicate rows or 
 incorrect results. You will need to verify though that the total number of rows returned by your query can be retrieved
 in a single request to MarkLogic without the request timing out. 
+
+### Partitions and Spark worker threads
+
+As of Flux 1.2.0, when you set the number of partitions via `--partitions`, Flux will default the value of the 
+`--spark-master-url` option to `local[N]`, where `N` is the number of partitions. This option controls the number of 
+worker threads available to Spark. This default value ensures that each partition that reads rows from MarkLogic has 
+a worker thread available for it. 
+
+Depending on the target for writing rows, you may wish to use the `--repartition` option as well. This will adjust the
+number of partitions after all the rows have been read from MarkLogic. This approach can be useful for a scenario where
+Flux can quickly read a large number of rows from MarkLogic, but writing them to the target of the export command is 
+much slower.

--- a/docs/import/tuning-performance.md
+++ b/docs/import/tuning-performance.md
@@ -22,7 +22,10 @@ Flux will log the number of partitions for each import command as shown below:
 
     INFO com.marklogic.spark: Number of partitions: 1
 
-You can force a number of partitions via the `--repartition` option.
+Because each partition writer in an import process has its own pool of threads (independent from the number of 
+Spark worker threads), you typically will not need to worry about the number of partitions for an import process. 
+Setting `--thread-count` gives you the control you will typically need to ensure that Flux is able to use a sufficient 
+number of threads for sending requests to MarkLogic.
 
 ### Thread count and cluster size
 

--- a/docs/reprocess.md
+++ b/docs/reprocess.md
@@ -227,9 +227,12 @@ perform well. The two primary techniques for improving performance are:
 1. Configuring `--batch-size` and altering your writer code to accept multiple items in a single call, as described in the "Processing multiple items at once" section above.
 2. Configuring `--thread-count` to specify the number of threads for processing items.
 
-The `--thread-count` option is actually an alias for the `--repartition` option. It is included in the `reprocess` command
+The `--thread-count` option is an alias for the `--repartition` option. It is included in the `reprocess` command
 as it is a familiar option name for other tools for reprocessing data in MarkLogic. Both options have the same effect, 
-which is to configure the number of threads or partitions used by Flux for processing items. 
+which is to configure the number of partitions used by Flux for processing items. In addition, as of Flux 1.2.0, 
+setting either option will adjust the default value of the `--spark-master-url` option to be `local[N]`, where `N` is
+the number of Spark worker threads. This ensures that each partition processing items will have a Spark worker thread
+available to it. 
 
 You may also be able to improve reader performance by partitioning your query by database forests. The section on 
 creating partitions above uses the following, which is a simple way to both create and use forest-based partitions:

--- a/flux-cli/src/main/java/com/marklogic/flux/api/Flux.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/Flux.java
@@ -14,57 +14,57 @@ import com.marklogic.flux.impl.reprocess.ReprocessCommand;
 /**
  * Entry point for executing Flux commands via the API.
  */
-public abstract class Flux {
+public interface Flux {
 
-    public static DocumentCopier copyDocuments() {
+    static DocumentCopier copyDocuments() {
         return new CopyCommand();
     }
 
-    public static CustomImporter customImport() {
+    static CustomImporter customImport() {
         return new CustomImportCommand();
     }
 
-    public static CustomDocumentsExporter customExportDocuments() {
+    static CustomDocumentsExporter customExportDocuments() {
         return new CustomExportDocumentsCommand();
     }
 
-    public static CustomRowsExporter customExportRows() {
+    static CustomRowsExporter customExportRows() {
         return new CustomExportRowsCommand();
     }
 
-    public static ArchiveFilesExporter exportArchiveFiles() {
+    static ArchiveFilesExporter exportArchiveFiles() {
         return new ExportArchiveFilesCommand();
     }
 
-    public static AvroFilesExporter exportAvroFiles() {
+    static AvroFilesExporter exportAvroFiles() {
         return new ExportAvroFilesCommand();
     }
 
-    public static DelimitedFilesExporter exportDelimitedFiles() {
+    static DelimitedFilesExporter exportDelimitedFiles() {
         return new ExportDelimitedFilesCommand();
     }
 
-    public static GenericFilesExporter exportGenericFiles() {
+    static GenericFilesExporter exportGenericFiles() {
         return new ExportFilesCommand();
     }
 
-    public static JdbcExporter exportJdbc() {
+    static JdbcExporter exportJdbc() {
         return new ExportJdbcCommand();
     }
 
-    public static JsonLinesFilesExporter exportJsonLinesFiles() {
+    static JsonLinesFilesExporter exportJsonLinesFiles() {
         return new ExportJsonLinesFilesCommand();
     }
 
-    public static OrcFilesExporter exportOrcFiles() {
+    static OrcFilesExporter exportOrcFiles() {
         return new ExportOrcFilesCommand();
     }
 
-    public static ParquetFilesExporter exportParquetFiles() {
+    static ParquetFilesExporter exportParquetFiles() {
         return new ExportParquetFilesCommand();
     }
 
-    public static RdfFilesExporter exportRdfFiles() {
+    static RdfFilesExporter exportRdfFiles() {
         return new ExportRdfFilesCommand();
     }
 
@@ -72,7 +72,7 @@ public abstract class Flux {
      * @return an object that can import aggregate JSON files, where the files to import either contains an array of
      * JSON objects or conforms to the JSON Lines format.
      */
-    public static AggregateJsonFilesImporter importAggregateJsonFiles() {
+    static AggregateJsonFilesImporter importAggregateJsonFiles() {
         return new ImportAggregateJsonFilesCommand();
     }
 
@@ -80,22 +80,22 @@ public abstract class Flux {
      * @return an object that can import aggregate XML files, where each instance of a particular child element is
      * written to MarkLogic as a separate document.
      */
-    public static AggregateXmlFilesImporter importAggregateXmlFiles() {
+    static AggregateXmlFilesImporter importAggregateXmlFiles() {
         return new ImportAggregateXmlFilesCommand();
     }
 
     /**
      * @return an object that can import archive files - i.e. ZIP files that contain documents and metadata.
      */
-    public static ArchiveFilesImporter importArchiveFiles() {
+    static ArchiveFilesImporter importArchiveFiles() {
         return new ImportArchiveFilesCommand();
     }
 
-    public static AvroFilesImporter importAvroFiles() {
+    static AvroFilesImporter importAvroFiles() {
         return new ImportAvroFilesCommand();
     }
 
-    public static DelimitedFilesImporter importDelimitedFiles() {
+    static DelimitedFilesImporter importDelimitedFiles() {
         return new ImportDelimitedFilesCommand();
     }
 
@@ -103,37 +103,34 @@ public abstract class Flux {
      * @return an object that can import any type of file as-is, with the document type being determined by
      * the file extension.
      */
-    public static GenericFilesImporter importGenericFiles() {
+    static GenericFilesImporter importGenericFiles() {
         return new ImportFilesCommand();
     }
 
-    public static JdbcImporter importJdbc() {
+    static JdbcImporter importJdbc() {
         return new ImportJdbcCommand();
     }
 
     /**
      * @return an object that can import archive files created by MLCP.
      */
-    public static MlcpArchiveFilesImporter importMlcpArchiveFiles() {
+    static MlcpArchiveFilesImporter importMlcpArchiveFiles() {
         return new ImportMlcpArchiveFilesCommand();
     }
 
-    public static OrcFilesImporter importOrcFiles() {
+    static OrcFilesImporter importOrcFiles() {
         return new ImportOrcFilesCommand();
     }
 
-    public static ParquetFilesImporter importParquetFiles() {
+    static ParquetFilesImporter importParquetFiles() {
         return new ImportParquetFilesCommand();
     }
 
-    public static RdfFilesImporter importRdfFiles() {
+    static RdfFilesImporter importRdfFiles() {
         return new ImportRdfFilesCommand();
     }
 
-    public static Reprocessor reprocess() {
+    static Reprocessor reprocess() {
         return new ReprocessCommand();
-    }
-
-    private Flux() {
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -29,16 +29,20 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
 
     private SparkSession sparkSession;
 
-    public String determineSparkMasterUrl() {
-        if (commonParams != null) {
-            if (commonParams.getSparkMasterUrl() != null) {
-                return commonParams.getSparkMasterUrl();
-            }
-            if (commonParams.getRepartition() > 0) {
-                return String.format("local[%d]", commonParams.getRepartition());
-            }
+    public final String determineSparkMasterUrl() {
+        if (commonParams.getSparkMasterUrl() != null) {
+            return commonParams.getSparkMasterUrl();
         }
-        return "local[*]";
+        if (commonParams.getRepartition() > 0) {
+            return SparkUtil.makeSparkMasterUrl(commonParams.getRepartition());
+        }
+        String url = getCustomSparkMasterUrl();
+        return url != null ? url : "local[*]";
+    }
+
+    protected String getCustomSparkMasterUrl() {
+        // Allows subclasses to provide their own Spark master URL based on command-specific options.
+        return null;
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
@@ -8,25 +8,18 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class SparkUtil {
+public interface SparkUtil {
 
-    private static final Logger logger = LoggerFactory.getLogger("com.marklogic.flux");
-
-    private SparkUtil() {
-        // Required by Sonar.
+    static String makeSparkMasterUrl(int workerThreads) {
+        return String.format("local[%d]", workerThreads);
     }
 
-    public static SparkSession buildSparkSession() {
+    static SparkSession buildSparkSession() {
         return buildSparkSession("local[*]");
     }
 
-    public static SparkSession buildSparkSession(String masterUrl) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Spark URL: {}", masterUrl);
-        }
+    static SparkSession buildSparkSession(String masterUrl) {
         SparkSession.Builder builder = SparkSession.builder()
             .master(masterUrl)
 
@@ -53,7 +46,7 @@ public class SparkUtil {
      * @param saveMode
      * @return
      */
-    public static org.apache.spark.sql.SaveMode toSparkSaveMode(SaveMode saveMode) {
+    static org.apache.spark.sql.SaveMode toSparkSaveMode(SaveMode saveMode) {
         if (SaveMode.APPEND.equals(saveMode)) {
             return org.apache.spark.sql.SaveMode.Append;
         } else if (SaveMode.ERRORIFEXISTS.equals(saveMode)) {
@@ -66,7 +59,7 @@ public class SparkUtil {
         return null;
     }
 
-    public static Dataset<Row> addFilePathColumn(Dataset<Row> dataset) {
+    static Dataset<Row> addFilePathColumn(Dataset<Row> dataset) {
         // The MarkLogic Spark connector has special processing for this column. If it's found by the writer, the
         // value of this column will be used to construct an initial URI for the associated document. The column
         // will then have its value set to null so that the value is not included in the JSON or XML

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportRowsCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomExportRowsCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.CustomExportWriteOptions;
 import com.marklogic.flux.api.CustomRowsExporter;
 import com.marklogic.flux.api.ReadRowsOptions;
 import com.marklogic.flux.impl.AbstractCommand;
+import com.marklogic.flux.impl.SparkUtil;
 import com.marklogic.flux.impl.export.ReadRowsParams;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.Dataset;
@@ -24,6 +25,11 @@ public class CustomExportRowsCommand extends AbstractCustomExportCommand<CustomR
 
     @CommandLine.Mixin
     private ReadRowsParams readParams = new ReadRowsParams();
+
+    @Override
+    protected String getCustomSparkMasterUrl() {
+        return readParams.getPartitions() > 0 ? SparkUtil.makeSparkMasterUrl(readParams.getPartitions()) : null;
+    }
 
     @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/AbstractExportRowsToFilesCommand.java
@@ -37,6 +37,11 @@ abstract class AbstractExportRowsToFilesCommand<T extends Executor> extends Abst
     }
 
     @Override
+    protected String getCustomSparkMasterUrl() {
+        return readParams.getPartitions() > 0 ? SparkUtil.makeSparkMasterUrl(readParams.getPartitions()) : null;
+    }
+
+    @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
         final Integer fileCount = getWriteFilesParams().getFileCount();
         if (fileCount != null && fileCount > 0) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
@@ -35,6 +35,11 @@ public class ExportJdbcCommand extends AbstractCommand<JdbcExporter> implements 
     }
 
     @Override
+    protected String getCustomSparkMasterUrl() {
+        return readParams.getPartitions() > 0 ? SparkUtil.makeSparkMasterUrl(readParams.getPartitions()) : null;
+    }
+
+    @Override
     protected Dataset<Row> loadDataset(SparkSession session, DataFrameReader reader) {
         return reader.format(MARKLOGIC_CONNECTOR)
             .options(getConnectionParams().makeOptions())

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadDocumentParams.java
@@ -79,7 +79,7 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
     }
 
     private Map<String, String> makeQueryOptions() {
-        Map<String, String> options = OptionsUtil.makeOptions(
+        Map<String, String> queryOptions = OptionsUtil.makeOptions(
             Options.READ_DOCUMENTS_STRING_QUERY, stringQuery,
             Options.READ_DOCUMENTS_URIS, uris,
             Options.READ_DOCUMENTS_QUERY, query,
@@ -87,11 +87,11 @@ public class ReadDocumentParams<T extends ReadDocumentsOptions> implements ReadD
             Options.READ_DOCUMENTS_DIRECTORY, directory
         );
 
-        if (options.isEmpty()) {
+        if (queryOptions.isEmpty()) {
             String trueQuery = "{\"query\": {\"queries\": [{\"true-query\": null}]}}";
-            options.put(Options.READ_DOCUMENTS_QUERY, trueQuery);
+            queryOptions.put(Options.READ_DOCUMENTS_QUERY, trueQuery);
         }
-        return options;
+        return queryOptions;
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ReadRowsParams.java
@@ -31,6 +31,9 @@ public class ReadRowsParams implements ReadRowsOptions {
     @CommandLine.Option(names = "--disable-aggregation-push-down", hidden = true)
     private boolean disableAggregationPushDown;
 
+    // As of 1.2.0, this now affects the Spark master URL. This ensures that if the user e.g. creates 16 partitions for
+    // reading rows, then the Spark master URL will specify 16 worker threads. The user may still reconfigure the
+    // number of partitions during the writer phase via "--repartition".
     @CommandLine.Option(names = "--partitions", description = "Number of partitions to create when reading rows from MarkLogic. " +
         "Increasing this may improve performance as the number of rows to read increases.")
     private int partitions;
@@ -79,5 +82,9 @@ public class ReadRowsParams implements ReadRowsOptions {
     public ReadRowsOptions logProgress(int interval) {
         this.progressInterval = interval;
         return this;
+    }
+
+    public int getPartitions() {
+        return partitions;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/reprocess/ReprocessCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.FluxException;
 import com.marklogic.flux.api.Reprocessor;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.OptionsUtil;
+import com.marklogic.flux.impl.SparkUtil;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.*;
 import picocli.CommandLine;
@@ -63,11 +64,8 @@ public class ReprocessCommand extends AbstractCommand<Reprocessor> implements Re
     }
 
     @Override
-    public String determineSparkMasterUrl() {
-        if (writeParams.threadCount > 0) {
-            return String.format("local[%d]", writeParams.threadCount);
-        }
-        return super.determineSparkMasterUrl();
+    protected String getCustomSparkMasterUrl() {
+        return writeParams.threadCount > 0 ? SparkUtil.makeSparkMasterUrl(writeParams.threadCount) : null;
     }
 
     @Override

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/custom/CustomExportRowsOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/custom/CustomExportRowsOptionsTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl.custom;
+
+import com.marklogic.flux.impl.AbstractOptionsTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomExportRowsOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        CustomExportRowsCommand command = (CustomExportRowsCommand) getCommand(
+            "custom-export-rows",
+            "--query", "anything",
+            "--target", "xml",
+            "--partitions", "4"
+        );
+
+        assertEquals("local[4]", command.determineSparkMasterUrl());
+    }
+}

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportArchiveFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportArchiveFilesOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl.export;
+
+import com.marklogic.flux.impl.AbstractOptionsTest;
+import com.marklogic.spark.Options;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportArchiveFilesOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void encoding() {
+        ExportArchiveFilesCommand command = (ExportArchiveFilesCommand) getCommand(
+            "export-archive-files",
+            "--connection-string", "test:test@host:8000",
+            "--collections", "anything",
+            "--path", "anywhere",
+            "--encoding", "ISO-8859-1"
+        );
+
+        Map<String, String> options = command.writeParams.get();
+        assertEquals("ISO-8859-1", options.get(Options.WRITE_FILES_ENCODING));
+    }
+
+    @Test
+    void streaming() {
+        ExportArchiveFilesCommand command = (ExportArchiveFilesCommand) getCommand(
+            "export-archive-files",
+            "--connection-string", "test:test@host:8000",
+            "--collections", "anything",
+            "--path", "anywhere",
+            "--streaming",
+            "--categories", "collections,permissions",
+            "--no-snapshot"
+        );
+
+        assertOptions(command.makeReadOptions(),
+            Options.STREAM_FILES, "true",
+            Options.READ_DOCUMENTS_COLLECTIONS, "anything",
+            Options.READ_SNAPSHOT, "false"
+        );
+
+        assertOptions(command.makeWriteOptions(),
+            Options.STREAM_FILES, "true",
+
+            // Needed for reading documents and metadata.
+            Options.CLIENT_URI, "test:test@host:8000",
+
+            // Needed so that the connector knows what metadata to retrieve.
+            Options.READ_DOCUMENTS_CATEGORIES, "content,collections,permissions"
+        );
+    }
+}

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcOptionsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl.export;
+
+import com.marklogic.flux.impl.AbstractOptionsTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExportJdbcOptionsTest extends AbstractOptionsTest {
+
+    @Test
+    void test() {
+        ExportJdbcCommand command = (ExportJdbcCommand) getCommand("export-jdbc",
+            "--query", "anything",
+            "--partitions", "12",
+            "--jdbc-url", "some-jdbc-url",
+            "--table", "anywhere"
+        );
+
+        assertEquals("local[12]", command.determineSparkMasterUrl());
+    }
+
+    @Test
+    void userDefinedSparkMasterUrl() {
+        ExportJdbcCommand command = (ExportJdbcCommand) getCommand("export-jdbc",
+            "--query", "anything",
+            "--partitions", "12",
+            "--spark-master-url", "local[6]",
+            "--jdbc-url", "some-jdbc-url",
+            "--table", "anywhere"
+        );
+
+        assertEquals("local[6]", command.determineSparkMasterUrl(), "If the user defines the Spark master URL, " +
+            "then it should be used instead of the one calculated from the number of partitions.");
+    }
+}

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesOptionsTest.java
@@ -20,12 +20,15 @@ class ExportJsonLinesFilesOptionsTest extends AbstractOptionsTest {
             "--query", "anything",
             "--path", "anywhere",
             "--encoding", "UTF-16",
-            "-Pkey=value"
+            "-Pkey=value",
+            "--partitions", "7"
         );
 
         Map<String, String> options = command.getWriteFilesParams().get();
         assertEquals("value", options.get("key"));
         assertEquals("UTF-16", options.get("encoding"), "--encoding is included for consistency with other commands " +
             "that support a custom encoding, even though a user can also specify it via -Pencoding=");
+
+        assertEquals("local[7]", command.determineSparkMasterUrl());
     }
 }


### PR DESCRIPTION
This is for export operations using Optic, where the user is able to specify the number of partitions.

Updated the docs as well, though I'm thinking the docs could use a scrub soon to iron out the subtleties between "partitions" and "Spark threads" and "partition threads".

And - fixed a gitignore issue that had hidden a couple of export tests. Odd.
