### PR TITLE
MLE-23884 Better approach for configuring SparkConf

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/cli/Main.java
@@ -78,7 +78,9 @@ public class Main {
     }
 
     /**
-     * Allows for providing a SparkConf that will be used when creating a SparkSession.
+     * Allows for providing a SparkConf that will be used when creating a SparkSession. The options for configuring
+     * Spark can still be used, but this allows for programmatically providing a shared SparkConf in an environment
+     * where this class is being invoked multiple times in the same JVM.
      *
      * @since 1.5.0
      */

--- a/flux-tests-api/src/main/resources/log4j2.properties
+++ b/flux-tests-api/src/main/resources/log4j2.properties
@@ -1,3 +1,5 @@
+# Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+
 # The root logger with appender name
 rootLogger = INFO, STDOUT
 
@@ -14,6 +16,8 @@ logger.marklogicclient.name=com.marklogic.client
 logger.marklogicclient.level=WARN
 logger.marklogicspark.name=com.marklogic.spark
 logger.marklogicspark.level=INFO
+logger.appdeployer.name=com.marklogic.appdeployer
+logger.appdeployer.level=WARN
 
 # Set to INFO or DEBUG for langchain4j-specific logging from the MarkLogic Spark connector.
 logger.marklogiclangchain4j.name=com.marklogic.langchain4j


### PR DESCRIPTION
This appears to be the better way to apply Spark config params, such that we likely don't need both -B and -C any more. I opened a ticket to figure that one out.
