### PR TITLE
MLE-21825 Can now choose type of TDE to generate

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/tde/JsonTdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/JsonTdeBuilder.java
@@ -50,7 +50,7 @@ public class JsonTdeBuilder implements TdeBuilder {
         }
 
         addColumns(row, tdeInputs);
-        return new JsonTemplate(tde);
+        return new JsonTemplate(tde, tdeInputs.getPermissions(), tdeInputs);
     }
 
     private static void addColumns(ObjectNode row, TdeInputs tdeInputs) {
@@ -108,7 +108,7 @@ public class JsonTdeBuilder implements TdeBuilder {
         columnNode.put("scalarType", scalarType);
 
         final String val = (inputs.getColumnVals() != null && inputs.getColumnVals().containsKey(name))
-            ? inputs.getColumnVals().get(name) : name;
+            ? inputs.getColumnVals().get(name) : column.getVal();
         columnNode.put("val", val);
 
         return columnNode;
@@ -116,19 +116,35 @@ public class JsonTdeBuilder implements TdeBuilder {
 
     private static class JsonTemplate implements TdeTemplate {
         private final ObjectNode tdeTemplate;
+        private final String permissions;
+        private final String uri;
 
-        public JsonTemplate(ObjectNode tdeTemplate) {
+        public JsonTemplate(ObjectNode tdeTemplate, String permissions, TdeInputs inputs) {
             this.tdeTemplate = tdeTemplate;
+            this.permissions = permissions;
+            final String inputUri = inputs.getUri();
+            this.uri = inputUri != null && !inputUri.isEmpty() ? inputUri :
+                String.format("/tde/%s/%s.json", inputs.getSchemaName(), inputs.getViewName());
         }
 
         @Override
-        public AbstractWriteHandle toWriteHandle() {
+        public AbstractWriteHandle getWriteHandle() {
             return new JacksonHandle(tdeTemplate);
         }
 
         @Override
         public String toPrettyString() {
             return tdeTemplate.toPrettyString();
+        }
+
+        @Override
+        public String getUri() {
+            return uri;
+        }
+
+        @Override
+        public String getPermissions() {
+            return permissions;
         }
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeBuilder.java
@@ -5,9 +5,5 @@ package com.marklogic.flux.tde;
 
 public interface TdeBuilder {
 
-    static TdeBuilder newTdeBuilder(TdeInputs inputs) {
-        return inputs.isJson() ? new JsonTdeBuilder() : new XmlTdeBuilder();
-    }
-
     TdeTemplate buildTde(TdeInputs inputs);
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
@@ -32,7 +32,6 @@ public class TdeInputs {
     private String[] collections;
     private String[] directories;
     private String permissions;
-    private boolean json = true; // Default to JSON TDE, can be set to false for XML TDE
     private boolean disabled;
     private String viewLayout;
     private Map<String, String> columnVals;
@@ -65,27 +64,23 @@ public class TdeInputs {
     }
 
     public TdeInputs withJsonRootName(String jsonRootName) {
-        if (jsonRootName != null && !jsonRootName.isEmpty()) {
-            this.json = true;
+        if (jsonRootName != null && !jsonRootName.isEmpty()
             // Don't override the context if the user already specified one.
-            if (DEFAULT_CONTEXT.equals(this.context)) {
-                this.context = "/" + jsonRootName;
-            }
+            && DEFAULT_CONTEXT.equals(this.context)) {
+            this.context = "/" + jsonRootName;
         }
         return this;
     }
 
     public TdeInputs withXmlRootName(String xmlRootName, String namespace) {
-        if (xmlRootName != null && !xmlRootName.isEmpty()) {
-            this.json = false;
+        if (xmlRootName != null && !xmlRootName.isEmpty()
             // Don't override the context if the user already specified one.
-            if (DEFAULT_CONTEXT.equals(this.context)) {
-                if (namespace != null) {
-                    this.namespaces.put("ns1", namespace);
-                    this.context = "/ns1:" + xmlRootName;
-                } else {
-                    this.context = "/" + xmlRootName;
-                }
+            && DEFAULT_CONTEXT.equals(this.context)) {
+            if (namespace != null) {
+                this.namespaces.put("ns1", namespace);
+                this.context = "/ns1:" + xmlRootName;
+            } else {
+                this.context = "/" + xmlRootName;
             }
         }
         return this;
@@ -182,10 +177,6 @@ public class TdeInputs {
 
     public Map<String, String> getNamespaces() {
         return namespaces;
-    }
-
-    public boolean isJson() {
-        return json;
     }
 
     public String getPermissions() {

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeTemplate.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeTemplate.java
@@ -7,7 +7,14 @@ import marklogicspark.marklogic.client.io.marker.AbstractWriteHandle;
 
 public interface TdeTemplate {
 
-    AbstractWriteHandle toWriteHandle();
+    String getUri();
+
+    AbstractWriteHandle getWriteHandle();
+
+    /**
+     * @return a comma-delimited string of permissions in the format of role1,capability1,role2,capability2,...
+     */
+    String getPermissions();
 
     String toPrettyString();
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/XmlTdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/XmlTdeBuilder.java
@@ -52,7 +52,7 @@ public class XmlTdeBuilder implements TdeBuilder {
             xmlTemplate.setDisabled();
         }
 
-        return new DOMTemplate(doc);
+        return new DOMTemplate(doc, tdeInputs.getPermissions(), tdeInputs);
     }
 
     private static class XmlTemplate {
@@ -92,7 +92,7 @@ public class XmlTdeBuilder implements TdeBuilder {
         void addColumn(TdeInputs.Column column, TdeInputs inputs) {
             Element columnElement = addColumnWithRequiredFields(column, inputs);
             final String name = column.getName();
-            
+
             if (inputs.getNullableColumns() != null && inputs.getNullableColumns().contains(name)) {
                 addChildWithText(columnElement, "nullable", "true");
             }
@@ -131,7 +131,7 @@ public class XmlTdeBuilder implements TdeBuilder {
             addChildWithText(columnElement, "scalar-type", scalarType);
 
             final String val = inputs.getColumnVals() != null && inputs.getColumnVals().containsKey(name) ?
-                inputs.getColumnVals().get(name) : name;
+                inputs.getColumnVals().get(name) : column.getVal();
             addChildWithText(columnElement, "val", val);
             return columnElement;
         }
@@ -174,19 +174,35 @@ public class XmlTdeBuilder implements TdeBuilder {
 
     private static class DOMTemplate implements TdeTemplate {
         private final Document tdeTemplate;
+        private final String permissions;
+        private final String uri;
 
-        public DOMTemplate(Document tdeTemplate) {
+        public DOMTemplate(Document tdeTemplate, String permissions, TdeInputs inputs) {
             this.tdeTemplate = tdeTemplate;
+            this.permissions = permissions;
+            final String inputUri = inputs.getUri();
+            this.uri = inputUri != null && !inputUri.isEmpty() ? inputUri :
+                String.format("/tde/%s/%s.xml", inputs.getSchemaName(), inputs.getViewName());
         }
 
         @Override
-        public AbstractWriteHandle toWriteHandle() {
+        public AbstractWriteHandle getWriteHandle() {
             return new DOMHandle(tdeTemplate);
         }
 
         @Override
         public String toPrettyString() {
             return DOMHelper.prettyPrintNode(tdeTemplate);
+        }
+
+        @Override
+        public String getUri() {
+            return uri;
+        }
+
+        @Override
+        public String getPermissions() {
+            return permissions;
         }
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithTdeTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithTdeTest.java
@@ -23,7 +23,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ImportJdbcWithTdeTest extends AbstractTest {
 
-    private static final String DEFAULT_TDE_URI = "/tde/junit/customer.json";
+    private static final String JSON_TDE_URI = "/tde/junit/customer.json";
+    private static final String XML_TDE_URI = "/tde/junit/customer.xml";
 
     private DatabaseClient schemasDatabaseClient;
 
@@ -36,7 +37,7 @@ class ImportJdbcWithTdeTest extends AbstractTest {
     void deleteCustomerTemplate() {
         // This needs to be deleted after a test so as not to impact other tests that aren't aware that this might
         // exist.
-        schemasDatabaseClient.newDocumentManager().delete(DEFAULT_TDE_URI, "/tde/custom-uri.json");
+        schemasDatabaseClient.newDocumentManager().delete(JSON_TDE_URI, XML_TDE_URI, "/tde/custom-uri.json");
         schemasDatabaseClient.release();
     }
 
@@ -80,6 +81,26 @@ class ImportJdbcWithTdeTest extends AbstractTest {
 
         assertCollectionSize("customer", 10);
         verifyOpticQueryUsingTdeViewReturnsCustomers();
+
+        assertNotNull(schemasDatabaseClient.newDocumentManager().exists(JSON_TDE_URI));
+        assertNull(schemasDatabaseClient.newDocumentManager().exists(XML_TDE_URI));
+    }
+
+    @Test
+    void xmlTde() {
+        importJdbcWithArgs(
+            "--tde-schema", "junit",
+            "--tde-view", "customer",
+            "--tde-document-type", "xml",
+            "--tde-permissions", "flux-test-role,read,flux-test-role,update",
+            "--tde-collections", "customer"
+        );
+
+        assertCollectionSize("customer", 10);
+        verifyOpticQueryUsingTdeViewReturnsCustomers();
+
+        assertNotNull(schemasDatabaseClient.newDocumentManager().exists(XML_TDE_URI));
+        assertNull(schemasDatabaseClient.newDocumentManager().exists(JSON_TDE_URI));
     }
 
     @Test
@@ -114,7 +135,7 @@ class ImportJdbcWithTdeTest extends AbstractTest {
         verifyOpticQueryUsingTdeViewReturnsCustomers();
 
         assertNotNull(schemasDatabaseClient.newDocumentManager().exists("/tde/custom-uri.json"));
-        assertNull(schemasDatabaseClient.newDocumentManager().exists(DEFAULT_TDE_URI));
+        assertNull(schemasDatabaseClient.newDocumentManager().exists(JSON_TDE_URI));
     }
 
     @Test
@@ -245,7 +266,7 @@ class ImportJdbcWithTdeTest extends AbstractTest {
 
     private void verifyTdeContainsColumnCustomizations() {
         JsonNode tdeTemplate = schemasDatabaseClient.newJSONDocumentManager()
-            .read(DEFAULT_TDE_URI, new JacksonHandle()).get();
+            .read(JSON_TDE_URI, new JacksonHandle()).get();
 
         JsonNode columns = tdeTemplate.get("template").get("rows").get(0).get("columns");
 

--- a/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildJsonTdeTest.java
+++ b/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildJsonTdeTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * This test is in this Java17-dependent project solely for using triple quotes for easily putting the
  * expected TDE template in the test.
@@ -229,7 +231,10 @@ class BuildJsonTdeTest {
     }
 
     private ObjectNode buildTde(TdeInputs inputs) {
-        AbstractWriteHandle handle = TdeBuilder.newTdeBuilder(inputs).buildTde(inputs).toWriteHandle();
+        TdeTemplate template = new JsonTdeBuilder().buildTde(inputs);
+        assertEquals("/tde/%s/%s.json".formatted(inputs.getSchemaName(), inputs.getViewName()), template.getUri());
+
+        AbstractWriteHandle handle = template.getWriteHandle();
         return (ObjectNode) ((JacksonHandle) handle).get();
     }
 }

--- a/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildXmlTdeTest.java
+++ b/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildXmlTdeTest.java
@@ -15,6 +15,7 @@ import org.xmlunit.diff.Diff;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class BuildXmlTdeTest {
@@ -182,7 +183,10 @@ class BuildXmlTdeTest {
     }
 
     private Document buildTde(TdeInputs inputs) {
-        AbstractWriteHandle handle = TdeBuilder.newTdeBuilder(inputs).buildTde(inputs).toWriteHandle();
+        TdeTemplate template = new XmlTdeBuilder().buildTde(inputs);
+        assertEquals("/tde/%s/%s.xml".formatted(inputs.getSchemaName(), inputs.getViewName()), template.getUri());
+
+        AbstractWriteHandle handle = template.getWriteHandle();
         return ((DOMHandle) handle).get();
     }
 


### PR DESCRIPTION
I realized I messed this up initially - the user needs an option to choose whether JSON or XML should be used for the TDE. And that's independent of whether the documents being written to MarkLogic are XML or JSON.
