### PR TITLE
MLE-21825 Refactor: Moved TDE params into their own class

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.CustomImporter;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.S3Params;
+import com.marklogic.flux.impl.importdata.TdeHelper;
 import com.marklogic.flux.impl.importdata.WriteStructuredDocumentParams;
 import org.apache.spark.sql.*;
 import picocli.CommandLine;
@@ -37,9 +38,12 @@ public class CustomImportCommand extends AbstractCommand<CustomImporter> impleme
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
+
         return super.afterDatasetLoaded(dataset);
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
@@ -136,10 +136,12 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
-
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
+        
         // If jsonLinesRaw, the MarkLogic connector is used, in which case the Spark file path column will not be present.
         if (readParams.uriIncludeFilePath && !readParams.jsonLinesRaw) {
             dataset = SparkUtil.addFilePathColumn(dataset);

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -103,9 +103,11 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
 
         return dataset;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -127,9 +127,11 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
 
         return dataset;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
@@ -53,9 +53,11 @@ public class ImportJdbcCommand extends AbstractCommand<JdbcImporter> implements 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
         return dataset;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -103,9 +103,11 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
 
         return dataset;
     }

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
@@ -103,10 +103,12 @@ public class ImportParquetFilesCommand extends AbstractImportFilesCommand<Parque
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper tdeHelper = new TdeHelper(writeParams.getTdeParams(), writeParams.getJsonRootName(), writeParams.getXmlRootName(), writeParams.getXmlNamespace());
+        if (tdeHelper.logTemplateIfNecessary(dataset.schema())) {
             return null;
         }
-
+        tdeHelper.loadTemplateIfNecessary(dataset.schema(), getConnectionParams());
+        
         return dataset;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeHelper.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl.importdata;
