### PR TITLE
MLE-23170 Defaulting to Netty's pure Java SSL

### DIFF
--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -177,7 +177,12 @@ application {
 
     // Allows a reflective access by org.apache.spark.serializer.SerializationDebugger$ObjectStreamClassReflection .
     // This warning otherwise shows on Java 11 but not Java 17.
-    "--add-opens", "java.base/java.io=ALL-UNNAMED"
+    "--add-opens", "java.base/java.io=ALL-UNNAMED",
+
+    // Disable Netty's native SSL support to avoid tcnative loading errors when using Azure OpenAI embedding model.
+    // Netty will fall back to pure Java SSL implementation, which works fine for our use case.
+    // Advanced users can remove this property from the startup script to enable native SSL for potential performance gains.
+    "-Dio.netty.handler.ssl.noOpenSsl=true"
   ]
 }
 

--- a/flux-embedding-model-azure-open-ai/build.gradle
+++ b/flux-embedding-model-azure-open-ai/build.gradle
@@ -8,10 +8,12 @@ java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(17)
   }
+  withJavadocJar()
+  withSourcesJar()
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-azure-open-ai:1.0.0-beta5") {
+  implementation ("dev.langchain4j:langchain4j-azure-open-ai:1.1.0-rc1") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"
@@ -19,27 +21,19 @@ dependencies {
   }
 
   // Repeating this here so that the Jackson dependencies are included for running tests in this subproject.
-  testImplementation "dev.langchain4j:langchain4j-azure-open-ai:1.0.0-beta5"
+  testImplementation "dev.langchain4j:langchain4j-azure-open-ai:1.1.0-rc1"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.11.2"
   testImplementation "ch.qos.logback:logback-classic:1.5.18"
 }
 
 shadowJar {
-  // Avoids conflict with Spark's version of netty.
-  relocate "io.netty", "com.marklogic.flux.io.netty"
-
   // Don't need Jackson dependencies in the shadowJar, as Spark will provide those.
   dependencies {
     exclude {
       it.moduleGroup == 'com.fasterxml.jackson.core' || it.moduleGroup == 'com.fasterxml.jackson.databind'
     }
   }
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
 }
 
 publishing {

--- a/flux-embedding-model-minilm/build.gradle
+++ b/flux-embedding-model-minilm/build.gradle
@@ -8,19 +8,17 @@ java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(17)
   }
+
+  withJavadocJar()
+  withSourcesJar()
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.0.0-beta5") {
+  implementation ("dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.1.0-beta7") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"
   }
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
 }
 
 publishing {

--- a/flux-embedding-model-ollama/build.gradle
+++ b/flux-embedding-model-ollama/build.gradle
@@ -8,17 +8,20 @@ java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(17)
   }
+
+  withJavadocJar()
+  withSourcesJar()
 }
 
 dependencies {
-  implementation ("dev.langchain4j:langchain4j-ollama:1.0.0-beta5") {
+  implementation ("dev.langchain4j:langchain4j-ollama:1.1.0-rc1") {
     // Ensures that the version of Jackson preferred by Spark is used instead. Otherwise, this library's pom
     // will bring in a later version of Jackson that causes Spark to fail.
     exclude group: "com.fasterxml.jackson.core"
   }
 
   // Repeating this here so that the Jackson dependencies are included for running tests in this subproject.
-  testImplementation "dev.langchain4j:langchain4j-ollama:1.0.0-beta5"
+  testImplementation "dev.langchain4j:langchain4j-ollama:1.1.0-rc1"
 
   testImplementation "org.junit.jupiter:junit-jupiter:5.11.2"
   testImplementation "ch.qos.logback:logback-classic:1.5.18"
@@ -35,11 +38,6 @@ shadowJar {
       it.moduleGroup == 'com.fasterxml.jackson.core' || it.moduleGroup == 'com.fasterxml.jackson.databind'
     }
   }
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
 }
 
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ connectorVersion=2.7-SNAPSHOT
 
 # Aligned with our Spark connector.
 sparkVersion=3.5.6
-langchain4jVersion=1.0.0
+langchain4jVersion=1.1.0
 tikaVersion=3.2.1
 
 # Define these on the command line to publish to OSSRH


### PR DESCRIPTION
This avoids a potential nasty error message. Also TIL we don't need to relocate the Netty classes for the Azure embedding model given that Flux is already using the same Netty version courtesy of Azure Storage jars.
