### PR TITLE
MLE-23420 Fixing classpath issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ flux-cli/src/dist/ext/*.jar
 flux-version.properties
 docker/sonarqube
 optionsExperiments
+dep.txt

--- a/examples/client-project/build.gradle
+++ b/examples/client-project/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     mavenLocal()
   }
   dependencies {
-    classpath "com.marklogic:flux-api:1.4.0"
+    classpath "com.marklogic:flux-api:1.5-SNAPSHOT"
   }
 
   // This is required when a plugin, such as ml-gradle, is on the classpath that brings along a version of Jackson
@@ -41,18 +41,9 @@ repositories {
   mavenLocal()
 }
 
-configurations.all {
-  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-    if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-      details.useVersion '2.15.2'
-      details.because 'Must use the version of Jackson required by Spark.'
-    }
-  }
-}
-
 dependencies {
-  implementation "com.marklogic:flux-api:1.4.0"
-  implementation "com.marklogic:flux-embedding-model-minilm:1.4.0"
+  implementation "com.marklogic:flux-api:1.5-SNAPSHOT"
+  implementation "com.marklogic:flux-embedding-model-minilm:1.5-SNAPSHOT"
 }
 
 /**

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -60,7 +60,13 @@ dependencies {
   // For Blob Storage
   implementation "com.microsoft.azure:azure-storage:8.6.6"
   // For Data Lake Storage Gen2
-  implementation "com.azure:azure-storage-file-datalake:12.23.1"
+  implementation ("com.azure:azure-storage-file-datalake:12.23.1") {
+    // Exclude the Jackson dependencies that Spark already provides, and we need the version required by Spark.
+    // This exclusion can be tested by publishing flux-api locally and running the test programs in
+    // examples/client-project.
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.datatype"
+  }
 
   implementation "org.apache.hadoop:hadoop-client:3.3.4"
 


### PR DESCRIPTION
This currently has to be manually tested via the client-project example, where we're able to ensure that the pom file for flux-api does not bring in later versions of Jackson that cause Spark to break.
