### PR TITLE
MLE-23366 Minor doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,56 +139,6 @@ files after changing any of the classes in the `com.marklogic.flux.api` package,
 
     ./gradlew updateJavadoc
 
-## Examining error reports
-
-The following commands show examples of how the tool reports errors. One gap is that when a batch fails, the contents
-of the batch are not yet logged. This is an area of research as while the URIs can easily be included in the error
-reporting, they are not necessarily helpful. Support for trying each document individually may be added in the future.
-
-You can test an invalid command name:
-
-    ./flux/bin/flux not_a_real_command
-
-You can forget a required argument:
-
-    ./flux/bin/flux import-files
-
-You can cause an error from Spark:
-
-    ./flux/bin/flux import-files --path invalid-path
-
-You can cause a failure with MarkLogic that caused the command to stop:
-
-```
-./flux/bin/flux import-files --path "flux-cli/src/test/resources/mixed-files/*" \
-  --connection-string "flux-test-user:password@localhost:8000" \
-  --repartition 1 \
-  --abort-on-write-failure \
-  --permissions "invalid-role,read,flux-test-role,update" \
-  --uri-replace ".*/mixed-files,'/test'"
-```
-
-You can cause a failure and ask to see the full stacktrace (often noisy and not helpful):
-
-```
-./flux/bin/flux import-files --path "flux-cli/src/test/resources/mixed-files/*" \
-  --connection-string "flux-test-user:password@localhost:8000" \
-  --repartition 1 \
-  --permissions "invalid-role,read,flux-test-role,update" \
-  --uri-replace ".*/mixed-files,'/test'" \
-  --abort-on-write-failure \
-  --stacktrace
-```
-
-You can cause a failure and tell the command to keep executing by not including `--abort-on-write-failure`:
-
-```
-./flux/bin/flux import-files --path "flux-cli/src/test/resources/mixed-files/*" \
-  --connection-string "flux-test-user:password@localhost:8000" \
-  --permissions "invalid-role,read,flux-test-role,update" \
-  --uri-replace ".*/mixed-files,'/test'"
-```
-
 ## Testing with a load balancer
 
 The `docker-compose.yml` file includes an instance of a 
@@ -241,7 +191,7 @@ along with a link to the worker that you started. You are now able to run tests 
 
 ### Testing with spark-submit
 
-Spark's [spark-submit](https://spark.apache.org/docs/latest/submitting-applications.html) program allows for a Spark
+Spark's [spark-submit](https://spark.apache.org/docs/3.5.6/submitting-applications.html) program allows for a Spark
 program to be run on a separate (and possibly remote) Spark cluster. Now that you have a separate Spark cluster running
 per the above instructions, you can test each CLI command by running it via spark-submit.
 
@@ -251,7 +201,7 @@ are all synonyms):
 
     ./gradlew shadowJar
 
-This will produce an assembly jar at `./flux-cli/build/libs/marklogic-flux-1.2-SNAPSHOT-all.jar`.
+This will produce an assembly jar at `./flux-cli/build/libs/marklogic-flux-1.4-SNAPSHOT-all.jar`.
 
 You can now run any CLI command via spark-submit. This is an example of previewing an import of files - change the value
 of `--path`, as an absolute path is needed, and of course change the value of `--master` to match that of your Spark
