### PR TITLE
MLE-23506 Exposing connection params as system properties

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/ConnectionParams.java
@@ -13,6 +13,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--connection-string",
+        defaultValue = "${sys:marklogic.client.connectionString}",
         converter = ConnectionStringValidator.class,
         description = "Defines a connection string as user:password@host:port/optionalDatabaseName; only usable when using 'DIGEST' or 'BASIC' authentication."
     )
@@ -24,6 +25,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = {"--host"},
+        defaultValue = "${sys:marklogic.client.host}",
         description = "The MarkLogic host to connect to."
     )
     public ConnectionOptions host(String host) {
@@ -34,6 +36,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--port",
+        defaultValue = "${sys:marklogic.client.port}",
         description = "Port of a MarkLogic REST API app server to connect to."
     )
     public ConnectionOptions port(int port) {
@@ -44,6 +47,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--base-path",
+        defaultValue = "${sys:marklogic.client.basePath}",
         description = "Path to prepend to each call to a MarkLogic REST API app server."
     )
     public ConnectionOptions basePath(String basePath) {
@@ -54,6 +58,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--database",
+        defaultValue = "${sys:marklogic.client.database}",
         description = "Name of a database to connect to if it differs from the one associated with the app server identified by '--port'."
     )
     public ConnectionOptions database(String database) {
@@ -63,6 +68,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
 
     @CommandLine.Option(
         names = "--connection-type",
+        defaultValue = "${sys:marklogic.client.connectionType}",
         description = "Set to 'DIRECT' if connections can be made directly to each host in the MarkLogic cluster. Defaults to 'GATEWAY'. " + OptionsUtil.VALID_VALUES_DESCRIPTION
     )
     public ConnectionOptions connectionType(ConnectionType connectionType) {
@@ -78,6 +84,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--disable-gzipped-responses",
+        defaultValue = "${sys:marklogic.client.disableGzippedResponses}",
         description = "If included, responses from MarkLogic will not be gzipped. May improve performance when responses are very small."
     )
     public ConnectionOptions disableGzippedResponses(boolean disableGzippedResponses) {
@@ -88,6 +95,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--auth-type",
+        defaultValue = "${sys:marklogic.client.authType}",
         description = "Type of authentication to use. " + OptionsUtil.VALID_VALUES_DESCRIPTION
     )
     public ConnectionOptions authenticationType(AuthenticationType authType) {
@@ -98,6 +106,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--username",
+        defaultValue = "${sys:marklogic.client.username}",
         description = "Username when using 'DIGEST' or 'BASIC' authentication."
     )
     public ConnectionOptions username(String username) {
@@ -108,6 +117,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--password",
+        defaultValue = "${sys:marklogic.client.password}",
         description = "Password when using 'DIGEST' or 'BASIC' authentication.",
         interactive = true,
         arity = "0..1"
@@ -120,6 +130,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--certificate-file",
+        defaultValue = "${sys:marklogic.client.certificate.file}",
         description = "File path for a keystore to be used for 'CERTIFICATE' authentication."
     )
     public ConnectionOptions certificateFile(String certificateFile) {
@@ -130,6 +141,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--certificate-password",
+        defaultValue = "${sys:marklogic.client.certificate.password}",
         description = "Password for the keystore referenced by '--certificate-file'.",
         interactive = true,
         arity = "0..1"
@@ -142,6 +154,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--cloud-api-key",
+        defaultValue = "${sys:marklogic.client.cloud.apiKey}",
         description = "API key for authenticating with a MarkLogic Cloud cluster when using 'CLOUD' authentication."
     )
     public ConnectionOptions cloudApiKey(String cloudApiKey) {
@@ -152,6 +165,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--kerberos-principal",
+        defaultValue = "${sys:marklogic.client.kerberos.principal}",
         description = "Principal to be used with 'KERBEROS' authentication."
     )
     public ConnectionOptions kerberosPrincipal(String kerberosPrincipal) {
@@ -162,6 +176,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--saml-token",
+        defaultValue = "${sys:marklogic.client.saml.token}",
         description = "Token to be used with 'SAML' authentication."
     )
     public ConnectionOptions samlToken(String samlToken) {
@@ -172,6 +187,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--oauth-token",
+        defaultValue = "${sys:marklogic.client.oauth.token}",
         description = "Token to be used with 'OAUTH' authentication."
     )
     public ConnectionOptions oauthToken(String oauthToken) {
@@ -182,6 +198,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--ssl-protocol",
+        defaultValue = "${sys:marklogic.client.sslProtocol}",
         description = "SSL protocol to use when the MarkLogic app server requires an SSL connection. If a keystore " +
             "or truststore is configured, defaults to 'TLSv1.2'."
     )
@@ -193,6 +210,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--ssl-hostname-verifier",
+        defaultValue = "${sys:marklogic.client.sslHostnameVerifier}",
         description = "Hostname verification strategy when connecting via SSL. " + OptionsUtil.VALID_VALUES_DESCRIPTION
     )
     public ConnectionOptions sslHostnameVerifier(SslHostnameVerifier sslHostnameVerifier) {
@@ -203,6 +221,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--keystore-path",
+        defaultValue = "${sys:marklogic.client.ssl.keystore.path}",
         description = "File path for a keystore for two-way SSL connections."
     )
     public ConnectionOptions keyStorePath(String keyStorePath) {
@@ -213,6 +232,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--keystore-password",
+        defaultValue = "${sys:marklogic.client.ssl.keystore.password}",
         description = "Password for the keystore identified by '--keystore-path'.",
         interactive = true,
         arity = "0..1"
@@ -225,6 +245,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--keystore-type",
+        defaultValue = "${sys:marklogic.client.ssl.keystore.type}",
         description = "Type of the keystore identified by '--keystore-path'; defaults to 'JKS'."
     )
     public ConnectionOptions keyStoreType(String keyStoreType) {
@@ -235,6 +256,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--keystore-algorithm",
+        defaultValue = "${sys:marklogic.client.ssl.keystore.algorithm}",
         description = "Algorithm of the keystore identified by '--keystore-path'; defaults to 'SunX509'."
     )
     public ConnectionOptions keyStoreAlgorithm(String keyStoreAlgorithm) {
@@ -245,6 +267,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--truststore-path",
+        defaultValue = "${sys:marklogic.client.ssl.truststore.path}",
         description = "File path for a truststore for establishing trust with the certificate used by the MarkLogic app server."
     )
     public ConnectionOptions trustStorePath(String trustStorePath) {
@@ -255,6 +278,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--truststore-password",
+        defaultValue = "${sys:marklogic.client.ssl.truststore.password}",
         description = "Password for the truststore identified by '--truststore-path'.",
         interactive = true,
         arity = "0..1"
@@ -267,6 +291,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--truststore-type",
+        defaultValue = "${sys:marklogic.client.ssl.truststore.type}",
         description = "Type of the truststore identified by '--truststore-path'; defaults to 'JKS'."
     )
     public ConnectionOptions trustStoreType(String trustStoreType) {
@@ -277,6 +302,7 @@ public class ConnectionParams extends ConnectionInputs implements ConnectionOpti
     @Override
     @CommandLine.Option(
         names = "--truststore-algorithm",
+        defaultValue = "${sys:marklogic.client.ssl.truststore.algorithm}",
         description = "Algorithm of the truststore identified by '--truststore-path'; defaults to 'SunX509'."
     )
     public ConnectionOptions trustStoreAlgorithm(String trustStoreAlgorithm) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ConnectionParamsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ConnectionParamsTest.java
@@ -7,7 +7,82 @@ import com.marklogic.flux.impl.importdata.ImportFilesCommand;
 import com.marklogic.spark.Options;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 class ConnectionParamsTest extends AbstractOptionsTest {
+
+    /**
+     * Verifies that system properties are used to provide default values to connection options.
+     * This makes Flux much easier to configure via e.g. a Spring Boot application.
+     */
+    @Test
+    void systemProperties() {
+        Map<String, String> systemProps = new HashMap<>();
+        systemProps.put("marklogic.client.connectionString", "user:password@host:8000");
+        systemProps.put("marklogic.client.host", "localhost");
+        systemProps.put("marklogic.client.port", "8123");
+        systemProps.put("marklogic.client.basePath", "/path");
+        systemProps.put("marklogic.client.database", "somedb");
+        systemProps.put("marklogic.client.connectionType", "direct");
+        systemProps.put("marklogic.client.disableGzippedResponses", "true");
+        systemProps.put("marklogic.client.authType", "basic");
+        systemProps.put("marklogic.client.username", "jane");
+        systemProps.put("marklogic.client.password", "secret");
+        systemProps.put("marklogic.client.certificate.file", "/cert/file");
+        systemProps.put("marklogic.client.certificate.password", "certword");
+        systemProps.put("marklogic.client.cloud.apiKey", "key123");
+        systemProps.put("marklogic.client.kerberos.principal", "kerb123");
+        systemProps.put("marklogic.client.saml.token", "saml123");
+        systemProps.put("marklogic.client.oauth.token", "oauth123");
+        systemProps.put("marklogic.client.sslProtocol", "TLSv1.3");
+        systemProps.put("marklogic.client.sslHostnameVerifier", "STRICT");
+        systemProps.put("marklogic.client.ssl.keystore.path", "key.jks");
+        systemProps.put("marklogic.client.ssl.keystore.password", "keypass");
+        systemProps.put("marklogic.client.ssl.keystore.type", "SOMEJKS");
+        systemProps.put("marklogic.client.ssl.keystore.algorithm", "SomeX509");
+        systemProps.put("marklogic.client.ssl.truststore.path", "trust.jks");
+        systemProps.put("marklogic.client.ssl.truststore.password", "trustpass");
+        systemProps.put("marklogic.client.ssl.truststore.type", "SOMETRUST");
+        systemProps.put("marklogic.client.ssl.truststore.algorithm", "SomeX510");
+
+        try {
+            systemProps.forEach(System::setProperty);
+            ImportFilesCommand command = (ImportFilesCommand) getCommand(
+                "import-files",
+                "--path", "/doesnt/matter/for-this-test");
+            assertOptions(command.getConnectionParams().makeOptions(),
+                Options.CLIENT_URI, "user:password@host:8000",
+                Options.CLIENT_HOST, "localhost",
+                Options.CLIENT_PORT, "8123",
+                "spark.marklogic.client.basePath", "/path",
+                Options.CLIENT_DATABASE, "somedb",
+                Options.CLIENT_CONNECTION_TYPE, "DIRECT",
+                "spark.marklogic.client.disableGzippedResponses", "true",
+                Options.CLIENT_AUTH_TYPE, "basic",
+                Options.CLIENT_USERNAME, "jane",
+                Options.CLIENT_PASSWORD, "secret",
+                "spark.marklogic.client.certificate.file", "/cert/file",
+                "spark.marklogic.client.certificate.password", "certword",
+                "spark.marklogic.client.cloud.apiKey", "key123",
+                "spark.marklogic.client.kerberos.principal", "kerb123",
+                "spark.marklogic.client.saml.token", "saml123",
+                "spark.marklogic.client.oauth.token", "oauth123",
+                "spark.marklogic.client.sslProtocol", "TLSv1.3",
+                "spark.marklogic.client.sslHostnameVerifier", "STRICT",
+                "spark.marklogic.client.ssl.keystore.path", "key.jks",
+                "spark.marklogic.client.ssl.keystore.password", "keypass",
+                "spark.marklogic.client.ssl.keystore.type", "SOMEJKS",
+                "spark.marklogic.client.ssl.keystore.algorithm", "SomeX509",
+                "spark.marklogic.client.ssl.truststore.path", "trust.jks",
+                "spark.marklogic.client.ssl.truststore.password", "trustpass",
+                "spark.marklogic.client.ssl.truststore.type", "SOMETRUST",
+                "spark.marklogic.client.ssl.truststore.algorithm", "SomeX510"
+            );
+        } finally {
+            systemProps.keySet().forEach(System::clearProperty);
+        }
+    }
 
     @Test
     void allConnectionParams() {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -24,6 +24,25 @@ class ImportFilesTest extends AbstractTest {
     private static final String[] MIXED_FILES_URIS = new String[]{"/hello.json", "/hello.txt", "/hello.xml", "/hello2.txt.gz"};
 
     @Test
+    void connectionStringViaSysProperty() {
+        final String property = "marklogic.client.connectionString";
+        try {
+            System.setProperty(property, makeConnectionString());
+            run(
+                "import-files",
+                "--path", "src/test/resources/mixed-files/hello*",
+                "--permissions", DEFAULT_PERMISSIONS,
+                "--collections", "files",
+                "--uri-replace", ".*/mixed-files,''"
+            );
+
+            verifyDocsWereWritten(MIXED_FILES_URIS.length, MIXED_FILES_URIS);
+        } finally {
+            System.clearProperty(property);
+        }
+    }
+
+    @Test
     void multiplePaths() {
         run(
             CommandLine.ExitCode.OK,


### PR DESCRIPTION
All connection params can now be set via system properties.  Not documenting this yet, as the main use case is for an internal project.
