### PR TITLE
MLE-23884 Allowing for SparkConf to be provided

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -14,6 +14,7 @@ import com.marklogic.flux.impl.custom.CustomImportCommand;
 import com.marklogic.flux.impl.export.*;
 import com.marklogic.flux.impl.importdata.*;
 import com.marklogic.flux.impl.reprocess.ReprocessCommand;
+import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,21 @@ import java.util.concurrent.atomic.AtomicReference;
 public class Main {
 
     private static final Logger logger = LoggerFactory.getLogger("com.marklogic.flux");
+
+    private final SparkConf sparkConf;
+
+    public Main() {
+        this(null);
+    }
+
+    /**
+     * Allows for providing a SparkConf that will be used when creating a SparkSession.
+     *
+     * @since 1.5.0
+     */
+    public Main(SparkConf sparkConf) {
+        this.sparkConf = sparkConf;
+    }
 
     // Intended to be invoked solely by the application script. Tests should invoke "run" instead to avoid the
     // System.exit call.
@@ -200,7 +216,7 @@ public class Main {
                 sparkSessionBuilderParams = abstractCommand.getCommonParams().getSparkSessionBuilderParams();
             }
         }
-        return SparkUtil.buildSparkSession(masterUrl, sparkSessionBuilderParams);
+        return SparkUtil.buildSparkSession(masterUrl, sparkConf, sparkSessionBuilderParams);
     }
 
     private void printException(@NotNull CommandLine.ParseResult parseResult, Exception ex) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/SparkUtil.java
@@ -4,6 +4,7 @@
 package com.marklogic.flux.impl;
 
 import com.marklogic.flux.api.SaveMode;
+import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -19,10 +20,10 @@ public interface SparkUtil {
     }
 
     static SparkSession buildSparkSession() {
-        return buildSparkSession(null, new HashMap<>());
+        return buildSparkSession(null, null, new HashMap<>());
     }
 
-    static SparkSession buildSparkSession(String masterUrl, Map<String, String> sparkConfigParams) {
+    static SparkSession buildSparkSession(String masterUrl, SparkConf sparkConf, Map<String, String> sparkConfigParams) {
         if (masterUrl == null || masterUrl.trim().isEmpty()) {
             masterUrl = "local[*]";
         }
@@ -40,6 +41,10 @@ public interface SparkUtil {
             // handles constructing a SparkSession. We may eventually provide a feature though for providing options
             // at this point for local users that want more control over the SparkSession itself.
             .config("spark.sql.session.timeZone", "UTC");
+
+        if (sparkConf != null) {
+            builder = builder.config(sparkConf);
+        }
 
         if (sparkConfigParams != null) {
             for (Map.Entry<String, String> entry : sparkConfigParams.entrySet()) {


### PR DESCRIPTION
Required for internal "box" app. No tests, as the main use case for this is to disable the Spark UI, which is only really verifiable via log messages.
