### PR TITLE
MLE-23024 Updating Jackson to 2.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ subprojects {
         details.because "Bumping to 3.4.2 to minimize CVEs."
       }
       if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-        details.useVersion '2.17.2'
-        details.because 'Need to match the version used by Spark.'
+        details.useVersion '2.18.2'
+        details.because 'Need to match the version used by Spark 4.0.1.'
       }
       if (details.requested.group.equals("org.slf4j")) {
         details.useVersion "2.0.17"
@@ -75,6 +75,13 @@ subprojects {
 
       // Forcing 3.18.0 to resolve CVEs on earlier versions of commons-lang3.
       force "org.apache.commons:commons-lang3:3.18.0"
+
+      // Forcing Hadoop 3.4.2 to use this to address a medium CVE. This is the latest 9.x version.
+      // It may be possible to exclude this as well as Flux does not use Java web tokens in any way with Hadoop.
+      force "com.nimbusds:nimbus-jose-jwt:9.48"
+
+      // Resolves a medium CVE that comes from json-unit-assertj .
+      force "net.minidev:json-smart:2.5.2"
     }
 
     // Without this exclusion, we have multiple slf4j providers, leading to an ugly warning at the start

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ To add Flux as a dependency to your application, add the following to your Maven
 <dependency>
   <groupId>com.marklogic</groupId>
   <artifactId>flux-api</artifactId>
-  <version>1.4.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
@@ -30,7 +30,7 @@ Or if you are using Gradle, add the following to your `build.gradle` file:
 
 ```
 dependencies {
-  implementation "com.marklogic:flux-api:1.4.0"
+  implementation "com.marklogic:flux-api:2.0.0"
 }
 ```
 
@@ -40,12 +40,14 @@ dependencies {
 configurations.all {
   resolutionStrategy.eachDependency { DependencyResolveDetails details ->
     if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-      details.useVersion '2.15.2'
+      details.useVersion '2.18.2'
       details.because 'Must use the version of Jackson required by Spark.'
     }
   }
 }
 ```
+
+The above is not needed for Flux 2.0.0 and later. 
 
 If you are using Maven, you must add the following to your `pom.xml` file:
 ```xml
@@ -54,22 +56,22 @@ If you are using Maven, you must add the following to your `pom.xml` file:
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.2</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.2</version>
+      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.15.2</version>
+      <version>2.18.2</version>
     </dependency>
   </dependencies>
 </dependencyManagement>
@@ -140,7 +142,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "com.marklogic:flux-api:1.4.0"
+    classpath "com.marklogic:flux-api:2.0.0"
   }
 }
 ```
@@ -194,12 +196,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "com.marklogic:flux-api:1.4.0"
+    classpath "com.marklogic:flux-api:2.0.0"
   }
   configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
       if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-        details.useVersion '2.15.2'
+        details.useVersion '2.18.2'
         details.because 'Must ensure the Jackson version preferred by Spark is used to avoid classpath conflicts.'
       }
     }
@@ -211,7 +213,7 @@ Without the `configurations` block shown above, you will encounter an error simi
 (you will likely need to include the Gradle `--stacktrace` option to see this error):
 
 ```
-Scala module 2.17.2 requires Jackson Databind version >= 2.17.0 and < 2.18.0 - Found jackson-databind version 2.15.2
+Scala module 2.18.2 requires Jackson Databind version >= 2.18.0 and < 2.19.0 - Found jackson-databind version 2.17.2
 ```
 
 You may encounter this error with Gradle plugins other than ml-gradle that also use the Jackson library. If you do, 

--- a/examples/client-project/build.gradle
+++ b/examples/client-project/build.gradle
@@ -18,7 +18,7 @@ buildscript {
   configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
       if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-        details.useVersion '2.17.2'
+        details.useVersion '2.18.2'
         details.because 'Must ensure the Jackson version preferred by Spark is used to avoid classpath conflicts.'
       }
     }
@@ -31,9 +31,8 @@ plugins {
   // Include ml-gradle to verify that it can be used on the buildscript classpath along with flux-api without any
   // class conflicts pertaining to OkHttp or Jackson.
   // Can run "./gradlew mlTestConnections -PmlUsername=admin -PmlPassword=admin -PmlRestPort=8000" to verify that
-  // ml-gradle is able to connect to MarkLogic. This works as of Flux 1.3.0, but had classpath issues with Flux 1.2.x
-  // and earlier.
-  id "com.marklogic.ml-gradle" version "5.0.0"
+  // ml-gradle is able to connect to MarkLogic.
+  id "com.marklogic.ml-gradle" version "6.0.1"
 }
 
 repositories {
@@ -48,7 +47,7 @@ dependencies {
 
 /**
  * Demonstrates how a custom program can be written that depends on the "flux-api" and "flux-embedding-model-minilm"
- * dependencies. Requires Java 17 and use of the Gradle "java" plugin.
+ * dependencies. Requires use of the Gradle "java" plugin.
  */
 tasks.register("runCustomProgram", JavaExec) {
   mainClass = "org.example.CustomProgram"
@@ -60,8 +59,8 @@ tasks.register("runCustomProgram", JavaExec) {
 
 /**
  * Demonstrates how Flux can be invoked via its public "Main" class, passing in command line options. This depends
- * on the "flux-api" dependency but uses the "Main" class instead of the Flux API interface. Requires Java 17
- * and use of the Gradle "java" plugin.
+ * on the "flux-api" dependency but uses the "Main" class instead of the Flux API interface. Requires use of the Gradle
+ * "java" plugin.
  */
 tasks.register("runFluxMain", JavaExec) {
   description = "Demonstrates invoking Flux via its main class, allowing for CLI options to be passed to it."
@@ -84,7 +83,6 @@ tasks.register("runFluxMain", JavaExec) {
  * depends on the "flux-api" dependency being added to the Gradle buildscript classpath, as shown at the top of this
  * file. It also depends on the "org.gradle.jvmargs" option in this project's "gradle.properties" file which sets the
  * required "add-exports" options. The benefit of this approach is avoiding the need to create a separate Java class.
- * Requires Java 11 or 17 to run.
  */
 tasks.register("runCustomTask") {
   doLast {


### PR DESCRIPTION
Spark 4.0.1 wants 2.18.2, verified all is fine via the example client project.
