### PR TITLE
Bumped Spark from 3.5.3 to 3.5.5

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,8 +11,8 @@ hadoop-aws 3.3.4 (Apache-2.0)
 hadoop-client 3.3.4 (Apache-2.0)
 marklogic-spark-connector 2.5.1 (Apache-2.0)
 picocli 4.7.6 (Apache-2.0)
-spark-avro_2.12 3.5.3 (Apache-2.0)
-spark-sql_2.12 3.5.3 (Apache-2.0)
+spark-avro_2.12 3.5.5 (Apache-2.0)
+spark-sql_2.12 3.5.5 (Apache-2.0)
 
 Common Licenses
 
@@ -42,11 +42,11 @@ picocli 4.7.6 (Apache-2.0)
 https://repo1.maven.org/maven2/info/picocli/picocli
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 
-spark-avro_2.12 3.5.3 (Apache-2.0)
+spark-avro_2.12 3.5.5 (Apache-2.0)
 https://repo1.maven.org/maven2/org/apache/spark/spark-avro_2.12
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 
-spark-sql_2.12 3.5.3 (Apache-2.0)
+spark-sql_2.12 3.5.5 (Apache-2.0)
 https://repo1.maven.org/maven2/org/apache/spark/spark-sql_2.12
 For the full text of the Apache-2.0 license, see Apache License 2.0 (Apache-2.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
     }
 
     resolutionStrategy {
-      // By default, Spark 3.5.3 does not include the log4j 1.x dependency via its zookeeper dependency. But somehow, by
+      // By default, Spark 3.5.x does not include the log4j 1.x dependency via its zookeeper dependency. But somehow, by
       // adding hadoop-client 3.3.4 to the mix, the log4j 1.x dependency comes via the zookeeper 3.6.3 dependency. Per
       // the release notes at https://zookeeper.apache.org/doc/r3.6.4/releasenotes.html, using zookeeper 3.6.4 - which
       // removes log4j 1.x, thus avoiding the major CVE associated with log4j 1.x - appears safe, which is confirmed by

--- a/docs/spark-integration.md
+++ b/docs/spark-integration.md
@@ -15,7 +15,7 @@ require more system resources than what are available when running Flux as a com
 
 ## Spark security notice
 
-As of October 2024 and the Flux 1.1.0 release, all public releases of Apache Spark 3.4.x through 3.5.3 depend on 
+As of October 2024 and the Flux 1.1.0 release, all public releases of Apache Spark 3.4.x through 3.5.5 depend on 
 Apache Hadoop 3.3.4. This version of Hadoop has a 
 [CVE filed against it](https://nvd.nist.gov/vuln/detail/CVE-2023-26031). The CVE involves Spark running with a 
 YARN cluster manager and the YARN cluster "is accepting work from remote (authenticated) users". 
@@ -40,8 +40,8 @@ To use Flux with `spark-submit`, first download the `marklogic-flux-1.2.1-all.ja
 its dependencies, excluding those of Spark itself, which will be provided via the Spark cluster that you connect to 
 via `spark-submit`. 
 
-You can now run any Flux command with `spark-submit`. As of Flux 1.2.0, Flux depends on Spark 3.5.3, and thus you should
-use Spark 3.5.3 or higher. Prior versions of Spark 3.5.x may work as well. Please also ensure that you use a Spark 
+You can now run any Flux command with `spark-submit`. As of Flux 1.2.0, Flux depends on Spark 3.5.5, and thus you should
+use Spark 3.5.5 or higher. Prior versions of Spark 3.5.x may work as well. Please also ensure that you use a Spark 
 runtime that depends on Scala 2.12 and not Scala 2.13.
 
 The following shows a notional example of running the Flux `import-files` command:

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation "org.apache.hadoop:hadoop-client:3.3.4"
 
   // Spark doesn't include Avro support by default, so need to bring this in.
-  implementation "org.apache.spark:spark-avro_2.12:3.5.3"
+  implementation "org.apache.spark:spark-avro_2.12:${sparkVersion}"
 
   distributionDependencies "org.apache.tika:tika-parser-microsoft-module:${tikaVersion}"
   distributionDependencies "org.apache.tika:tika-parser-pdf-module:${tikaVersion}"


### PR DESCRIPTION
Should be a no-op in terms of functionality, but does bump a few transitive dependencies up.
