### PR TITLE
MLE-21825 Refactored TDE generator with my good friend Copilot

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeBuilder.java
@@ -3,7 +3,35 @@
  */
 package com.marklogic.flux.tde;
 
+import java.util.Iterator;
+import java.util.Set;
+
 public interface TdeBuilder {
 
-    TdeTemplate buildTde(TdeInputs inputs);
+    TdeTemplate buildTde(TdeInputs inputs, Iterator<Column> columns);
+
+    interface Column {
+        String getName();
+
+        String getVal();
+
+        String getScalarType();
+
+        boolean isNullable();
+
+        String getDefaultValue();
+
+        String getInvalidValues();
+
+        String getReindexing();
+
+        /**
+         * @return a set of role names that define read permissions for the column. A MarkLogic TDE uses the term
+         * "permissions" even though it's really a set of role names (while "permission" normally refers to a role
+         * name joined with a capability in MarkLogic).
+         */
+        Set<String> getPermissions();
+
+        String getCollation();
+    }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
@@ -4,25 +4,14 @@
 package com.marklogic.flux.tde;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TdeInputs {
 
-    public interface Column {
-        String getName();
-
-        default String getVal() {
-            return getName();
-        }
-
-        String getScalarType();
-    }
-
     private final String schemaName;
     private final String viewName;
-    private final Iterator<Column> columns;
     private final Map<String, String> namespaces = new HashMap<>();
 
     private static final String DEFAULT_CONTEXT = "/";
@@ -39,14 +28,13 @@ public class TdeInputs {
     private Map<String, String> columnDefaultValues;
     private Map<String, String> columnInvalidValues;
     private Map<String, String> columnReindexing;
-    private Map<String, String> columnPermissions;
+    private Map<String, Set<String>> columnPermissions;
     private Map<String, String> columnCollations;
     private List<String> nullableColumns;
 
-    public TdeInputs(String schemaName, String viewName, Iterator<Column> columns) {
+    public TdeInputs(String schemaName, String viewName) {
         this.schemaName = schemaName;
         this.viewName = viewName;
-        this.columns = columns;
     }
 
     public TdeInputs withContext(String context) {
@@ -136,7 +124,7 @@ public class TdeInputs {
         return this;
     }
 
-    public TdeInputs withColumnPermissions(Map<String, String> columnPermissions) {
+    public TdeInputs withColumnPermissions(Map<String, Set<String>> columnPermissions) {
         this.columnPermissions = columnPermissions;
         return this;
     }
@@ -157,10 +145,6 @@ public class TdeInputs {
 
     public String getViewName() {
         return viewName;
-    }
-
-    public Iterator<Column> getColumns() {
-        return columns;
     }
 
     public String getContext() {
@@ -215,7 +199,7 @@ public class TdeInputs {
         return columnReindexing;
     }
 
-    public Map<String, String> getColumnPermissions() {
+    public Map<String, Set<String>> getColumnPermissions() {
         return columnPermissions;
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
@@ -5,12 +5,11 @@ package com.marklogic.flux.impl.importdata;
 
 import com.marklogic.flux.impl.AbstractOptionsTest;
 import com.marklogic.flux.tde.TdeInputs;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +40,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        TdeInputs inputs = params.buildTdeInputs(new StructType().add("doesnt-matter", DataTypes.StringType));
+        TdeInputs inputs = params.buildTdeInputs();
         String[] directories = inputs.getDirectories();
         assertEquals(2, directories.length);
         assertEquals("/dir1", directories[0]);
@@ -76,10 +75,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        StructType schema = new StructType()
-            .add("column1", DataTypes.StringType)
-            .add("column2", DataTypes.StringType);
-        TdeInputs inputs = params.buildTdeInputs(schema);
+        TdeInputs inputs = params.buildTdeInputs();
 
         Map<String, String> columnVals = inputs.getColumnVals();
         assertEquals("customVal1", columnVals.get("column1"));
@@ -101,9 +97,10 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         assertEquals("visible", columnReindexing.get("column1"));
         assertEquals("hidden", columnReindexing.get("column2"));
 
-        Map<String, String> columnPermissions = inputs.getColumnPermissions();
-        assertEquals("role1,role2", columnPermissions.get("column1"));
-        assertEquals("role3", columnPermissions.get("column2"));
+        Map<String, Set<String>> columnPermissions = inputs.getColumnPermissions();
+        assertTrue(columnPermissions.get("column1").contains("role1"));
+        assertTrue(columnPermissions.get("column1").contains("role2"));
+        assertTrue(columnPermissions.get("column2").contains("role3"));
 
         Map<String, String> columnCollation = inputs.getColumnCollations();
         assertEquals("http://marklogic.com/collation/codepoint", columnCollation.get("column1"));

--- a/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildXmlTdeTest.java
+++ b/flux-java17-tests/src/test/java/com/marklogic/flux/tde/BuildXmlTdeTest.java
@@ -15,6 +15,7 @@ import org.xmlunit.diff.Diff;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,7 +48,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
             </template>""";
 
         Document doc = buildTde(
-            new TdeInputs("my_schema", "my_view", new SparkColumnIterator(SCHEMA))
+            new TdeInputs("my_schema", "my_view")
                 .withCollections("customer")
                 .withDirectories()
                 .withXmlRootName("my-root", null));
@@ -91,7 +92,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
             </template>""";
 
         Document doc = buildTde(
-            new TdeInputs("my_schema", "my_view", new SparkColumnIterator(SCHEMA))
+            new TdeInputs("my_schema", "my_view")
                 .withCollections("customer", "another-collection")
                 .withDirectories("/dir1/", "dir2/")
                 .withViewLayout("sparse")
@@ -122,7 +123,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
             </template>""";
 
         Document doc = buildTde(
-            new TdeInputs("my_schema", "my_view", new SparkColumnIterator(SCHEMA))
+            new TdeInputs("my_schema", "my_view")
                 .withContext("/some-custom-context")
                 .withDisabled(true)
                 .withXmlRootName("my-root", null));
@@ -130,7 +131,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
         verifyTemplate(expectedXml, doc);
 
         doc = buildTde(
-            new TdeInputs("my_schema", "my_view", new SparkColumnIterator(SCHEMA))
+            new TdeInputs("my_schema", "my_view")
                 .withXmlRootName("my-root", null)
                 .withDisabled(true)
                 .withContext("/some-custom-context"));
@@ -168,7 +169,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
             </template>""";
 
         Document doc = buildTde(
-            new TdeInputs("my_schema", "my_view", new SparkColumnIterator(SCHEMA))
+            new TdeInputs("my_schema", "my_view")
                 .withXmlRootName("my-root", null)
                 .withColumnVals(Map.of("myString", "myStringValue"))
                 .withColumnTypes(Map.of("myString", "int"))
@@ -176,7 +177,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
                 .withColumnDefaultValues(Map.of("myString", "0"))
                 .withColumnInvalidValues(Map.of("myString", "reject"))
                 .withColumnReindexing(Map.of("myString", "visible"))
-                .withColumnPermissions(Map.of("myString", "rest-reader,rest-writer"))
+                .withColumnPermissions(Map.of("myString", Set.of("rest-reader", "rest-writer")))
                 .withColumnCollations(Map.of("myString", "http://marklogic.com/collation/codepoint"))
         );
 
@@ -184,7 +185,7 @@ class BuildXmlTdeTest extends AbstractTdeTest {
     }
 
     private Document buildTde(TdeInputs inputs) {
-        TdeTemplate template = new XmlTdeBuilder().buildTde(inputs);
+        TdeTemplate template = new XmlTdeBuilder().buildTde(inputs, new SparkColumnIterator(SCHEMA, inputs));
         assertEquals("/tde/%s/%s.xml".formatted(inputs.getSchemaName(), inputs.getViewName()), template.getUri());
 
         verifyTdeCanBeLoaded(template);


### PR DESCRIPTION
And I'm now curious to see what comments GitHub Copilot makes about the code that VSCode Copilot generated.

Summary from Copilot:

The refactoring journey we just completed was really satisfying:

Started with duplicated column customization logic scattered across JsonTdeBuilder and XmlTdeBuilder
Moved all the logic into the Column interface methods in SparkColumn
Renamed everything to use consistent "permissions" terminology (matching MarkLogic's naming)
Upgraded from String[] to Set<String> for better type safety and consistency
Centralized the comma-splitting logic in WriteStructuredDocumentParams where it belongs
Now the code is much more maintainable - all column customization logic lives in one place (SparkColumn), the builders are clean and focused, and everything uses consistent naming and types throughout!
