### PR TITLE
Added extraction options, and no longer compiling against Java Client

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/GenericFilesImporter.java
@@ -24,6 +24,31 @@ public interface GenericFilesImporter extends Executor<GenericFilesImporter> {
 
     interface WriteGenericDocumentsOptions extends WriteDocumentsOptions<WriteGenericDocumentsOptions> {
         WriteGenericDocumentsOptions documentType(DocumentType documentType);
+
+        /**
+         * @since 1.3.0
+         */
+        WriteGenericDocumentsOptions extractText();
+
+        /**
+         * @since 1.3.0
+         */
+        WriteGenericDocumentsOptions extractedTextDocumentType(DocumentType documentType);
+
+        /**
+         * @since 1.3.0
+         */
+        WriteGenericDocumentsOptions extractedTextCollections(String commaDelimitedCollections);
+
+        /**
+         * @since 1.3.0
+         */
+        WriteGenericDocumentsOptions extractedTextPermissionsString(String rolesAndCapabilities);
+
+        /**
+         * @since 1.3.0
+         */
+        WriteGenericDocumentsOptions extractedTextDropSource();
     }
 
     GenericFilesImporter from(Consumer<ReadGenericFilesOptions> consumer);

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionInputs.java
@@ -3,8 +3,6 @@
  */
 package com.marklogic.flux.impl;
 
-import com.marklogic.client.DatabaseClient;
-import com.marklogic.client.impl.ConnectionString;
 import com.marklogic.flux.api.AuthenticationType;
 import com.marklogic.flux.api.FluxException;
 import com.marklogic.flux.api.SslHostnameVerifier;
@@ -18,6 +16,8 @@ import java.util.Map;
  * with parameter annotations.
  */
 public abstract class ConnectionInputs {
+
+    public enum ConnectionType {DIRECT, GATEWAY}
 
     public static class ConnectionStringValidator implements CommandLine.ITypeConverter<String> {
 
@@ -38,7 +38,7 @@ public abstract class ConnectionInputs {
     protected int port;
     protected String basePath;
     protected String database;
-    protected DatabaseClient.ConnectionType connectionType;
+    protected ConnectionType connectionType;
     protected boolean disableGzippedResponses;
     protected AuthenticationType authType;
     protected String username;

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.flux.impl;
 
-import com.marklogic.client.DatabaseClient;
 import com.marklogic.flux.api.AuthenticationType;
 import com.marklogic.flux.api.ConnectionOptions;
 import com.marklogic.flux.api.SslHostnameVerifier;
@@ -66,14 +65,14 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
         names = "--connection-type",
         description = "Set to 'DIRECT' if connections can be made directly to each host in the MarkLogic cluster. Defaults to 'GATEWAY'. " + OptionsUtil.VALID_VALUES_DESCRIPTION
     )
-    public ConnectionOptions connectionType(DatabaseClient.ConnectionType connectionType) {
+    public ConnectionOptions connectionType(ConnectionType connectionType) {
         this.connectionType = connectionType;
         return this;
     }
 
     @Override
     public ConnectionOptions connectionType(String connectionType) {
-        return connectionType(DatabaseClient.ConnectionType.valueOf(connectionType));
+        return connectionType(ConnectionType.valueOf(connectionType));
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionString.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionString.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * Copied here from marklogic-client-api to avoid compile-time dependency, which can conflict with the
+ * shadowed marklogic-client-api in the marklogic-spark connector.
+ */
+public class ConnectionString {
+
+    private final String host;
+    private final int port;
+    private final String username;
+    private final String password;
+    private final String database;
+
+    public ConnectionString(String connectionString, String optionNameForErrorMessage) {
+        final String errorMessage = String.format(
+            "Invalid value for %s; must be username:password@host:port/optionalDatabaseName",
+            optionNameForErrorMessage
+        );
+
+        String[] parts = connectionString.split("@");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        String[] tokens = parts[0].split(":");
+        if (tokens.length != 2) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        this.username = decodeValue(tokens[0], "username");
+        this.password = decodeValue(tokens[1], "password");
+
+        tokens = parts[1].split(":");
+        if (tokens.length != 2) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        this.host = tokens[0];
+        if (tokens[1].contains("/")) {
+            tokens = tokens[1].split("/");
+            this.port = parsePort(tokens[0], optionNameForErrorMessage);
+            this.database = tokens[1];
+        } else {
+            this.port = parsePort(tokens[1], optionNameForErrorMessage);
+            this.database = null;
+        }
+    }
+
+    private int parsePort(String value, String optionNameForErrorMessage) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format(
+                "Invalid value for %s; port must be numeric, but was '%s'", optionNameForErrorMessage, value
+            ));
+        }
+    }
+
+    private String decodeValue(String value, String label) {
+        try {
+            return URLDecoder.decode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(String.format("Unable to decode '%s'; cause: %s", label, e.getMessage()));
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/OutputConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/OutputConnectionParams.java
@@ -3,7 +3,6 @@
  */
 package com.marklogic.flux.impl.copy;
 
-import com.marklogic.client.DatabaseClient;
 import com.marklogic.flux.api.AuthenticationType;
 import com.marklogic.flux.api.ConnectionOptions;
 import com.marklogic.flux.api.SslHostnameVerifier;
@@ -92,14 +91,14 @@ public class OutputConnectionParams extends ConnectionInputs implements Connecti
         names = "--output-connection-type",
         description = "Set to 'DIRECT' if connections can be made directly to each host in the MarkLogic cluster. Defaults to 'GATEWAY'. " + OptionsUtil.VALID_VALUES_DESCRIPTION
     )
-    public ConnectionOptions connectionType(DatabaseClient.ConnectionType connectionType) {
+    public ConnectionOptions connectionType(ConnectionType connectionType) {
         this.connectionType = connectionType;
         return this;
     }
 
     @Override
     public ConnectionOptions connectionType(String connectionType) {
-        return connectionType(DatabaseClient.ConnectionType.valueOf(connectionType));
+        return connectionType(ConnectionType.valueOf(connectionType));
     }
 
     @Override

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportFilesCommand.java
@@ -170,5 +170,38 @@ public class ImportFilesCommand extends AbstractImportFilesCommand<GenericFilesI
                 Options.WRITE_EXTRACTED_TEXT_DROP_SOURCE, extractedTextDropSource ? "true" : null
             );
         }
+
+        @Override
+        public WriteGenericDocumentsOptions extractText() {
+            this.extractText = true;
+            return this;
+        }
+
+        @Override
+        public WriteGenericDocumentsOptions extractedTextDocumentType(DocumentType documentType) {
+            if (DocumentType.TEXT.equals(documentType)) {
+                documentType = DocumentType.JSON;
+            }
+            this.extractedTextDocumentType = documentType.name();
+            return this;
+        }
+
+        @Override
+        public WriteGenericDocumentsOptions extractedTextCollections(String commaDelimitedCollections) {
+            this.extractedTextCollections = commaDelimitedCollections;
+            return this;
+        }
+
+        @Override
+        public WriteGenericDocumentsOptions extractedTextPermissionsString(String rolesAndCapabilities) {
+            this.extractedTextPermissions = rolesAndCapabilities;
+            return this;
+        }
+
+        @Override
+        public WriteGenericDocumentsOptions extractedTextDropSource() {
+            this.extractedTextDropSource = true;
+            return this;
+        }
     }
 }

--- a/flux-tests-api/build.gradle
+++ b/flux-tests-api/build.gradle
@@ -3,19 +3,14 @@
  * flux-java17-tests subprojects.
  */
 dependencies {
-  compileOnly "com.marklogic:marklogic-client-api:7.1.0"
+  api "com.marklogic:marklogic-client-api:7.1.0"
+
   compileOnly "org.apache.spark:spark-sql_2.12:${sparkVersion}"
 
-  api("com.marklogic:marklogic-junit5:1.5.0") {
-    // Use the Java Client in the connector jar.
-    exclude module: "marklogic-client-api"
-  }
+  api "com.marklogic:marklogic-junit5:1.5.0"
 
   // For configuring two-way SSL in tests.
-  api("com.marklogic:ml-app-deployer:5.0.0") {
-    // Use the Java Client in the connector jar.
-    exclude module: "marklogic-client-api"
-  }
+  api "com.marklogic:ml-app-deployer:5.0.0"
 
   // Using Apache HttpClient for connecting to the MarkLogic Manage API.
   api 'org.apache.httpcomponents:httpclient:4.5.14'


### PR DESCRIPTION
Started this branch with adding the necessary extraction options to the API.

Then modified it to not have to compile against the Java Client, which is now fully shadowed in the marklogic-spark-connector.