@@ -259,7 +209,7 @@ cluster:
 
 ```
 $SPARK_HOME/bin/spark-submit --class com.marklogic.flux.spark.Submit \
---master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.2-SNAPSHOT-all.jar \
+--master spark://NYWHYC3G0W:7077 flux-cli/build/libs/marklogic-flux-1.4-SNAPSHOT-all.jar \
 import-files --path /Users/rudin/workspace/flux/flux-cli/src/test/resources/mixed-files \
 --connection-string "admin:admin@localhost:8000" \
 --preview 5 --preview-drop content

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Flux can also be easily embedded in your own application to support any flow of 
 With Flux, you can automate common data movement use cases including:
 
 - Importing rows from an RDBMS.
-- Importing JSON, XML, CSV, Parquet and other file types from a local filesystem or S3.
+- Importing JSON, XML, CSV, Parquet and other file types from a local filesystem, Amazon S3, or Azure Storage.
 - Extract text from binary documents and classify it using [Progress Semaphore](https://www.progress.com/semaphore).
 - Implementing a data pipeline for a [RAG solution with MarkLogic](https://www.progress.com/marklogic/solutions/generative-ai).
 - Copying data from one MarkLogic database to another database.

--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -504,7 +504,7 @@ configuring the underlying Spark runtime environment used by Flux.
 By default, Flux creates a Spark runtime with a master URL of `local[*]`, which runs Spark with as many worker 
 threads as logical cores on the machine running Flux. The number of worker threads affects how many partitions can be
 processed in parallel. You can change this setting via the`--spark-master-url` option; please see 
-[the Spark documentation](https://spark.apache.org/docs/latest/submitting-applications.html#master-urls) for examples
+[the Spark documentation](https://spark.apache.org/docs/3.5.6/submitting-applications.html#master-urls) for examples
 of valid values. If you are looking to run a Flux command on a remote Spark cluster, please instead see the 
 [Spark Integration guide](spark-integration.md) for details on integrating Flux with `spark-submit`.
 
@@ -542,9 +542,9 @@ to it. You can still override `--spark-master-url` if you wish.
 
 ### Configuring Spark Session creation
 
-Many [Spark configuration options](https://spark.apache.org/docs/latest/configuration.html) must be specified before
+Many [Spark configuration options](https://spark.apache.org/docs/3.5.6/configuration.html) must be specified before
 the Spark Session is built. For example, if you wish to 
-[encrypt data that Spark spills from memory to disk](https://spark.apache.org/docs/latest/security.html#local-storage-encryption), 
+[encrypt data that Spark spills from memory to disk](https://spark.apache.org/docs/3.5.6/security.html#local-storage-encryption), 
 the `spark.io.encryption.enabled=true` option must be set before the Spark session is built. 
 
 To specify options that control how the Spark Session is built, use the `-B` option as many times as need. For example, 
@@ -555,12 +555,12 @@ to enable encryption with a custom value for the key size in bits, include the f
 
 ### Configuring the Spark Session at runtime
 
-Some Flux commands reuse [Spark data sources](https://spark.apache.org/docs/latest/sql-data-sources.html) that 
+Some Flux commands reuse [Spark data sources](https://spark.apache.org/docs/3.5.6/sql-data-sources.html) that 
 accept configuration items via the Spark runtime. You can provide these configuration items via the `-C` option. 
-For example, the [Spark Avro data source](https://spark.apache.org/docs/latest/sql-data-sources-avro.html#configuration)
+For example, the [Spark Avro data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html#configuration)
 identifies several configuration items, such as `spark.sql.avro.compression.codec`. You can set this value by 
 including `-Cspark.sql.avro.compression.codec=snappy` as a command line option. 
 
-Note that the majority of [Spark cluster configuration properties](https://spark.apache.org/docs/latest/configuration.html)
+Note that the majority of [Spark cluster configuration properties](https://spark.apache.org/docs/3.5.6/configuration.html)
 cannot be set via the `-C` option as those options must be set before a Spark session is built. Please see the section
 above on using the `-B` option for options that control how a Spark session is built.

--- a/docs/export/custom-export.md
+++ b/docs/export/custom-export.md
@@ -17,13 +17,13 @@ MarkLogic and write the results to a custom target.
 ## Usage
 
 With the required `--target` option, you can specify
-[any Spark data source](https://spark.apache.org/docs/latest/sql-data-sources.html) or the name of a third-party Spark
+[any Spark data source](https://spark.apache.org/docs/3.5.6/sql-data-sources.html) or the name of a third-party Spark
 connector. For a third-party Spark connector, you must include the necessary JAR files for the connector in the
 `./ext` directory of your Flux installation. Note that if the connector is not available as a single "uber" jar, you
 will need to ensure that the connector and all of its dependencies are added to the `./ext` directory.
 
 As an example, Flux does not provide an out-of-the-box command that uses the
-[Spark Text data source](https://spark.apache.org/docs/latest/sql-data-sources-text.html). You can use this data source
+[Spark Text data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-text.html). You can use this data source
 via `custom-export-rows`:
 
 {% tabs log %}

--- a/docs/export/export-rows.md
+++ b/docs/export/export-rows.md
@@ -125,7 +125,7 @@ bin\flux export-avro-files ^
 {% endtabs %}
 
 You can include any of the 
-[Spark Avro data source options](https://spark.apache.org/docs/latest/sql-data-sources-avro.html) via the `-P` option to
+[Spark Avro data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html) via the `-P` option to
 control how Avro content is written. These options are expressed as `-PoptionName=optionValue`.
 
 For configuration options listed in the above Spark Avro guide, use the `-C` option instead. For example,
@@ -156,7 +156,7 @@ bin\flux export-delimited-files ^
 {% endtabs %}
 
 This command reuses Spark's support for writing delimited text files. You can include
-any of the [Spark CSV options](https://spark.apache.org/docs/latest/sql-data-sources-csv.html) via the `-P` 
+any of the [Spark CSV options](https://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html) via the `-P` 
 option to control how delimited text is written. These options are expressed as `-PoptionName=optionValue`. 
 
 The command defaults to setting the Spark CSV `header` option to `true` so that column
@@ -217,7 +217,7 @@ bin\flux export-json-lines-files ^
 
 
 This command reuses Spark's support for writing JSON files. You can include any of the
-[Spark JSON options](https://spark.apache.org/docs/latest/sql-data-sources-json.html) via the `-P` option to control
+[Spark JSON options](https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html) via the `-P` option to control
 how JSON Lines files are written. These options are expressed as `-PoptionName=optionValue`.
 
 By default, each file will be written using the UTF-8 encoding. You can specify an alternate encoding via the
@@ -269,7 +269,7 @@ bin\flux export-orc-files ^
 
 
 This command reuses Spark's support for writing ORC files. You can include any of the
-[Spark ORC data source options](https://spark.apache.org/docs/latest/sql-data-sources-orc.html) via the `-P` option to
+[Spark ORC data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html) via the `-P` option to
 control how ORC content is written. These options are expressed as `-PoptionName=optionValue`.
 
 For configuration options listed in the above Spark ORC guide, use the `-C` option instead. For example,
@@ -299,7 +299,7 @@ bin\flux export-parquet-files ^
 {% endtabs %}
 
 This command reuses Spark's support for writing Parquet files. You can include any of the
-[Spark Parquet data source options](https://spark.apache.org/docs/latest/sql-data-sources-parquet.html) via the `-P` option to
+[Spark Parquet data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html) via the `-P` option to
 control how Parquet content is written. These options are expressed as `-PoptionName=optionValue`.
 
 For configuration options listed in the above Spark Parquet guide, use the `-C` option instead. For example, 
@@ -322,7 +322,7 @@ release, these commands defaulted to `Overwrite`. The `export-jdbc` command defa
 an existing table in any way.
 
 For further information on each mode, please see 
-[the Spark documentation](https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html#save-modes).
+[the Spark documentation](https://spark.apache.org/docs/3.5.6/sql-data-sources-load-save-functions.html#save-modes).
 
 ## Tuning query performance
 

--- a/docs/import/custom-import.md
+++ b/docs/import/custom-import.md
@@ -9,13 +9,13 @@ The `custom-import` command allows you to read data from any Spark-supported dat
 JSON or XML documents to MarkLogic. 
 
 With the required `--source` option, you can specify 
-[any Spark data source](https://spark.apache.org/docs/latest/sql-data-sources.html) or the name of a third-party Spark
+[any Spark data source](https://spark.apache.org/docs/3.5.6/sql-data-sources.html) or the name of a third-party Spark
 connector. For a third-party Spark connector, you must include the necessary JAR files for the connector in the 
 `./ext` directory of your Flux installation. Note that if the connector is not available as a single "uber" jar, you 
 will need to ensure that the connector and all of its dependencies are added to the `./ext` directory.
 
 As an example, Flux does not provide an out-of-the-box command that uses the 
-[Spark Text data source](https://spark.apache.org/docs/latest/sql-data-sources-text.html). You can use this data source
+[Spark Text data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-text.html). You can use this data source
 via `custom-import`:
 
 {% tabs log %}

--- a/docs/import/embedder/embedder.md
+++ b/docs/import/embedder/embedder.md
@@ -374,7 +374,7 @@ straightforward and human-readable, it can result in large documents when embedd
 For example, a typical embedding with 1536 dimensions can add significant size to each document. 
 
 To reduce document size, typically resulting in a document that is faster to load and index and query, 
-you can configure Flux to encode embeddings into string values using the following option:
+you can configure Flux 1.4.0 or higher to encode embeddings into string values using the following option:
 
     --embedder-base64-encode
 

--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -129,7 +129,7 @@ explicitly specify a compression algorithm if Flux is not able to read your comp
 ## Advanced options
 
 The `import-avro-files` command reuses Spark's support for reading Avro files. You can include any of
-the [Spark Avro data source options](https://spark.apache.org/docs/latest/sql-data-sources-avro.html) via the `-P` option
+the [Spark Avro data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html) via the `-P` option
 to control how Avro content is read. These options are expressed as `-PoptionName=optionValue`.
 
 For the configuration options listed in the above Spark Avro guide, use the `-C` option instead. For example, 

--- a/docs/import/import-files/delimited-text.md
+++ b/docs/import/import-files/delimited-text.md
@@ -186,7 +186,7 @@ Flux once and processing each file separately.
 ## Advanced options
 
 The `import-delimited-files` command reuses Spark's support for reading delimited text data. You can include any of
-the [Spark CSV options](https://spark.apache.org/docs/latest/sql-data-sources-csv.html) via the `-P` option
+the [Spark CSV options](https://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html) via the `-P` option
 to control how delimited text is read. These options are expressed as `-PoptionName=optionValue`.
 
 A common option to include is `-PmultiLine=true` for when your files have rows with values that include newline 

--- a/docs/import/import-files/import-files.md
+++ b/docs/import/import-files/import-files.md
@@ -6,7 +6,6 @@ has_children: true
 parent: Importing Data
 ---
 
-Flux can import a variety of file types from a local filesystem, HDFS, or Amazon S3. 
+Flux can import a variety of file types from a local filesystem, HDFS, Amazon S3, or Azure Storage.  
 
-The guide on [selecting files](selecting-files.md) describes how to select files, including from S3,
-regardless of the type of file being imported.
+The guide on [selecting files](selecting-files.md) describes how to select files regardless of the type of file being imported.

--- a/docs/import/import-files/json.md
+++ b/docs/import/import-files/json.md
@@ -110,7 +110,7 @@ The JSON Lines format is often useful for exporting data from MarkLogic as well.
 ### Importing JSON Lines files as is
 
 When importing JSON Lines files, Flux uses the 
-[Spark JSON data source](https://spark.apache.org/docs/latest/sql-data-sources-json.html) to read each line and conform
+[Spark JSON data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html) to read each line and conform
 the JSON objects to a common schema across the entire set of lines. As noted in the Advanced Options section below, 
 Spark JSON provides a number of configuration options for controlling how the lines are read. These features can result
 in changes to the JSON objects, such as the keys being reordered and fields being added to match the common schema. 
@@ -131,7 +131,7 @@ effects on the `import-aggregate-json-files` command:
 Flux defaults to reading JSON lines with a mode of "permissive". With this mode, any malformed lines will be dropped 
 and Flux will continue processing lines. 
 
-You can configure the underlying [Spark JSON data source](https://spark.apache.org/docs/latest/sql-data-sources-json.html) to 
+You can configure the underlying [Spark JSON data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html) to 
 instead fail fast when it encounters a malformed line by including `-Pmode=failfast` as an option. When Flux encounters
 a malformed line, it will immediately fail with an error message describing the problem with the line. 
 
@@ -213,7 +213,7 @@ that the use of `-Pcompression=` is only supported if the `--json-lines-raw` opt
 ## Advanced options
 
 The `import-aggregate-json-files` command reuses Spark's support for reading JSON files. You can include any of
-the [Spark JSON options](https://spark.apache.org/docs/latest/sql-data-sources-json.html) via the `-P` option
+the [Spark JSON options](https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html) via the `-P` option
 to control how JSON content is read. These options are expressed as `-PoptionName=optionValue`.
 
 For example, if your files use a format other than `yyyy-MM-dd` values, you can specify that format via the following:

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -129,7 +129,7 @@ explicitly specify a compression algorithm if Flux is not able to read your comp
 ## Advanced options
 
 The `import-orc-files` command reuses Spark's support for reading ORC files. You can include any of
-the [Spark ORC data source options](https://spark.apache.org/docs/latest/sql-data-sources-orc.html) via the `-P` option
+the [Spark ORC data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html) via the `-P` option
 to control how ORC content is read. These options are expressed as `-PoptionName=optionValue`.
 
 For the configuration options listed in the above Spark ORC guide, use the `-C` option instead. For example, 

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -129,7 +129,7 @@ explicitly specify a compression algorithm if Flux is not able to read your comp
 ## Advanced options
 
 The `import-parquet-files` command reuses Spark's support for reading Parquet files. You can include any of
-the [Spark Parquet data source options](https://spark.apache.org/docs/latest/sql-data-sources-parquet.html) via the `-P` option
+the [Spark Parquet data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html) via the `-P` option
 to control how Parquet content is read. These options are expressed as `-PoptionName=optionValue`.
 
 For the configuration options listed in the above Spark Parquet guide, use the `-C` option instead. For example,

--- a/docs/import/import-jdbc.md
+++ b/docs/import/import-jdbc.md
@@ -87,7 +87,7 @@ bin\flux import-jdbc ^
 {% endtabs %}
 
 The `--table` option maps to the `dbtable` option for 
-[the Spark JDBC data source](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html). Per the Spark documentation, 
+[the Spark JDBC data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html). Per the Spark documentation, 
 in addition to a table name, you can also specify "anything that is valid in the `FROM` clause of a SQL query... 
 such as a subquery in parentheses".
 
@@ -146,5 +146,5 @@ queries. See [TDE template generation](tde-generation.md) for more information.
 ## Advanced options
 
 The `import-jdbc` command reuses Spark's support for reading via a JDBC driver. You can include any of
-the [Spark JDBC options](https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html) via the `-P` option
+the [Spark JDBC options](https://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html) via the `-P` option
 to control how JDBC is used. These options are expressed as `-PoptionName=optionValue`.

--- a/docs/spark-integration.md
+++ b/docs/spark-integration.md
@@ -22,7 +22,7 @@ YARN cluster manager and the YARN cluster "is accepting work from remote (authen
 
 For normal Flux CLI usage, this CVE is a false positive as Flux does not use a YARN cluster manager. Flux uses 
 Spark's standalone cluster manager by default - see the 
-[Spark documentation](https://spark.apache.org/docs/latest/cluster-overview.html) for further information on Spark
+[Spark documentation](https://spark.apache.org/docs/3.5.6/cluster-overview.html) for further information on Spark
 cluster managers. 
 
 If you use Flux with the Apache Spark `spark-submit` program as described below, you should consider the above CVE if
@@ -31,7 +31,7 @@ Spark cluster, as Flux does not include any Spark or Hadoop packages when it is 
 
 ## Submitting Flux commands
 
-Flux integrates with [spark-submit](https://spark.apache.org/docs/latest/submitting-applications.html) to allow you to 
+Flux integrates with [spark-submit](https://spark.apache.org/docs/3.5.6/submitting-applications.html) to allow you to 
 submit a Flux command invocation to a remote Spark cluster. Every Flux command is a Spark application, and thus every
 Flux command, along with all of its option, can be invoked via `spark-submit`. 
 
@@ -76,7 +76,7 @@ Key points on the above example:
 1. You must provide a value of `com.marklogic.flux.spark.Submit` for the required `--class` option. This class 
 provides the entry point that allows for a Flux command to be run.
 2. Set the value of `--master` to the master URL of your Spark cluster.
-3. As noted in the [Spark documentation](https://spark.apache.org/docs/latest/submitting-applications.html), the path
+3. As noted in the [Spark documentation](https://spark.apache.org/docs/3.5.6/submitting-applications.html), the path
 to the Flux jar - the "application jar" - must be globally visible inside your cluster.
 4. The "application arguments" consist of the name of the Flux command and the options you provide to that command. 
 
@@ -92,7 +92,7 @@ The above packages are not included in the Flux jar file, as the version require
 
 ### Using Avro data with spark-submit
 
-Per the [Spark Avro documentation](https://spark.apache.org/docs/latest/sql-data-sources-avro.html), the `spark-avro`
+Per the [Spark Avro documentation](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html), the `spark-avro`
 dependency is not included in Spark by default. If you wish to run either `import-avro-files` or `export-avro-files`
 with Flux and `spark-submit`, you must include the following line in your `spark-submit` invocation:
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AggregateJsonFilesImporter.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 /**
- * Read either JSON Lines files or files containing arrays of JSON objects from local, HDFS, and S3 locations using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-json.html">Spark's JSON support</a>,
+ * Read either JSON Lines files or files containing arrays of JSON objects from supported file locations using
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html">Spark's JSON support</a>,
  * and write each object as a JSON document to MarkLogic.
  */
 public interface AggregateJsonFilesImporter extends Executor<AggregateJsonFilesImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/AggregateXmlFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AggregateXmlFilesImporter.java
@@ -6,7 +6,7 @@ package com.marklogic.flux.api;
 import java.util.function.Consumer;
 
 /**
- * Read aggregate XML files from local, HDFS, and S3 locations with each row being written to MarkLogic.
+ * Read aggregate XML files from supported file locations with each row being written to MarkLogic.
  */
 public interface AggregateXmlFilesImporter extends Executor<AggregateXmlFilesImporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/AvroFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AvroFilesExporter.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 /**
  * Read rows via Optic from MarkLogic and write them to Avro files on a local filesystem,
  * HDFS, or S3 using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-avro.html">Spark's Avro support</a>.
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html">Spark's Avro support</a>.
  */
 public interface AvroFilesExporter extends Executor<AvroFilesExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/AvroFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/AvroFilesImporter.java
@@ -6,8 +6,8 @@ package com.marklogic.flux.api;
 import java.util.function.Consumer;
 
 /**
- * Read Avro files from local, HDFS, and S3 locations using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-avro.html">Spark's Avro support</a>,
+ * Read Avro files from supported file locations using
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html">Spark's Avro support</a>,
  * and write JSON or XML documents to MarkLogic.
  */
 public interface AvroFilesImporter extends Executor<AvroFilesImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesExporter.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows via Optic from MarkLogic and write them to delimited text files on a local filesystem, HDFS, or S3
- * using <a href="https://spark.apache.org/docs/latest/sql-data-sources-csv.html">Spark's CSV support</a>.
+ * using <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html">Spark's CSV support</a>.
  */
 public interface DelimitedFilesExporter extends Executor<DelimitedFilesExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/DelimitedFilesImporter.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 /**
- * Read delimited text files from local, HDFS, and S3 locations using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-csv.html">Spark's CSV support</a>,
+ * Read delimited text files from supported file locations using
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html">Spark's CSV support</a>,
  * and write JSON or XML documents to MarkLogic.
  */
 public interface DelimitedFilesImporter extends Executor<DelimitedFilesImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/JdbcExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/JdbcExporter.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows via Optic from MarkLogic and write them to a table using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html">Spark's JDBC support</a>.
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html">Spark's JDBC support</a>.
  */
 public interface JdbcExporter extends Executor<JdbcExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/JdbcImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/JdbcImporter.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html">Spark's JDBC support</a>
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html">Spark's JDBC support</a>
  * and write JSON or XML documents to MarkLogic.
  */
 public interface JdbcImporter extends Executor<JdbcImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/JsonLinesFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/JsonLinesFilesExporter.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows via Optic from MarkLogic and write them to JSON Lines files on a local filesystem, HDFS, or S3 using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-json.html">Spark's JSON support</a>.
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-json.html">Spark's JSON support</a>.
  */
 public interface JsonLinesFilesExporter extends Executor<JsonLinesFilesExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/OrcFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/OrcFilesExporter.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows via Optic from MarkLogic and write them to ORC files on a local filesystem, HDFS, or S3 using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-orc.html">Spark's ORC support</a>.
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html">Spark's ORC support</a>.
  */
 public interface OrcFilesExporter extends Executor<OrcFilesExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/OrcFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/OrcFilesImporter.java
@@ -6,8 +6,8 @@ package com.marklogic.flux.api;
 import java.util.function.Consumer;
 
 /**
- * Read ORC files from local, HDFS, and S3 locations using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-orc.html">Spark's ORC support</a>,
+ * Read ORC files from supported file locations using
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html">Spark's ORC support</a>,
  * and write JSON or XML documents to MarkLogic.
  */
 public interface OrcFilesImporter extends Executor<OrcFilesImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ParquetFilesExporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ParquetFilesExporter.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 
 /**
  * Read rows via Optic from MarkLogic and write them to Parquet files on a local filesystem, HDFS, or S3 using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-parquet.html">Spark's Parquet support</a>.
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html">Spark's Parquet support</a>.
  */
 public interface ParquetFilesExporter extends Executor<ParquetFilesExporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ParquetFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ParquetFilesImporter.java
@@ -6,8 +6,8 @@ package com.marklogic.flux.api;
 import java.util.function.Consumer;
 
 /**
- * Read Parquet files from local, HDFS, and S3 locations using
- * <a href="https://spark.apache.org/docs/latest/sql-data-sources-parquet.html">Spark's Parquet support</a>,
+ * Read Parquet files from supported file locations using
+ * <a href="https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html">Spark's Parquet support</a>,
  * and write JSON or XML documents to MarkLogic.
  */
 public interface ParquetFilesImporter extends Executor<ParquetFilesImporter> {

--- a/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesImporter.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/RdfFilesImporter.java
@@ -6,7 +6,7 @@ package com.marklogic.flux.api;
 import java.util.function.Consumer;
 
 /**
- * Read RDF data from local, HDFS, and S3 files and write the data as managed triples documents in MarkLogic.
+ * Read RDF data from supported file locations and write the data as managed triples documents in MarkLogic.
  */
 public interface RdfFilesImporter extends Executor<RdfFilesImporter> {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/JdbcParams.java
@@ -32,7 +32,7 @@ public class JdbcParams<T extends JdbcOptions> implements JdbcOptions<T> {
     @CommandLine.Option(
         names = "-P",
         description = "Specify any Spark JDBC option defined at " +
-            "%nhttps://spark.apache.org/docs/latest/sql-data-sources-jdbc.html; e.g. -Pfetchsize=100 ."
+            "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html; e.g. -Pfetchsize=100 ."
     )
     private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/custom/AbstractCustomExportCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/custom/AbstractCustomExportCommand.java
@@ -45,7 +45,7 @@ abstract class AbstractCustomExportCommand<T extends Executor<T>> extends Abstra
 
         @CommandLine.Option(names = "--mode",
             description = "Specifies how data is written if the path already exists. " +
-                "See %nhttps://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/SaveMode.html for more information. "
+                "See %nhttps://spark.apache.org/docs/3.5.6/api/java/org/apache/spark/sql/SaveMode.html for more information. "
                 + OptionsUtil.VALID_VALUES_DESCRIPTION)
         private SaveMode saveMode = SaveMode.APPEND;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportAvroFilesCommand.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-avro-files",
     description = "Read rows via Optic from MarkLogic and write them to Avro files on a local filesystem, HDFS, or S3 " +
-        "using Spark's support defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-avro.html ."
+        "using Spark's support defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html ."
 )
 public class ExportAvroFilesCommand extends AbstractExportRowsToFilesCommand<AvroFilesExporter> implements AvroFilesExporter {
 
@@ -37,7 +37,7 @@ public class ExportAvroFilesCommand extends AbstractExportRowsToFilesCommand<Avr
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark Avro option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -Pcompression=bzip2."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html; e.g. -Pcompression=bzip2."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportDelimitedFilesCommand.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-delimited-files",
     description = "Read rows via Optic from MarkLogic and write them to delimited text files on a local filesystem, " +
-        "HDFS, or S3 using Spark's support defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-csv.html ."
+        "HDFS, or S3 using Spark's support defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html ."
 )
 public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesCommand<DelimitedFilesExporter> implements DelimitedFilesExporter {
 
@@ -39,7 +39,7 @@ public class ExportDelimitedFilesCommand extends AbstractExportRowsToFilesComman
 
         @CommandLine.Option(
             names = {"-P"},
-            description = "Specify any Spark CSV option defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-csv.html; e.g. -PquoteAll=true."
+            description = "Specify any Spark CSV option defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html; e.g. -PquoteAll=true."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJdbcCommand.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-jdbc",
     description = "Read rows via Optic from MarkLogic and write them to a table using Spark's support defined at" +
-        "%nhttps://spark.apache.org/docs/latest/sql-data-sources-jdbc.html ."
+        "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html ."
 )
 public class ExportJdbcCommand extends AbstractCommand<JdbcExporter> implements JdbcExporter {
 
@@ -67,7 +67,7 @@ public class ExportJdbcCommand extends AbstractCommand<JdbcExporter> implements 
 
         @CommandLine.Option(names = "--mode",
             description = "Specifies how data is written to a table if the table already exists. " +
-                "See %nhttps://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/SaveMode.html for more information. "
+                "See %nhttps://spark.apache.org/docs/3.5.6/api/java/org/apache/spark/sql/SaveMode.html for more information. "
                 + OptionsUtil.VALID_VALUES_DESCRIPTION)
         private SaveMode saveMode = SaveMode.ERRORIFEXISTS;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportJsonLinesFilesCommand.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-json-lines-files",
     description = "Read rows via Optic from MarkLogic and write them to JSON Lines files on a local filesystem, HDFS, or S3 " +
-        "using Spark's support defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html ."
+        "using Spark's support defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-json.html ."
 )
 public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesCommand<JsonLinesFilesExporter> implements JsonLinesFilesExporter {
 
@@ -30,7 +30,7 @@ public class ExportJsonLinesFilesCommand extends AbstractExportRowsToFilesComman
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark JSON option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html; e.g. -Pcompression=bzip2."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-json.html; e.g. -Pcompression=bzip2."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportOrcFilesCommand.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-orc-files",
     description = "Read rows via Optic from MarkLogic and write them to ORC files on a local filesystem, HDFS, or S3 " +
-        "using Spark's support defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-orc.html ."
+        "using Spark's support defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html ."
 )
 public class ExportOrcFilesCommand extends AbstractExportRowsToFilesCommand<OrcFilesExporter> implements OrcFilesExporter {
 
@@ -37,7 +37,7 @@ public class ExportOrcFilesCommand extends AbstractExportRowsToFilesCommand<OrcF
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark ORC option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -Pcompression=lz4."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html; e.g. -Pcompression=lz4."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/ExportParquetFilesCommand.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "export-parquet-files",
     description = "Read rows via Optic from MarkLogic and write them to Parquet files on a local filesystem, HDFS, or S3 " +
-        "using Spark's support defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-parquet.html ."
+        "using Spark's support defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html ."
 )
 public class ExportParquetFilesCommand extends AbstractExportRowsToFilesCommand<ParquetFilesExporter> implements ParquetFilesExporter {
 
@@ -37,7 +37,7 @@ public class ExportParquetFilesCommand extends AbstractExportRowsToFilesCommand<
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark Parquet option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-parquet.html; e.g. -Pcompression=gzip."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html; e.g. -Pcompression=gzip."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteStructuredFilesParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/export/WriteStructuredFilesParams.java
@@ -15,7 +15,7 @@ public abstract class WriteStructuredFilesParams<T extends WriteFilesOptions> ex
 
     @CommandLine.Option(names = "--mode",
         description = "Specifies how data is written if the path already exists. " +
-            "See %nhttps://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/SaveMode.html for more information. "
+            "See %nhttps://spark.apache.org/docs/3.5.6/api/java/org/apache/spark/sql/SaveMode.html for more information. "
             + OptionsUtil.VALID_VALUES_DESCRIPTION)
     private SaveMode saveMode = SaveMode.APPEND;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesCommand.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
     name = "import-aggregate-json-files",
     description = "Read either JSON Lines files or files containing arrays of JSON objects from " +
         "local, HDFS, and S3 locations using Spark's support " +
-        "defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html, with each object being written " +
+        "defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-json.html, with each object being written " +
         "as a JSON document to MarkLogic."
 )
 public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<AggregateJsonFilesImporter> implements AggregateJsonFilesImporter {
@@ -51,7 +51,7 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
         @CommandLine.Option(
             names = "--json-lines",
             description = "Specifies that the file contains one JSON object per line, per the JSON Lines format defined at https://jsonlines.org/ , " +
-                "using the Spark JSON data source defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html."
+                "using the Spark JSON data source defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-json.html."
         )
         private boolean jsonLines;
 
@@ -74,7 +74,7 @@ public class ImportAggregateJsonFilesCommand extends AbstractImportFilesCommand<
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark JSON option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-json.html; e.g. -PallowComments=true."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-json.html; e.g. -PallowComments=true."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesCommand.java
@@ -17,7 +17,7 @@ import java.util.function.Supplier;
 
 @CommandLine.Command(
     name = "import-aggregate-xml-files",
-    description = "Read aggregate XML files from local, HDFS, and S3 locations with each row being written to MarkLogic."
+    description = "Read aggregate XML files from supported file locations with each row being written to MarkLogic."
 )
 public class ImportAggregateXmlFilesCommand extends AbstractImportFilesCommand<AggregateXmlFilesImporter> implements AggregateXmlFilesImporter {
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -18,8 +18,8 @@ import java.util.function.Consumer;
 
 @CommandLine.Command(
     name = "import-avro-files",
-    description = "Read Avro files from local, HDFS, and S3 locations using Spark's support defined at" +
-        "%nhttps://spark.apache.org/docs/latest/sql-data-sources-avro.html, and write JSON or XML documents " +
+    description = "Read Avro files from supported file locations using Spark's support defined at" +
+        "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html, and write JSON or XML documents " +
         "to MarkLogic."
 )
 public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFilesImporter> implements AvroFilesImporter {
@@ -56,7 +56,7 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark Avro data source option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-avro.html; e.g. -PignoreExtension=true. " +
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html; e.g. -PignoreExtension=true. " +
                 "Spark configuration options must be defined via '-C'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesCommand.java
@@ -17,8 +17,8 @@ import java.util.function.Consumer;
 
 @CommandLine.Command(
     name = "import-delimited-files",
-    description = "Read delimited text files from local, HDFS, and S3 locations using Spark's support " +
-        "defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-csv.html, and write JSON or XML documents " +
+    description = "Read delimited text files from supported file locations using Spark's support " +
+        "defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html, and write JSON or XML documents " +
         "to MarkLogic."
 )
 public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<DelimitedFilesImporter> implements DelimitedFilesImporter {
@@ -61,7 +61,7 @@ public class ImportDelimitedFilesCommand extends AbstractImportFilesCommand<Deli
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark CSV option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-csv.html; e.g. -PquoteAll=true."
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-csv.html; e.g. -PquoteAll=true."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportJdbcCommand.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 @CommandLine.Command(
     name = "import-jdbc",
     description = "Read rows via JDBC using Spark's support defined at " +
-        "%nhttps://spark.apache.org/docs/latest/sql-data-sources-jdbc.html, and write JSON or XML documents " +
+        "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-jdbc.html, and write JSON or XML documents " +
         "to MarkLogic."
 )
 public class ImportJdbcCommand extends AbstractCommand<JdbcImporter> implements JdbcImporter {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -18,8 +18,8 @@ import java.util.function.Consumer;
 
 @CommandLine.Command(
     name = "import-orc-files",
-    description = "Read ORC files from local, HDFS, and S3 locations using Spark's support " +
-        "defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-orc.html, and write JSON or " +
+    description = "Read ORC files from supported file locations using Spark's support " +
+        "defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html, and write JSON or " +
         "XML documents to MarkLogic."
 )
 public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesImporter> implements OrcFilesImporter {
@@ -56,7 +56,7 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark ORC data source option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-orc.html; e.g. -PmergeSchema=true. " +
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html; e.g. -PmergeSchema=true. " +
                 "Spark configuration options must be defined via '-C'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
@@ -18,8 +18,8 @@ import java.util.function.Consumer;
 
 @CommandLine.Command(
     name = "import-parquet-files",
-    description = "Read Parquet files from local, HDFS, and S3 locations using Spark's support " +
-        "defined at %nhttps://spark.apache.org/docs/latest/sql-data-sources-parquet.html, and write JSON or XML " +
+    description = "Read Parquet files from supported file locations using Spark's support " +
+        "defined at %nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html, and write JSON or XML " +
         "documents to MarkLogic."
 )
 public class ImportParquetFilesCommand extends AbstractImportFilesCommand<ParquetFilesImporter> implements ParquetFilesImporter {
@@ -56,7 +56,7 @@ public class ImportParquetFilesCommand extends AbstractImportFilesCommand<Parque
         @CommandLine.Option(
             names = "-P",
             description = "Specify any Spark Parquet data source option defined at " +
-                "%nhttps://spark.apache.org/docs/latest/sql-data-sources-parquet.html; e.g. -PmergeSchema=true. " +
+                "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html; e.g. -PmergeSchema=true. " +
                 "Spark configuration options must be defined via '-C'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportRdfFilesCommand.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 
 @CommandLine.Command(
     name = "import-rdf-files",
-    description = "Read RDF data from local, HDFS, and S3 files and write the data as managed triples documents in MarkLogic."
+    description = "Read RDF data from supported file locations and write the data as managed triples documents in MarkLogic."
 )
 public class ImportRdfFilesCommand extends AbstractImportFilesCommand<RdfFilesImporter> implements RdfFilesImporter {
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
@@ -27,6 +27,6 @@ class ImportAvroFilesOptionsTest extends AbstractOptionsTest {
         assertFalse(options.containsKey("spark.sql.parquet.filterPushdown"),
             "Dynamic params starting with 'spark.sql' should not be added to the 'read' options. They should " +
                 "instead be added to the SparkConf object, per the documentation at " +
-                "https://spark.apache.org/docs/latest/sql-data-sources-avro.html .");
+                "https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html .");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
@@ -27,6 +27,6 @@ class ImportOrcFilesOptionsTest extends AbstractOptionsTest {
         assertFalse(options.containsKey("spark.sql.parquet.filterPushdown"),
             "Dynamic params starting with 'spark.sql' should not be added to the 'read' options. They should " +
                 "instead be added to the SparkConf object, per the documentation at " +
-                "https://spark.apache.org/docs/latest/sql-data-sources-orc.html .");
+                "https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html .");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
@@ -27,6 +27,6 @@ class ImportParquetFilesOptionsTest extends AbstractOptionsTest {
         assertFalse(options.containsKey("spark.sql.parquet.filterPushdown"),
             "Dynamic params starting with 'spark.sql' should not be added to the 'read' options. They should " +
                 "instead be added to the SparkConf object, per the documentation at " +
-                "https://spark.apache.org/docs/latest/sql-data-sources-parquet.html .");
+                "https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html .");
     }
 }


### PR DESCRIPTION
Most changes are updating the Spark URLs to point to the 3.5.6 docs instead of "latest", which now points to the 4.0.0 docs.
