### PR TITLE
MLE-21825 Improved unit tests to load TDE

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SparkColumnIterator.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/SparkColumnIterator.java
@@ -1,8 +1,9 @@
 /*
  * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
  */
-package com.marklogic.flux.tde;
+package com.marklogic.flux.impl.importdata;
 
+import com.marklogic.flux.tde.TdeInputs;
 import org.apache.spark.sql.types.*;
 
 import java.util.Arrays;

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class TdeInputs {
 
-    interface Column {
+    public interface Column {
         String getName();
 
         default String getVal() {

--- a/flux-java17-tests/src/test/java/com/marklogic/flux/tde/AbstractTdeTest.java
+++ b/flux-java17-tests/src/test/java/com/marklogic/flux/tde/AbstractTdeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.tde;
+
+import com.marklogic.flux.AbstractJava17Test;
+import marklogicspark.marklogic.client.DatabaseClient;
+import marklogicspark.marklogic.client.DatabaseClientFactory;
+
+import java.util.Properties;
+
+abstract class AbstractTdeTest extends AbstractJava17Test {
+
+    protected final void verifyTdeCanBeLoaded(TdeTemplate template) {
+        Properties props = loadTestProperties();
+        final String uri = template.getUri();
+        DatabaseClient client = null;
+        try {
+            client = DatabaseClientFactory.newClient(props::get);
+            // Verify that the TDE can be loaded without errors.
+            new TdeLoader(client).loadTde(template);
+        } finally {
+            if (client != null) {
+                client.newDocumentManager().delete(uri);
+                client.release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This ensures the TDE can be loaded without error.

Also did a simple move of SparkColumnIterator to a spark-specific package.
