### PR TITLE
Bumping langchain4j

### DIFF
--- a/flux-embedding-model-azure-open-ai/build.gradle
+++ b/flux-embedding-model-azure-open-ai/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-azure-open-ai:${langchain4jVersion}") {
+  implementation ("dev.langchain4j:langchain4j-azure-open-ai:1.0.0-beta4") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"
@@ -19,7 +19,7 @@ dependencies {
   }
 
   // Repeating this here so that the Jackson dependencies are included for running tests in this subproject.
-  testImplementation "dev.langchain4j:langchain4j-azure-open-ai:${langchain4jVersion}"
+  testImplementation "dev.langchain4j:langchain4j-azure-open-ai:1.0.0-beta4"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.11.2"
   testImplementation "ch.qos.logback:logback-classic:1.5.18"

--- a/flux-embedding-model-minilm/build.gradle
+++ b/flux-embedding-model-minilm/build.gradle
@@ -11,7 +11,7 @@ java {
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:${langchain4jVersion}") {
+  implementation ("dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.0.0-beta4") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"

--- a/flux-embedding-model-ollama/build.gradle
+++ b/flux-embedding-model-ollama/build.gradle
@@ -11,14 +11,14 @@ java {
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-ollama:${langchain4jVersion}") {
+  implementation ("dev.langchain4j:langchain4j-ollama:1.0.0-beta4") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"
   }
 
-// Repeating this here so that the Jackson dependencies are included for running tests in this subproject.
-  testImplementation "dev.langchain4j:langchain4j-ollama:${langchain4jVersion}"
+  // Repeating this here so that the Jackson dependencies are included for running tests in this subproject.
+  testImplementation "dev.langchain4j:langchain4j-ollama:1.0.0-beta4"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.11.2"
   testImplementation "ch.qos.logback:logback-classic:1.5.18"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ connectorVersion=2.6-SNAPSHOT
 
 # Aligned with our Spark connector.
 sparkVersion=3.5.5
-langchain4jVersion=1.0.0-beta2
+langchain4jVersion=1.0.0-rc1
 tikaVersion=3.1.0
 
 # Define these on the command line to publish to OSSRH


### PR DESCRIPTION
Unfortunately only the main library is on 1.0.0-rc1 while the others are still on 1.0.0-beta4.
