### PR TITLE
MLE-23024 Bumping to Spark 4.1.0 preview1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,63 +42,6 @@ subprojects {
     }
   }
 
-  configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-      if (details.requested.group.equals("org.apache.hadoop") and details.requested.version.equals("3.4.1")) {
-        details.useVersion "3.4.2"
-        details.because "Bumping to 3.4.2 to minimize CVEs."
-      }
-      if (details.requested.group.startsWith('com.fasterxml.jackson')) {
-        details.useVersion '2.18.2'
-        details.because 'Need to match the version used by Spark 4.0.1.'
-      }
-      if (details.requested.group.equals("org.slf4j")) {
-        details.useVersion "2.0.17"
-        details.because "Ensures that slf4j-api 1.x does not appear on the Flux classpath in particular, which can " +
-          "lead to this issue - https://www.slf4j.org/codes.html#StaticLoggerBinder."
-      }
-      if (details.requested.group.equals("org.codehaus.janino")) {
-        details.useVersion "3.1.12"
-        details.because "Bumping from 3.1.9 (what Spark SQL 4.0.1 depends on) to 3.1.12 to minimize CVEs."
-      }
-      if (details.requested.group.equals("io.netty") and details.requested.version.startsWith("4.1.1")) {
-        details.useVersion "4.1.127.Final"
-        details.because "Bumping from 4.1.118 (what Spark SQL 4.0.1 depends on) to 4.1.127 to minimize CVEs."
-      }
-    }
-
-    resolutionStrategy {
-      // Avoids a classpath conflict between Spark and tika-parser-microsoft-module. Forces Spark to use the
-      // version that tika-parser-microsoft-module wants.
-      // Avoids another classpath conflict between Spark and tika-parser-microsoft-module.
-      force "org.apache.commons:commons-compress:1.27.1"
-
-      // Forcing 3.18.0 to resolve CVEs on earlier versions of commons-lang3.
-      force "org.apache.commons:commons-lang3:3.18.0"
-
-      // Resolves a medium CVE that comes from json-unit-assertj .
-      force "net.minidev:json-smart:2.5.2"
-    }
-
-    // Excluding the nimbus-jose-jwt dependency that comes in via hadoop-auth. Hadoop 3.4.2 depends on 9.x, which has a
-    // medium CVE that is addressed in 10.x. But it is only used for JWT auth with Hadoop, which Flux will never expose
-    // to a user.
-    exclude group: "com.nimbusds", module: "nimbus-jose-jwt"
-
-    // Without this exclusion, we have multiple slf4j providers, leading to an ugly warning at the start
-    // of each Flux execution.
-    exclude group: "org.slf4j", module: "slf4j-reload4j"
-
-    // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
-    exclude module: "rocksdbjni"
-
-    // Excluding Jetty, as Spark 4 depends on Jetty 9 which brings in several medium CVEs. Testing has shown that Spark
-    // must be modular enough to run fine without Jetty on the classpath, as no failures are occurring without Jetty
-    // bring present. Note that org.eclipse.jetty.websocket libraries are still on the classpath, but those are fine as
-    // they do not have any CVEs.
-    exclude group: "org.eclipse.jetty"
-  }
-
   test {
     useJUnitPlatform()
     testLogging {

--- a/flux-cli/build.gradle
+++ b/flux-cli/build.gradle
@@ -10,20 +10,38 @@ configurations {
   // Defines only those dependencies that we want to include in the assembly/shadow jar that will be used by spark-submit.
   shadowDependencies
 
-  // Defines dependencies to be included in the Flux distribution (in addition to all normal runtime dependencies),
-  // but should not be transitive dependencies of the Flux API. Typically, a Flux API user can easily choose to include
-  // those transitive dependencies if desired.
-  distributionDependencies
-
-  // Since the distribution dependencies are included in Flux, we want to test them. So the test runtime includes all
-  // distribution dependencies.
-  testImplementation.extendsFrom(distributionDependencies)
+  all {
+    resolutionStrategy {
+      // Resolves a medium CVE that comes from json-unit-assertj .
+      force "net.minidev:json-smart:2.5.2"
+    }
+  }
 }
 
 dependencies {
-  implementation "org.apache.spark:spark-sql_2.13:${sparkVersion}"
+  constraints {
+    // Ensures the two top-level Hadoop dependencies of Spark will be 3.4.2, which fixes several CVEs found in 3.4.1.
+    implementation("org.apache.hadoop:hadoop-client-api:${hadoopVersion}") {
+      because "Force Spark's Hadoop dependencies from 3.4.1 to ${hadoopVersion}"
+    }
+    implementation("org.apache.hadoop:hadoop-client-runtime:${hadoopVersion}") {
+      because "Force Spark's Hadoop dependencies from 3.4.1 to ${hadoopVersion}"
+    }
+    implementation("org.codehaus.janino:janino:3.1.12") {
+      because "Bumping from 3.1.9 (what Spark SQL 4.0.1 depends on) to 3.1.12 to minimize CVEs."
+    }
+  }
+
+  implementation ("org.apache.spark:spark-sql_2.13:${sparkVersion}") {
+    // The rocksdbjni dependency weighs in at 50mb and so far does not appear necessary for our use of Spark.
+    exclude module: "rocksdbjni"
+  }
+
   implementation "com.marklogic:marklogic-spark-connector:${connectorVersion}"
   implementation "info.picocli:picocli:${picocliVersion}"
+
+  // Need this for compilation as it's not an API dependency of the Spark connector.
+  compileOnly "com.marklogic:marklogic-client-api:7.2.0"
 
   // The shadow jar intended for usage with spark-submit needs the above "core" libraries as well, but not the Spark
   // API since spark-submit provides that.
@@ -56,16 +74,23 @@ dependencies {
     exclude group: "com.fasterxml.jackson.datatype"
   }
 
-  implementation "org.apache.hadoop:hadoop-client:${hadoopVersion}"
-
   // Spark doesn't include Avro support by default, so need to bring this in.
   implementation "org.apache.spark:spark-avro_2.13:${sparkVersion}"
 
-  distributionDependencies "org.apache.tika:tika-parser-microsoft-module:${tikaVersion}"
-  distributionDependencies "org.apache.tika:tika-parser-pdf-module:${tikaVersion}"
+  // Optional dependencies - included in distribution but marked as optional in POM
+  implementation("org.apache.tika:tika-parser-microsoft-module:${tikaVersion}") {
+    // Will be marked as optional in the POM
+  }
+  implementation("org.apache.tika:tika-parser-pdf-module:${tikaVersion}") {
+    // Will be marked as optional in the POM
+  }
 
   // For configuring two-way SSL in tests.
-  testImplementation "com.marklogic:ml-app-deployer:6.0.1"
+  testImplementation ("com.marklogic:ml-app-deployer:6.0.1") {
+    // Prefer Spark's versions of Jackson.
+    exclude group: "com.fasterxml.jackson.core"
+    exclude group: "com.fasterxml.jackson.dataformat"
+  }
 
   testImplementation ("com.marklogic:marklogic-junit5:1.5.0") {
     // Prefer the one from ml-app-deployer
@@ -83,7 +108,10 @@ dependencies {
   testImplementation "org.postgresql:postgresql:42.7.8"
 
   // Required for compile-time references in the tests to langchain4j classes.
-  testImplementation "dev.langchain4j:langchain4j:${langchain4jVersion}"
+  testImplementation ("dev.langchain4j:langchain4j:${langchain4jVersion}") {
+    // Prefer Spark's versions of Jackson.
+    exclude group: "com.fasterxml.jackson.core"
+  }
 
   // The Gradle docs - https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:simple-sharing-artifacts-between-projects -
   // are not keen on this practice of depending on another project's configuration. But this seems fine for a test
@@ -127,14 +155,6 @@ distributions {
       from("..") {
         include "LICENSE"
         include "NOTICE.txt"
-      }
-      // The distributionDependencies configuration allows us to include dependencies that should be part of the Flux
-      // distribution, but not part of the default Flux API set of dependencies.
-      into("lib") {
-        from configurations.distributionDependencies
-        // It's expected to run into duplicates with dependencies already on the runtime classpath, so any duplicates
-        // can safely be excluded.
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
       }
     }
   }
@@ -266,6 +286,7 @@ publishing {
       artifactId = "flux-api"
       version = version
       from components.java
+
       pom {
         name = "${group}:flux-api"
         description = "Flux API for data movement with MarkLogic"
@@ -290,6 +311,18 @@ publishing {
           url = "git@github.com:marklogic/flux.git"
           connection = "scm:git@github.com:marklogic/flux.git"
           developerConnection = "scm:git@github.com:marklogic/flux.git"
+        }
+
+        // Mark some dependencies as optional.
+        // May eventually do this for Azure and AWS dependencies as well.
+        withXml {
+          def dependenciesNode = asNode().dependencies[0]
+          dependenciesNode.dependency.each { dep ->
+            var artifactId = dep.artifactId.text()
+            if (artifactId.startsWith('tika-parser-') || artifactId.equals('spark-avro_2.13')) {
+              dep.appendNode('optional', 'true')
+            }
+          }
         }
       }
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/OverrideSparkConfTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/OverrideSparkConfTest.java
@@ -24,7 +24,7 @@ class OverrideSparkConfTest extends AbstractTest {
             "--preview", "1"
         );
 
-        assertTrue(stderr.contains("The value of spark.sql.orc.impl"),
+        assertTrue(stderr.contains("INVALID_CONF_VALUE.OUT_OF_RANGE_OF_OPTIONS"),
             "This test confirms that the -C option works by passing in an invalid configuration value and " +
                 "verifying that the command fails with an error message from the Spark ORC data source; " +
                 "actual stderr: " + stderr);

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -126,7 +126,7 @@ class ImportAvroFilesTest extends AbstractTest {
             "-Cspark.sql.parquet.filterPushdown=invalid-value"
         );
 
-        assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
+        assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),
             "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
                 "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 class ImportOrcFilesTest extends AbstractTest {
 
     @Test
@@ -120,7 +119,7 @@ class ImportOrcFilesTest extends AbstractTest {
             "-Cspark.sql.parquet.filterPushdown=invalid-value"
         );
 
-        assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
+        assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),
             "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
                 "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -168,7 +168,7 @@ class ImportParquetFilesTest extends AbstractTest {
             "-Cspark.sql.parquet.filterPushdown=invalid-value"
         );
 
-        assertTrue(stderr.contains("spark.sql.parquet.filterPushdown should be boolean, but was invalid-value"),
+        assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),
             "This test verifies that spark.sql dynamic params are added to the Spark conf. An invalid value is used " +
                 "to verify this, as its inclusion in the Spark conf should cause an error. Actual stderr: " + stderr);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ connectorVersion=3.0-SNAPSHOT
 picocliVersion=4.7.7
 
 # Aligned with our Spark connector.
-sparkVersion=4.0.1
+sparkVersion=4.1.0-preview1
 
 # Spark 4.0.1 depends on 3.4.1, but using 3.4.2 to pick up latest fixes.
 hadoopVersion=3.4.2


### PR DESCRIPTION
Using constraints as well to ensure the pom.xml file contains the same dependency updates.

Spark 4.1.0 is using io.netty 4.1.122 - not changing that for now, need to see what Black Duck thinks.
