### PR TITLE
MLE-21825 Refactor: Moved logic into TdeHelper

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/TdeHelper.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/TdeHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 MarkLogic Corporation. All Rights Reserved.
+ */
+package com.marklogic.flux.impl;
+
+import com.marklogic.flux.impl.importdata.SparkColumnIterator;
+import com.marklogic.flux.impl.importdata.TdeParams;
+import com.marklogic.flux.tde.*;
+import com.marklogic.spark.ContextSupport;
+import com.marklogic.spark.Util;
+import marklogicspark.marklogic.client.DatabaseClient;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * Acts as a bridge between Flux and the intended-to-be-generic TDE template generation functionality.
+ */
+public class TdeHelper {
+
+    private final TdeParams tdeParams;
+    private final String jsonRootName;
+    private final String xmlRootName;
+    private final String xmlNamespace;
+
+    public TdeHelper(TdeParams tdeParams, String jsonRootName, String xmlRootName, String xmlNamespace) {
+        this.tdeParams = tdeParams;
+        this.jsonRootName = jsonRootName;
+        this.xmlRootName = xmlRootName;
+        this.xmlNamespace = xmlNamespace;
+    }
+
+    public enum Result {
+        TEMPLATE_LOGGED,
+        TEMPLATE_LOADED
+    }
+
+    public TdeInputs buildTdeInputs() {
+        return tdeParams.buildTdeInputs(jsonRootName, xmlRootName, xmlNamespace);
+    }
+
+    public Result logOrLoadTemplate(StructType sparkSchema, ConnectionParams connectionParams) {
+        if (tdeParams.hasSchemaAndView()) {
+            TdeInputs tdeInputs = buildTdeInputs();
+            TdeBuilder tdeBuilder = "xml".equalsIgnoreCase(tdeParams.getTdeDocumentType()) ? new XmlTdeBuilder() : new JsonTdeBuilder();
+            TdeTemplate tdeTemplate = tdeBuilder.buildTde(tdeInputs, new SparkColumnIterator(sparkSchema, tdeInputs));
+
+            if (tdeParams.isTdePreview()) {
+                if (Util.MAIN_LOGGER.isInfoEnabled()) {
+                    Util.MAIN_LOGGER.info("Generated TDE:\n{}", tdeTemplate.toPrettyString());
+                }
+                return Result.TEMPLATE_LOGGED;
+            } else {
+                try (DatabaseClient client = new ContextSupport(connectionParams.makeOptions()).connectToMarkLogic()) {
+                    new TdeLoader(client).loadTde(tdeTemplate);
+                    return Result.TEMPLATE_LOADED;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/CustomImportCommand.java
@@ -8,6 +8,7 @@ import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.S3Params;
 import com.marklogic.flux.impl.importdata.WriteStructuredDocumentParams;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.*;
 import picocli.CommandLine;
 
@@ -37,9 +38,11 @@ public class CustomImportCommand extends AbstractCommand<CustomImporter> impleme
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
+
         return super.afterDatasetLoaded(dataset);
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
@@ -6,6 +6,7 @@ package com.marklogic.flux.impl.importdata;
 import com.marklogic.flux.api.AggregateJsonFilesImporter;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import com.marklogic.spark.Options;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -136,7 +137,8 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.AvroFilesImporter;
 import com.marklogic.flux.api.ReadTabularFilesOptions;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -103,7 +104,8 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -6,6 +6,7 @@ package com.marklogic.flux.impl.importdata;
 import com.marklogic.flux.api.DelimitedFilesImporter;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -127,7 +128,8 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
@@ -10,6 +10,7 @@ import com.marklogic.flux.impl.AbstractCommand;
 import com.marklogic.flux.impl.JdbcParams;
 import com.marklogic.flux.impl.JdbcUtil;
 import com.marklogic.flux.impl.OptionsUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.*;
 import picocli.CommandLine;
 
@@ -53,9 +54,12 @@ public class ImportJdbcCommand extends AbstractCommand<JdbcImporter> implements 
     @Override
     protected Dataset<Row> afterDatasetLoaded(Dataset<Row> dataset) {
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
+
         return dataset;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.OrcFilesImporter;
 import com.marklogic.flux.api.ReadTabularFilesOptions;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -103,7 +104,8 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
@@ -7,6 +7,7 @@ import com.marklogic.flux.api.ParquetFilesImporter;
 import com.marklogic.flux.api.ReadTabularFilesOptions;
 import com.marklogic.flux.api.WriteStructuredDocumentsOptions;
 import com.marklogic.flux.impl.SparkUtil;
+import com.marklogic.flux.impl.TdeHelper;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import picocli.CommandLine;
@@ -103,7 +104,8 @@ public class ImportParquetFilesCommand extends AbstractImportFilesCommand<Parque
 
         dataset = readParams.aggregationParams.applyGroupBy(dataset);
 
-        if (writeParams.generateTde(dataset.schema(), getConnectionParams())) {
+        TdeHelper.Result result = writeParams.newTdeHelper().logOrLoadTemplate(dataset.schema(), getConnectionParams());
+        if (TdeHelper.Result.TEMPLATE_LOGGED.equals(result)) {
             return null;
         }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/TdeParams.java
@@ -16,20 +16,20 @@ import java.util.stream.Collectors;
 public class TdeParams implements TdeOptions {
 
     @CommandLine.Option(
-        names = "--tde-schema",
-        description = "Schema name of the TDE template to generate. Has no effect unless --tde-view is also specified."
+            names = "--tde-schema",
+            description = "Schema name of the TDE template to generate. Has no effect unless --tde-view is also specified."
     )
     private String schema;
 
     @CommandLine.Option(
-        names = "--tde-view",
-        description = "View name of the TDE template to generate. Has no effect unless --tde-schema is also specified."
+            names = "--tde-view",
+            description = "View name of the TDE template to generate. Has no effect unless --tde-schema is also specified."
     )
     private String view;
 
     @CommandLine.Option(
-        names = "--tde-document-type",
-        description = "Type of document to generate in the TDE template; defaults to 'json', can be set to 'xml'."
+            names = "--tde-document-type",
+            description = "Type of document to generate in the TDE template; defaults to 'json', can be set to 'xml'."
     )
     private String documentType = "json";
 
@@ -37,157 +37,217 @@ public class TdeParams implements TdeOptions {
     private boolean preview;
 
     @CommandLine.Option(
-        names = "--tde-permissions",
-        description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to the generated TDE template - e.g. role1,read,role2,update,role3,execute."
+            names = "--tde-permissions",
+            description = "Comma-delimited sequence of MarkLogic role names and capabilities to add to the generated TDE template - e.g. role1,read,role2,update,role3,execute."
     )
     private String permissions;
 
     @CommandLine.Option(
-        names = "--tde-collections",
-        description = "Comma-delimited sequence of collection names to include in the generated TDE template - e.g. collection1,collection2."
+            names = "--tde-collections",
+            description = "Comma-delimited sequence of collection names to include in the generated TDE template - e.g. collection1,collection2."
     )
     private String collections;
 
     @CommandLine.Option(
-        names = "--tde-directory",
-        description = "Database directories to include in the generated TDE template."
+            names = "--tde-directory",
+            description = "Database directories to include in the generated TDE template."
     )
     private List<String> directories;
 
     @CommandLine.Option(
-        names = "--tde-context",
-        description = "Context path to use for the generated TDE template. Will override the default context path of " +
-            "'/' and any context path determined by the use of --json-root-name or --xml-root-name."
+            names = "--tde-context",
+            description = "Context path to use for the generated TDE template. Will override the default context path of " +
+                    "'/' and any context path determined by the use of --json-root-name or --xml-root-name."
     )
     private String context;
 
     @CommandLine.Option(
-        names = "--tde-uri",
-        description = "URI for loading the generated TDE template."
+            names = "--tde-uri",
+            description = "URI for loading the generated TDE template."
     )
     private String uri;
 
     @CommandLine.Option(
-        names = "--tde-template-disabled",
-        description = "If set, the TDE template will be loaded but in a disabled state."
+            names = "--tde-template-disabled",
+            description = "If set, the TDE template will be loaded but in a disabled state."
     )
     private boolean templateDisabled;
 
     @CommandLine.Option(
-        names = "--tde-view-layout",
-        description = "View layout for the TDE template; defaults to 'sparse', can instead be set to 'identical'."
+            names = "--tde-view-layout",
+            description = "View layout for the TDE template; defaults to 'sparse', can instead be set to 'identical'."
     )
     private String viewLayout;
 
     @CommandLine.Option(
-        names = "--tde-column-val",
-        description = "Custom 'val' value for a column name in the generated TDE template; e.g. --tde-column-val myColumn=myValue. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-val",
+            description = "Custom 'val' value for a column name in the generated TDE template; e.g. --tde-column-val myColumn=myValue. " +
+                    "This option can be specified multiple times."
     )
     private Map<String, String> columnVals;
 
     @CommandLine.Option(
-        names = "--tde-column-type",
-        description = "Custom scalar type for a column name in the generated TDE template; e.g. --tde-column-type myColumn=dateTime. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-type",
+            description = "Custom scalar type for a column name in the generated TDE template; e.g. --tde-column-type myColumn=dateTime. " +
+                    "This option can be specified multiple times."
     )
     private Map<String, String> columnTypes;
 
     @CommandLine.Option(
-        names = "--tde-column-default",
-        description = "Default value for a column name in the generated TDE template; e.g. --tde-column-default myColumn=defaultValue. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-default",
+            description = "Default value for a column name in the generated TDE template; e.g. --tde-column-default myColumn=defaultValue. " +
+                    "This option can be specified multiple times."
     )
     private Map<String, String> columnDefaultValues;
 
     @CommandLine.Option(
-        names = "--tde-column-invalid-values",
-        description = "Invalid values handling for a column name in the generated TDE template; e.g. --tde-column-invalid-values myColumn=reject. " +
-            "Value can be 'ignore' or 'reject'. This option can be specified multiple times."
+            names = "--tde-column-invalid-values",
+            description = "Invalid values handling for a column name in the generated TDE template; e.g. --tde-column-invalid-values myColumn=reject. " +
+                    "Value can be 'ignore' or 'reject'. This option can be specified multiple times."
     )
     private Map<String, String> columnInvalidValues;
 
     @CommandLine.Option(
-        names = "--tde-column-reindexing",
-        description = "Reindexing setting for a column name in the generated TDE template; e.g. --tde-column-reindexing myColumn=visible. " +
-            "Value can be 'hidden' or 'visible'. This option can be specified multiple times."
+            names = "--tde-column-reindexing",
+            description = "Reindexing setting for a column name in the generated TDE template; e.g. --tde-column-reindexing myColumn=visible. " +
+                    "Value can be 'hidden' or 'visible'. This option can be specified multiple times."
     )
     private Map<String, String> columnReindexing;
 
     @CommandLine.Option(
-        names = "--tde-column-permissions",
-        description = "Comma-delimited role names for defining read permissions for a column in the generated " +
-            "TDE template; e.g. --tde-column-permissions myColumn=role1,role2. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-permissions",
+            description = "Comma-delimited role names for defining read permissions for a column in the generated " +
+                    "TDE template; e.g. --tde-column-permissions myColumn=role1,role2. " +
+                    "This option can be specified multiple times."
     )
     private Map<String, String> columnPermissions;
 
     @CommandLine.Option(
-        names = "--tde-column-nullable",
-        description = "Name of a column that should be marked as nullable in the generated TDE template. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-nullable",
+            description = "Name of a column that should be marked as nullable in the generated TDE template. " +
+                    "This option can be specified multiple times."
     )
     private List<String> nullableColumns;
 
     @CommandLine.Option(
-        names = "--tde-column-collation",
-        description = "Collation for a column name in the generated TDE template; e.g. --tde-column-collation myColumn=http://marklogic.com/collation/codepoint. " +
-            "This option can be specified multiple times."
+            names = "--tde-column-collation",
+            description = "Collation for a column name in the generated TDE template; e.g. --tde-column-collation myColumn=http://marklogic.com/collation/codepoint. " +
+                    "This option can be specified multiple times."
     )
     private Map<String, String> columnCollation;
+
+    public boolean hasSchemaAndView() {
+        return schema != null && view != null && !schema.isEmpty() && !view.isEmpty();
+    }
 
     public TdeInputs buildTdeInputs(String jsonRootName, String xmlRootName, String xmlNamespace) {
         Map<String, Set<String>> permissionsMap = null;
         if (columnPermissions != null) {
             permissionsMap = columnPermissions.entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> Arrays.stream(entry.getValue().split(","))
-                        .map(String::trim)
-                        .collect(Collectors.toSet())
-                ));
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            entry -> Arrays.stream(entry.getValue().split(","))
+                                    .map(String::trim)
+                                    .collect(Collectors.toSet())
+                    ));
         }
 
         return new TdeInputs(schema, view)
-            .withUri(uri)
-            .withDisabled(templateDisabled)
-            .withPermissions(permissions)
-            .withCollections(collections != null ? collections.split(",") : null)
-            .withDirectories(directories != null ? directories.toArray(new String[0]) : null)
-            .withContext(context)
-            .withJsonRootName(jsonRootName)
-            .withXmlRootName(xmlRootName, xmlNamespace)
-            .withViewLayout(viewLayout)
-            .withColumnVals(columnVals)
-            .withColumnTypes(columnTypes)
-            .withColumnDefaultValues(columnDefaultValues)
-            .withColumnInvalidValues(columnInvalidValues)
-            .withColumnReindexing(columnReindexing)
-            .withColumnPermissions(permissionsMap)
-            .withColumnCollations(columnCollation)
-            .withNullableColumns(nullableColumns);
+                .withUri(uri)
+                .withDisabled(templateDisabled)
+                .withPermissions(permissions)
+                .withCollections(collections != null ? collections.split(",") : null)
+                .withDirectories(directories != null ? directories.toArray(new String[0]) : null)
+                .withContext(context)
+                .withJsonRootName(jsonRootName)
+                .withXmlRootName(xmlRootName, xmlNamespace)
+                .withViewLayout(viewLayout)
+                .withColumnVals(columnVals)
+                .withColumnTypes(columnTypes)
+                .withColumnDefaultValues(columnDefaultValues)
+                .withColumnInvalidValues(columnInvalidValues)
+                .withColumnReindexing(columnReindexing)
+                .withColumnPermissions(permissionsMap)
+                .withColumnCollations(columnCollation)
+                .withNullableColumns(nullableColumns);
     }
 
     // Getters
-    public String getTdeSchema() { return schema; }
-    public String getTdeView() { return view; }
-    public String getTdeDocumentType() { return documentType; }
-    public boolean isTdePreview() { return preview; }
-    public String getTdePermissions() { return permissions; }
-    public String getTdeCollections() { return collections; }
-    public List<String> getTdeDirectories() { return directories; }
-    public String getTdeContext() { return context; }
-    public String getTdeUri() { return uri; }
-    public boolean isTdeTemplateDisabled() { return templateDisabled; }
-    public String getTdeViewLayout() { return viewLayout; }
-    public Map<String, String> getTdeColumnVals() { return columnVals; }
-    public Map<String, String> getTdeColumnTypes() { return columnTypes; }
-    public Map<String, String> getTdeColumnDefaultValues() { return columnDefaultValues; }
-    public Map<String, String> getTdeColumnInvalidValues() { return columnInvalidValues; }
-    public Map<String, String> getTdeColumnReindexing() { return columnReindexing; }
-    public Map<String, String> getTdeColumnPermissions() { return columnPermissions; }
-    public List<String> getTdeNullableColumns() { return nullableColumns; }
-    public Map<String, String> getTdeColumnCollation() { return columnCollation; }
+    public String getTdeSchema() {
+        return schema;
+    }
+
+    public String getTdeView() {
+        return view;
+    }
+
+    public String getTdeDocumentType() {
+        return documentType;
+    }
+
+    public boolean isTdePreview() {
+        return preview;
+    }
+
+    public String getTdePermissions() {
+        return permissions;
+    }
+
+    public String getTdeCollections() {
+        return collections;
+    }
+
+    public List<String> getTdeDirectories() {
+        return directories;
+    }
+
+    public String getTdeContext() {
+        return context;
+    }
+
+    public String getTdeUri() {
+        return uri;
+    }
+
+    public boolean isTdeTemplateDisabled() {
+        return templateDisabled;
+    }
+
+    public String getTdeViewLayout() {
+        return viewLayout;
+    }
+
+    public Map<String, String> getTdeColumnVals() {
+        return columnVals;
+    }
+
+    public Map<String, String> getTdeColumnTypes() {
+        return columnTypes;
+    }
+
+    public Map<String, String> getTdeColumnDefaultValues() {
+        return columnDefaultValues;
+    }
+
+    public Map<String, String> getTdeColumnInvalidValues() {
+        return columnInvalidValues;
+    }
+
+    public Map<String, String> getTdeColumnReindexing() {
+        return columnReindexing;
+    }
+
+    public Map<String, String> getTdeColumnPermissions() {
+        return columnPermissions;
+    }
+
+    public List<String> getTdeNullableColumns() {
+        return nullableColumns;
+    }
+
+    public Map<String, String> getTdeColumnCollation() {
+        return columnCollation;
+    }
 
     // TdeOptions implementation
     @Override

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
@@ -42,7 +42,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        TdeInputs inputs = params.buildTdeInputs();
+        TdeInputs inputs = params.newTdeHelper().buildTdeInputs();
         String[] directories = inputs.getDirectories();
         assertEquals(2, directories.length);
         assertEquals("/dir1", directories[0]);
@@ -77,7 +77,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
         );
 
         WriteStructuredDocumentParams params = (WriteStructuredDocumentParams) command.getWriteParams();
-        TdeInputs inputs = params.buildTdeInputs();
+        TdeInputs inputs = params.newTdeHelper().buildTdeInputs();
 
         Map<String, String> columnVals = inputs.getColumnVals();
         assertEquals("customVal1", columnVals.get("column1"));
@@ -149,7 +149,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
             });
 
         WriteStructuredDocumentParams params = writeParams.get();
-        TdeInputs inputs = params.buildTdeInputs();
+        TdeInputs inputs = params.newTdeHelper().buildTdeInputs();
 
         // Verify all TdeOptions methods were applied correctly
         assertEquals("api-schema", inputs.getSchemaName());


### PR DESCRIPTION
This still isn't great, but it avoids the messiness of WriteStructuredDocumentParams have a chunk of logic in it specific to generating a TDE. Also dumped the boolean result in favor of a new enum to make it more explicit as to why null is returned for a dataset when the TDE is only logged / previewed.