+
+import com.marklogic.flux.impl.ConnectionParams;
+import com.marklogic.flux.tde.*;
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Util;
+import marklogicspark.marklogic.client.DatabaseClient;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Acts as the bridge between the command classes that collect all the TDE-specific inputs and the classes for
+ * building and loading a TDE based on all the inputs. Supports both use cases of previewing a TDE by logging it and
+ * actually loading a TDE into MarkLogic.
+ */
+public class TdeHelper {
+
+    private final TdeParams tdeParams;
+    private final String jsonRootName;
+    private final String xmlRootName;
+    private final String xmlNamespace;
+
+    public TdeHelper(TdeParams tdeParams, String jsonRootName, String xmlRootName, String xmlNamespace) {
+        this.tdeParams = tdeParams;
+        this.jsonRootName = jsonRootName;
+        this.xmlRootName = xmlRootName;
+        this.xmlNamespace = xmlNamespace;
+    }
+
+    public boolean logTemplateIfNecessary(StructType sparkSchema) {
+        if (tdeParams.getSchemaName() != null && tdeParams.getViewName() != null && tdeParams.isPreview() && Util.MAIN_LOGGER.isInfoEnabled()) {
+            TdeTemplate tdeTemplate = buildTdeTemplate(sparkSchema);
+            Util.MAIN_LOGGER.info("Generated TDE:\n{}", tdeTemplate.toPrettyString());
+            return true;
+        }
+        return false;
+    }
+
+    public void loadTemplateIfNecessary(StructType sparkSchema, ConnectionParams connectionParams) {
+        if (tdeParams.getSchemaName() != null && tdeParams.getViewName() != null && !tdeParams.isPreview()) {
+            TdeTemplate tdeTemplate = buildTdeTemplate(sparkSchema);
+            try (DatabaseClient client = new ContextSupport(connectionParams.makeOptions()).connectToMarkLogic()) {
+                new TdeLoader(client).loadTde(tdeTemplate);
+            }
+        }
+    }
+
+    private TdeTemplate buildTdeTemplate(StructType sparkSchema) {
+        // This is awkward. We want a TdeParams object that captures all the TDE-specific fields - but the JSON/XML
+        // root fields are not specific to the TDE yet must affect the TDE context if the user didn't already
+        // specify a TDE context. Probably needs another refactor so that this modification doesn't occur - i.e. some
+        // sort of "default context provider" that gets passed to the TdeBuilder.
+        tdeParams.withJsonRootName(jsonRootName);
+        tdeParams.withXmlRootName(xmlRootName, xmlNamespace);
+        TdeBuilder tdeBuilder = "xml".equalsIgnoreCase(tdeParams.getDocumentType()) ? new XmlTdeBuilder() : new JsonTdeBuilder();
+        return tdeBuilder.buildTde(tdeParams, new SparkColumnIterator(sparkSchema, tdeParams));
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeParams.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl.importdata;
+
+import com.marklogic.flux.tde.TdeInputs;
+import picocli.CommandLine;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+/**
+ * Extends the non-Spark-specific TdeInputs class to provide command-line options for each of the inputs. The document
+ * type and preview mode are specific to Flux and thus not part of the TdeInputs class.
+ */
+public class TdeParams extends TdeInputs {
+
+    private String documentType = "json";
+    private boolean preview;
+
+    @CommandLine.Option(
+        names = "--tde-schema",
+        description = "Schema name of the TDE template to generate. Has no effect unless --tde-view is also specified."
+    )
+    public void setSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-view",
+        description = "View name of the TDE template to generate. Has no effect unless --tde-schema is also specified."
+    )
+    public void setViewName(String viewName) {
+        this.viewName = viewName;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-context",
+        description = "Context path to use for the generated TDE template. Will override the default context path of " +
+            "'/' and any context path determined by the use of --json-root-name or --xml-root-name."
+    )
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-collections",
+        description = "Comma-delimited sequence of collection names to include in the generated TDE template - e.g. collection1,collection2."
+    )
+    public void setCollectionsString(String collectionsString) {
+        this.collections = collectionsString != null ? collectionsString.split(",") : null;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-directory",
+        description = "Database directories to include in the generated TDE template."
+    )
+    public void setDirectoriesList(List<String> directories) {
+        this.directories = directories != null ? directories.toArray(new String[0]) : null;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-permissions",
+        description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to the generated TDE template - e.g. role1,read,role2,update,role3,execute."
+    )
+    public void setPermissions(String permissions) {
+        this.permissions = permissions;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-uri",
+        description = "URI for loading the generated TDE template."
+    )
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-template-disabled",
+        description = "If set, the TDE template will be loaded but in a disabled state."
+    )
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-view-layout",
+        description = "View layout for the TDE template; defaults to 'sparse', can instead be set to 'identical'."
+    )
+    public void setViewLayout(String viewLayout) {
+        this.viewLayout = viewLayout;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-val",
+        description = "Custom 'val' value for a column name in the generated TDE template; e.g. --tde-column-val myColumn=myValue. " +
+            "This option can be specified multiple times."
+    )
+    public void setColumnVals(Map<String, String> columnVals) {
+        this.columnVals = columnVals;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-type",
+        description = "Custom scalar type for a column name in the generated TDE template; e.g. --tde-column-type myColumn=dateTime. " +
+            "This option can be specified multiple times."
+    )
+    public void setColumnTypes(Map<String, String> columnTypes) {
+        this.columnTypes = columnTypes;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-default",
+        description = "Default value for a column name in the generated TDE template; e.g. --tde-column-default myColumn=defaultValue. " +
+            "This option can be specified multiple times."
+    )
+    public void setColumnDefaultValues(Map<String, String> columnDefaultValues) {
+        this.columnDefaultValues = columnDefaultValues;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-invalid-values",
+        description = "Invalid values handling for a column name in the generated TDE template; e.g. --tde-column-invalid-values myColumn=reject. " +
+            "Value can be 'ignore' or 'reject'. This option can be specified multiple times."
+    )
+    public void setColumnInvalidValues(Map<String, String> columnInvalidValues) {
+        this.columnInvalidValues = columnInvalidValues;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-reindexing",
+        description = "Reindexing setting for a column name in the generated TDE template; e.g. --tde-column-reindexing myColumn=visible. " +
+            "Value can be 'hidden' or 'visible'. This option can be specified multiple times."
+    )
+    public void setColumnReindexing(Map<String, String> columnReindexing) {
+        this.columnReindexing = columnReindexing;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-permissions",
+        description = "Comma-delimited role names for defining read permissions for a column in the generated " +
+            "TDE template; e.g. --tde-column-permissions myColumn=role1,role2. " +
+            "This option can be specified multiple times."
+    )
+    public void setColumnPermissionsString(Map<String, String> columnPermissionsString) {
+        if (columnPermissionsString != null) {
+            this.columnPermissions = columnPermissionsString.entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> Arrays.stream(entry.getValue().split(","))
+                        .map(String::trim)
+                        .collect(Collectors.toSet())
+                ));
+        }
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-nullable",
+        description = "Name of a column that should be marked as nullable in the generated TDE template. " +
+            "This option can be specified multiple times."
+    )
+    public void setNullableColumns(List<String> nullableColumns) {
+        this.nullableColumns = nullableColumns;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-column-collation",
+        description = "Collation for a column name in the generated TDE template; e.g. --tde-column-collation myColumn=http://marklogic.com/collation/codepoint. " +
+            "This option can be specified multiple times."
+    )
+    public void setColumnCollations(Map<String, String> columnCollations) {
+        this.columnCollations = columnCollations;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-document-type",
+        description = "Type of document to generate in the TDE template; defaults to 'json', can be set to 'xml'."
+    )
+    public void setDocumentType(String documentType) {
+        this.documentType = documentType;
+    }
+
+    @CommandLine.Option(
+        names = "--tde-preview"
+    )
+    public void setPreview(boolean preview) {
+        this.preview = preview;
+    }
+
+    public String getDocumentType() {
+        return documentType;
+    }
+
+    public boolean isPreview() {
+        return preview;
+    }
+
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/WriteStructuredDocumentParams.java
@@ -4,21 +4,11 @@
 package com.marklogic.flux.impl.importdata;
 
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
-import com.marklogic.flux.impl.ConnectionParams;
 import com.marklogic.flux.impl.OptionsUtil;
