### PR TITLE
MLE-23618 Added new Main method to return a Command object

### DIFF
--- a/flux-cli/src/test/java/com/marklogic/flux/impl/custom/CustomExportRowsOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/custom/CustomExportRowsOptionsTest.java
@@ -14,6 +14,7 @@ class CustomExportRowsOptionsTest extends AbstractOptionsTest {
     void test() {
         CustomExportRowsCommand command = (CustomExportRowsCommand) getCommand(
             "custom-export-rows",
+            "--connection-string", makeConnectionString(),
             "--query", "anything",
             "--target", "xml",
             "--partitions", "4"

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/export/ExportJdbcOptionsTest.java
@@ -13,6 +13,7 @@ class ExportJdbcOptionsTest extends AbstractOptionsTest {
     @Test
     void test() {
         ExportJdbcCommand command = (ExportJdbcCommand) getCommand("export-jdbc",
+            "--connection-string", makeConnectionString(),
             "--query", "anything",
             "--partitions", "12",
             "--jdbc-url", "some-jdbc-url",
@@ -25,6 +26,7 @@ class ExportJdbcOptionsTest extends AbstractOptionsTest {
     @Test
     void userDefinedSparkMasterUrl() {
         ExportJdbcCommand command = (ExportJdbcCommand) getCommand("export-jdbc",
+            "--connection-string", makeConnectionString(),
             "--query", "anything",
             "--partitions", "12",
             "--spark-master-url", "local[6]",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateJsonFilesOptionsTest.java
@@ -16,6 +16,7 @@ class ImportAggregateJsonFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportAggregateJsonFilesCommand command = (ImportAggregateJsonFilesCommand) getCommand(
             "import-aggregate-json-files",
+            "--connection-string", makeConnectionString(),
             "--path", "anywhere",
             "--encoding", "UTF-16"
         );

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAggregateXmlFilesOptionsTest.java
@@ -13,6 +13,7 @@ class ImportAggregateXmlFilesOptionsTest extends AbstractOptionsTest {
     void numPartitions() {
         ImportAggregateXmlFilesCommand command = (ImportAggregateXmlFilesCommand) getCommand(
             "import-aggregate-xml-files",
+            "--connection-string", makeConnectionString(),
             "--path", "src/test/resources/xml-file",
             "--preview", "10",
             "--element", "anything",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportArchiveFilesOptionsTest.java
@@ -13,6 +13,7 @@ class ImportArchiveFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportArchiveFilesCommand command = (ImportArchiveFilesCommand) getCommand(
             "import-archive-files",
+            "--connection-string", makeConnectionString(),
             "--path", "src/test/resources/archive-files",
             "--preview", "10",
             "--partitions", "18",
@@ -29,6 +30,7 @@ class ImportArchiveFilesOptionsTest extends AbstractOptionsTest {
     void streaming() {
         ImportArchiveFilesCommand command = (ImportArchiveFilesCommand) getCommand(
             "import-archive-files",
+            "--connection-string", makeConnectionString(),
             "--path", "src/test/resources/archive-files",
             "--streaming",
             "--document-type", "xml"

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
@@ -16,6 +16,7 @@ class ImportAvroFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportAvroFilesCommand command = (ImportAvroFilesCommand) getCommand(
             "import-avro-files",
+            "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
             "-Cspark.sql.parquet.filterPushdown=false",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportDelimitedFilesOptionsTest.java
@@ -22,6 +22,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportDelimitedFilesCommand command = (ImportDelimitedFilesCommand) getCommand(
             "import-delimited-files",
+            "--connection-string", makeConnectionString(),
             "--path", "anywhere",
             "--encoding", "UTF-16"
         );
@@ -35,6 +36,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
     void tdeDirectories() {
         ImportDelimitedFilesCommand command = (ImportDelimitedFilesCommand) getCommand(
             "import-delimited-files",
+            "--connection-string", makeConnectionString(),
             "--path", "anywhere",
             "--encoding", "UTF-16",
             "--tde-directory", "/dir1",
@@ -55,6 +57,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
     void tdeColumnCustomizations() {
         ImportDelimitedFilesCommand command = (ImportDelimitedFilesCommand) getCommand(
             "import-delimited-files",
+            "--connection-string", makeConnectionString(),
             "--path", "anywhere",
             "--tde-schema", "test-schema",
             "--tde-view", "test-view",
@@ -221,7 +224,7 @@ class ImportDelimitedFilesOptionsTest extends AbstractOptionsTest {
 
         assertEquals("col1", inputs.getVirtualColumns().get(0));
         assertEquals(1, inputs.getVirtualColumns().size());
-        
+
         assertEquals(384, inputs.getColumnDimensions().get("col1").intValue());
         assertEquals(0.5f, inputs.getColumnAnnCompressions().get("col1").floatValue());
         assertEquals("cosine", inputs.getColumnAnnDistances().get("col1"));

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -4,7 +4,10 @@
 package com.marklogic.flux.impl.importdata;
 
 import com.marklogic.flux.AbstractTest;
+import com.marklogic.flux.cli.Main;
 import com.marklogic.junit5.XmlNode;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.util.FileCopyUtils;
@@ -336,6 +339,44 @@ class ImportFilesTest extends AbstractTest {
         assertCollectionSize("files", 1);
         XmlNode doc = readXmlDocument("/japanese-files/太田佳伸のＸＭＬファイル.xml");
         doc.assertElementValue("/root/filename", "太田佳伸のＸＭＬファイル");
+    }
+
+    @Test
+    void withCustomSparkListener() {
+        Main.CommandContext commandContext = new Main().buildCommandContext(null, null,
+            "import-files",
+            "--path", "src/test/resources/mixed-files/hello*txt*",
+            "--path", "src/test/resources/mixed-files/hello.json",
+            "--path", "src/test/resources/mixed-files/hello.xml",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "files",
+            "--uri-replace", ".*/mixed-files,''"
+        );
+
+        TestListener testListener = new TestListener();
+        commandContext.sparkSession.sparkContext().addSparkListener(testListener);
+
+        try {
+            commandContext.command.execute(commandContext.sparkSession);
+
+            assertTrue(testListener.jobEnded, "Expected the SparkListener to have been called when the job ends. " +
+                "This verifies that a Flux user can use the Main class to construct a Command object that is ready " +
+                "to be executed, based on command line args, with a custom Spark Session provided by the user.");
+
+            verifyDocsWereWritten(MIXED_FILES_URIS.length, MIXED_FILES_URIS);
+        } finally {
+            commandContext.sparkSession.close();
+        }
+    }
+
+    private class TestListener extends SparkListener {
+        boolean jobEnded;
+
+        @Override
+        public void onJobEnd(SparkListenerJobEnd jobEnd) {
+            jobEnded = true;
+        }
     }
 
     private void verifyDocsWereWritten(int expectedUriCount, String... values) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportMlcpArchiveFilesOptionsTest.java
@@ -13,6 +13,7 @@ class ImportMlcpArchiveFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportMlcpArchiveFilesCommand command = (ImportMlcpArchiveFilesCommand) getCommand(
             "import-mlcp-archive-files",
+            "--connection-string", makeConnectionString(),
             "--path", "src/test/resources/archive-files",
             "--preview", "10",
             "--partitions", "7",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
@@ -16,6 +16,7 @@ class ImportOrcFilesOptionsTest extends AbstractOptionsTest {
     void test() {
         ImportOrcFilesCommand command = (ImportOrcFilesCommand) getCommand(
             "import-orc-files",
+            "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PmergeSchema=true",
             "-Cspark.sql.parquet.filterPushdown=false",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
@@ -16,6 +16,7 @@ class ImportParquetFilesOptionsTest extends AbstractOptionsTest {
     void configurationAndDataSourceOptions() {
         ImportParquetFilesCommand command = (ImportParquetFilesCommand) getCommand(
             "import-parquet-files",
+            "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
             "-Cspark.sql.parquet.filterPushdown=false",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportRdfFilesOptionsTest.java
@@ -13,6 +13,7 @@ class ImportRdfFilesOptionsTest extends AbstractOptionsTest {
     void numPartitions() {
         ImportRdfFilesCommand command = (ImportRdfFilesCommand) getCommand(
             "import-rdf-files",
+            "--connection-string", makeConnectionString(),
             "--path", "src/test/resources/rdf",
             "--preview", "10",
             "--partitions", "4"


### PR DESCRIPTION
This is for ragplus, so that a custom Spark session - specifically with a Spark listener - can be used to execute the command.

This also ended up being a better approach for our "options tests" that just need to parse options but not execute the command. So about a dozen tests were modified to use this approach. They also needed a connection string added since the command is being validated now too.
