### PR TITLE
MLE-23024 Bumping Hadoop to 3.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ subprojects {
 
   configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+      if (details.requested.group.equals("org.apache.hadoop") and details.requested.version.equals("3.4.1")) {
+        details.useVersion "3.4.2"
+        details.because "Bumping to 3.4.2 to minimize CVEs."
+      }
       if (details.requested.group.startsWith('com.fasterxml.jackson')) {
         details.useVersion '2.17.2'
         details.because 'Need to match the version used by Spark.'

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -38,7 +38,8 @@ dependencies {
   }
 
   // Based on testing so far, this appears to suffice for allowing hadoop-aws to read from and write to S3.
-  implementation "software.amazon.awssdk:s3-transfer-manager:2.24.6"
+  // Using 2.29.52, which is what Hadoop 3.4.2 depends on.
+  implementation "software.amazon.awssdk:s3-transfer-manager:2.29.52"
 
   // Adds support for Azure Storage. We may want these to be expressed using variants instead so that at least a
   // Gradle user of the API can ask for e.g. S3 or Azure Storage support without those dependencies being included

--- a/flux-cli/src/test/java/com/marklogic/flux/junit5/TwoWaySslConfigurer.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/junit5/TwoWaySslConfigurer.java
@@ -182,8 +182,8 @@ public class TwoWaySslConfigurer {
     private void deleteCertificateAuthority(String certificateAuthorityName) {
         String xquery = """
             xquery version "1.0-ml";
-            import module namespace pki = "http://marklogic.com/xdmp/pki" at "/MarkLogic/pki.xqy
-            pki:delete-authority("%s")", certificateAuthorityName)""".formatted(certificateAuthorityName);
+            import module namespace pki = 'http://marklogic.com/xdmp/pki' at '/MarkLogic/pki.xqy';
+            pki:delete-authority('%s')""".formatted(certificateAuthorityName);
 
         securityClient.newServerEval().xquery(xquery).evalAs(String.class);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,10 @@ picocliVersion=4.7.7
 
 # Aligned with our Spark connector.
 sparkVersion=4.0.1
-hadoopVersion=3.4.1
+
+# Spark 4.0.1 depends on 3.4.1, but using 3.4.2 to pick up latest fixes.
+hadoopVersion=3.4.2
+
 langchain4jVersion=1.5.0
 tikaVersion=3.2.3
 


### PR DESCRIPTION
Release notes indicate this should be safe, and Copilot was in favor of it as well as a way of minimizing CVEs.

Also fixed a typo in the SSL class.