-import com.marklogic.flux.tde.*;
-import com.marklogic.spark.ContextSupport;
 import com.marklogic.spark.Options;
-import com.marklogic.spark.Util;
-import marklogicspark.marklogic.client.DatabaseClient;
-import org.apache.spark.sql.types.StructType;
 import picocli.CommandLine;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * For import commands that can write "structured" rows with an arbitrary schema, either as JSON or XML documents.
@@ -49,129 +39,8 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
     )
     private boolean ignoreNullFields;
 
-    @CommandLine.Option(
-        names = "--tde-schema",
-        description = "Schema name of the TDE template to generate. Has no effect unless --tde-view is also specified."
-
-    )
-    private String tdeSchema;
-
-    @CommandLine.Option(
-        names = "--tde-view",
-        description = "View name of the TDE template to generate. Has no effect unless --tde-schema is also specified."
-    )
-    private String tdeView;
-
-    @CommandLine.Option(
-        names = "--tde-document-type",
-        description = "Type of document to generate in the TDE template; defaults to 'json', can be set to 'xml'."
-    )
-    private String tdeDocumentType = "json";
-
-    @CommandLine.Option(
-        names = "--tde-preview"
-    )
-    private boolean tdePreview;
-
-    @CommandLine.Option(
-        names = "--tde-permissions",
-        description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to the generated TDE template - e.g. role1,read,role2,update,role3,execute."
-    )
-    private String tdePermissions;
-
-    @CommandLine.Option(
-        names = "--tde-collections",
-        description = "Comma-delimited sequence of collection names to include in the generated TDE template - e.g. collection1,collection2."
-    )
-    private String tdeCollections;
-
-    @CommandLine.Option(
-        names = "--tde-directory",
-        description = "Database directories to include in the generated TDE template."
-    )
-    private List<String> tdeDirectories;
-
-    @CommandLine.Option(
-        names = "--tde-context",
-        description = "Context path to use for the generated TDE template. Will override the default context path of " +
-            "'/' and any context path determined by the use of --json-root-name or --xml-root-name."
-    )
-    private String tdeContext;
-
-    @CommandLine.Option(
-        names = "--tde-uri",
-        description = "URI for loading the generated TDE template."
-    )
-    private String tdeUri;
-
-    @CommandLine.Option(
-        names = "--tde-template-disabled",
-        description = "If set, the TDE template will be loaded but in a disabled state."
-    )
-    private boolean tdeTemplateDisabled;
-
-    @CommandLine.Option(
-        names = "--tde-view-layout",
-        description = "View layout for the TDE template; defaults to 'sparse', can instead be set to 'identical'."
-    )
-    private String tdeViewLayout;
-
-    @CommandLine.Option(
-        names = "--tde-column-val",
-        description = "Custom 'val' value for a column name in the generated TDE template; e.g. --tde-column-val myColumn=myValue. " +
-            "This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnVals;
-
-    @CommandLine.Option(
-        names = "--tde-column-type",
-        description = "Custom scalar type for a column name in the generated TDE template; e.g. --tde-column-type myColumn=dateTime. " +
-            "This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnTypes;
-
-    @CommandLine.Option(
-        names = "--tde-column-default",
-        description = "Default value for a column name in the generated TDE template; e.g. --tde-column-default myColumn=defaultValue. " +
-            "This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnDefaultValues;
-
-    @CommandLine.Option(
-        names = "--tde-column-invalid-values",
-        description = "Invalid values handling for a column name in the generated TDE template; e.g. --tde-column-invalid-values myColumn=reject. " +
-            "Value can be 'ignore' or 'reject'. This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnInvalidValues;
-
-    @CommandLine.Option(
-        names = "--tde-column-reindexing",
-        description = "Reindexing setting for a column name in the generated TDE template; e.g. --tde-column-reindexing myColumn=visible. " +
-            "Value can be 'hidden' or 'visible'. This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnReindexing;
-
-    @CommandLine.Option(
-        names = "--tde-column-permissions",
-        description = "Comma-delimited role names for defining read permissions for a column in the generated " +
-            "TDE template; e.g. --tde-column-permissions myColumn=role1,role2. " +
-            "This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnPermissions;
-
-    @CommandLine.Option(
-        names = "--tde-column-nullable",
-        description = "Name of a column that should be marked as nullable in the generated TDE template. " +
-            "This option can be specified multiple times."
-    )
-    private List<String> tdeNullableColumns;
-
-    @CommandLine.Option(
-        names = "--tde-column-collation",
-        description = "Collation for a column name in the generated TDE template; e.g. --tde-column-collation myColumn=http://marklogic.com/collation/codepoint. " +
-            "This option can be specified multiple times."
-    )
-    private Map<String, String> tdeColumnCollation;
+    @CommandLine.Mixin
+    private final TdeParams tdeParams = new TdeParams();
 
     @Override
     public Map<String, String> makeOptions() {
@@ -184,64 +53,6 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
             Options.WRITE_XML_ROOT_NAME, xmlRootName,
             Options.WRITE_XML_NAMESPACE, xmlNamespace
         );
-    }
-
-    /**
-     * @param sparkSchema
-     * @param connectionParams
-     * @return true if TDE was generated and previewed, false otherwise. This will likely change once we
-     * support loading the TDE into MarkLogic
-     */
-    public boolean generateTde(StructType sparkSchema, ConnectionParams connectionParams) {
-        if (tdeSchema != null && tdeView != null) {
-            TdeInputs inputs = buildTdeInputs();
-            TdeBuilder tdeBuilder = "xml".equalsIgnoreCase(tdeDocumentType) ? new XmlTdeBuilder() : new JsonTdeBuilder();
-            TdeTemplate tdeTemplate = tdeBuilder.buildTde(inputs, new SparkColumnIterator(sparkSchema, inputs));
-            if (tdePreview) {
-                if (Util.MAIN_LOGGER.isInfoEnabled()) {
-                    Util.MAIN_LOGGER.info("Generated TDE:\n{}", tdeTemplate.toPrettyString());
-                }
-                return true;
-            } else {
-                try (DatabaseClient client = new ContextSupport(connectionParams.makeOptions()).connectToMarkLogic()) {
-                    new TdeLoader(client).loadTde(tdeTemplate);
-                }
-            }
-        }
-
-        return false;
-    }
-
-    protected final TdeInputs buildTdeInputs() {
-        Map<String, Set<String>> permissions = null;
-        if (tdeColumnPermissions != null) {
-            permissions = tdeColumnPermissions.entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> Arrays.stream(entry.getValue().split(","))
-                        .map(String::trim)
-                        .collect(Collectors.toSet())
-                ));
-        }
-
-        return new TdeInputs(tdeSchema, tdeView)
-            .withUri(tdeUri)
-            .withDisabled(tdeTemplateDisabled)
-            .withPermissions(tdePermissions)
-            .withCollections(tdeCollections != null ? tdeCollections.split(",") : null)
-            .withDirectories(tdeDirectories != null ? tdeDirectories.toArray(new String[0]) : null)
-            .withContext(tdeContext)
-            .withJsonRootName(jsonRootName)
-            .withXmlRootName(xmlRootName, xmlNamespace)
-            .withViewLayout(tdeViewLayout)
-            .withColumnVals(tdeColumnVals)
-            .withColumnTypes(tdeColumnTypes)
-            .withColumnDefaultValues(tdeColumnDefaultValues)
-            .withColumnInvalidValues(tdeColumnInvalidValues)
-            .withColumnReindexing(tdeColumnReindexing)
-            .withColumnPermissions(permissions)
-            .withColumnCollations(tdeColumnCollation)
-            .withNullableColumns(tdeNullableColumns);
     }
 
     @Override
@@ -266,5 +77,21 @@ public class WriteStructuredDocumentParams extends WriteDocumentParams<WriteStru
     public WriteStructuredDocumentsOptions ignoreNullFields(boolean value) {
         this.ignoreNullFields = value;
         return this;
+    }
+
+    public String getJsonRootName() {
+        return jsonRootName;
+    }
+
+    public String getXmlRootName() {
+        return xmlRootName;
+    }
+
+    public String getXmlNamespace() {
+        return xmlNamespace;
+    }
+
+    public TdeParams getTdeParams() {
+        return tdeParams;
     }
 }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/JsonTdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/JsonTdeBuilder.java
@@ -22,6 +22,15 @@ public class JsonTdeBuilder implements TdeBuilder {
         ObjectNode template = tde.putObject("template");
         template.put("context", tdeInputs.getContext());
 
+        if (tdeInputs.getPathNamespaces() != null) {
+            ArrayNode array = template.putArray("pathNamespace");
+            tdeInputs.getPathNamespaces().entrySet().forEach(entry -> {
+                ObjectNode namespace = array.addObject();
+                namespace.put("prefix", entry.getKey());
+                namespace.put("namespaceUri", entry.getValue());
+            });
+        }
+
         if (tdeInputs.isDisabled()) {
             template.put("enabled", false);
         }

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/TdeInputs.java
@@ -10,27 +10,30 @@ import java.util.Set;
 
 public class TdeInputs {
 
-    private final String schemaName;
-    private final String viewName;
-    private final Map<String, String> namespaces = new HashMap<>();
+    protected String schemaName;
+    protected String viewName;
+    protected final Map<String, String> pathNamespaces = new HashMap<>();
 
-    private static final String DEFAULT_CONTEXT = "/";
+    protected static final String DEFAULT_CONTEXT = "/";
 
-    private String uri;
-    private String context = DEFAULT_CONTEXT;
-    private String[] collections;
-    private String[] directories;
-    private String permissions;
-    private boolean disabled;
-    private String viewLayout;
-    private Map<String, String> columnVals;
-    private Map<String, String> columnTypes;
-    private Map<String, String> columnDefaultValues;
-    private Map<String, String> columnInvalidValues;
-    private Map<String, String> columnReindexing;
-    private Map<String, Set<String>> columnPermissions;
-    private Map<String, String> columnCollations;
-    private List<String> nullableColumns;
+    protected String uri;
+    protected String context = DEFAULT_CONTEXT;
+    protected String[] collections;
+    protected String[] directories;
+    protected String permissions;
+    protected boolean disabled;
+    protected String viewLayout;
+    protected Map<String, String> columnVals;
+    protected Map<String, String> columnTypes;
+    protected Map<String, String> columnDefaultValues;
+    protected Map<String, String> columnInvalidValues;
+    protected Map<String, String> columnReindexing;
+    protected Map<String, Set<String>> columnPermissions;
+    protected Map<String, String> columnCollations;
+    protected List<String> nullableColumns;
+
+    public TdeInputs() {
+    }
 
     public TdeInputs(String schemaName, String viewName) {
         this.schemaName = schemaName;
@@ -65,7 +68,7 @@ public class TdeInputs {
             // Don't override the context if the user already specified one.
             && DEFAULT_CONTEXT.equals(this.context)) {
             if (namespace != null) {
-                this.namespaces.put("ns1", namespace);
+                this.pathNamespaces.put("ns1", namespace);
                 this.context = "/ns1:" + xmlRootName;
             } else {
                 this.context = "/" + xmlRootName;
@@ -159,8 +162,8 @@ public class TdeInputs {
         return directories;
     }
 
-    public Map<String, String> getNamespaces() {
-        return namespaces;
+    public Map<String, String> getPathNamespaces() {
+        return pathNamespaces;
     }
 
     public String getPermissions() {

--- a/flux-cli/src/main/java/com/marklogic/flux/tde/XmlTdeBuilder.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/tde/XmlTdeBuilder.java
@@ -52,7 +52,7 @@ public class XmlTdeBuilder implements TdeBuilder {
         }
 
         XmlTemplate xmlTemplate = new XmlTemplate(doc, tdeInputs.getSchemaName(), tdeInputs.getViewName(), tdeInputs.getViewLayout());
-        xmlTemplate.setContext(tdeInputs.getContext(), tdeInputs.getNamespaces());
+        xmlTemplate.setContext(tdeInputs.getContext(), tdeInputs.getPathNamespaces());
         xmlTemplate.setCollections(tdeInputs.getCollections());
         xmlTemplate.setDirectories(tdeInputs.getDirectories());
         while (columns.hasNext()) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
@@ -40,7 +40,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        TdeInputs inputs = params.buildTdeInputs();
+        TdeInputs inputs = params.getTdeParams();
         String[] directories = inputs.getDirectories();
         assertEquals(2, directories.length);
         assertEquals("/dir1", directories[0]);
@@ -75,7 +75,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        TdeInputs inputs = params.buildTdeInputs();
+        TdeInputs inputs = params.getTdeParams();
 
         Map<String, String> columnVals = inputs.getColumnVals();
         assertEquals("customVal1", columnVals.get("column1"));

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithTdeTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportJdbcWithTdeTest.java
@@ -119,6 +119,20 @@ class ImportJdbcWithTdeTest extends AbstractTest {
     }
 
     @Test
+    void tdeWithCustomRootName() {
+        importJdbcWithArgs(
+            "--tde-schema", "junit",
+            "--tde-view", "customer",
+            "--tde-permissions", "flux-test-role,read,flux-test-role,update",
+            "--json-root-name", "customRootName"
+        );
+
+        JsonNode tdeTemplate = schemasDatabaseClient.newJSONDocumentManager()
+            .read(JSON_TDE_URI, new JacksonHandle()).get();
+        assertEquals("/customRootName", tdeTemplate.get("template").get("context").asText());
+    }
+
+    @Test
     void tdeWithCustomUri() {
         importJdbcWithArgs(
             "--tde-schema", "junit",
@@ -241,13 +255,19 @@ class ImportJdbcWithTdeTest extends AbstractTest {
             "--query", "select * from customer where customer_id < 11",
             "--connection-string", makeConnectionString(),
             "--collections", "customer",
-            "--permissions", DEFAULT_PERMISSIONS,
-            "--uri-template", "/customer/{customer_id}.json"
+            "--permissions", DEFAULT_PERMISSIONS
         );
+
         List<String> args = new ArrayList<>(defaultArgs);
         for (String option : options) {
             args.add(option);
         }
+
+        if (!args.contains("--uri-template")) {
+            args.add("--uri-template");
+            args.add("/customer/{customer_id}.json");
+        }
+
         run(args.toArray(new String[0]));
     }
 


### PR DESCRIPTION
Also created TdeHelper to act as a bridge between the CLI stuff and the generic non-Spark stuff yet.

Also found an issue with generating a TDE template for XML docs, going to fix that in the next PR.
