### PR TITLE
MLE-24855 Changing -C to --spark-conf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def runtests(){
     ./gradlew mlTestConnections
     ./gradlew -i  mlDeploy;
 
-    wget https://www.postgresqltutorial.com/wp-content/uploads/2019/05/dvdrental.zip;
+    wget https://neon.com/postgresqltutorial/dvdrental.zip;
     unzip dvdrental.zip -d docker/postgres/ ;
     docker exec -i docker-tests-flux-postgres-1 psql -U postgres -c "CREATE DATABASE dvdrental";
     docker exec -i docker-tests-flux-postgres-1 pg_restore -U postgres -d dvdrental /opt/dvdrental.tar;

--- a/docs/common-options.md
+++ b/docs/common-options.md
@@ -561,14 +561,14 @@ to it. You can still override `--spark-master-url` if you wish.
 Flux allows for [Spark configuration properties](https://spark.apache.org/docs/latest/configuration.html) to be defined which will 
 control the Spark runtime and how a Spark session is built. 
 
-To specify options that control how the Spark Session is built, use the `-C` option as many times as needed. For example,
+To specify options that control how the Spark Session is built, use the `--spark-conf` option as many times as needed. For example,
 [encrypt data that Spark spills from memory to disk](https://spark.apache.org/docs/3.5.6/security.html#local-storage-encryption), you could include the following options:
 
-    -Cspark.io.encryption.enabled=true \
-    -Cspark.io.encryption.keySizeBits=256
+    --spark-conf spark.io.encryption.enabled=true \
+    --spark-conf spark.io.encryption.keySizeBits=256
 
 You can also use this option for [Spark data sources](https://spark.apache.org/docs/3.5.6/sql-data-sources.html) that 
 define configuration properties. 
 For example, the [Spark Avro data source](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html#configuration)
 identifies several configuration properties, such as `spark.sql.avro.compression.codec`. You can set this value by 
-including `-Cspark.sql.avro.compression.codec=snappy` as a command line option. 
+including `--spark-conf spark.sql.avro.compression.codec=snappy` as a command line option. 

--- a/docs/export/export-rows.md
+++ b/docs/export/export-rows.md
@@ -128,8 +128,8 @@ You can include any of the
 [Spark Avro data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html) via the `-P` option to
 control how Avro content is written. These options are expressed as `-PoptionName=optionValue`.
 
-For configuration options listed in the above Spark Avro guide, use the `-C` option instead. For example,
-`-Cspark.sql.avro.compression.codec=deflate` would change the type of compression used for writing Avro files.
+For configuration options listed in the above Spark Avro guide, use the `--spark-conf` option instead. For example,
+`--spark-conf spark.sql.avro.compression.codec=deflate` would change the type of compression used for writing Avro files.
 
 ### Delimited text
 
@@ -272,8 +272,8 @@ This command reuses Spark's support for writing ORC files. You can include any o
 [Spark ORC data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html) via the `-P` option to
 control how ORC content is written. These options are expressed as `-PoptionName=optionValue`.
 
-For configuration options listed in the above Spark ORC guide, use the `-C` option instead. For example,
-`-Cspark.sql.orc.impl=hive` would change the type of ORC implementation.
+For configuration options listed in the above Spark ORC guide, use the `--spark-conf` option instead. For example,
+`--spark-conf spark.sql.orc.impl=hive` would change the type of ORC implementation.
 
 ### Parquet
 
@@ -302,8 +302,8 @@ This command reuses Spark's support for writing Parquet files. You can include a
 [Spark Parquet data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html) via the `-P` option to
 control how Parquet content is written. These options are expressed as `-PoptionName=optionValue`.
 
-For configuration options listed in the above Spark Parquet guide, use the `-C` option instead. For example, 
-`-Cspark.sql.parquet.compression.codec=gzip` would change the compressed used for writing Parquet files.
+For configuration options listed in the above Spark Parquet guide, use the `--spark-conf` option instead. For example, 
+`--spark-conf spark.sql.parquet.compression.codec=gzip` would change the compressed used for writing Parquet files.
 
 ## Controlling the save mode
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ The error is due to the underlying Spark runtime in Flux failing to startup. You
 [resolutions for this error](https://stackoverflow.com/questions/52133731/how-to-solve-cant-assign-requested-address-service-sparkdriver-failed-after),
 a few of which are summarized below:
 
-1. Include `-Cspark.driver.bindAddress=127.0.0.1` to define a Spark bind address that does not use `localhost`.
+1. Include `--spark-conf spark.driver.bindAddress=127.0.0.1` to define a Spark bind address that does not use `localhost`.
 2. Run `export SPARK_LOCAL_IP="127.0.0.1"` to define a Spark bind address via an environment variable.
 3. If you are on a VPN, try disconnecting and reconnecting to the VPN.
 

--- a/docs/import/import-files/avro.md
+++ b/docs/import/import-files/avro.md
@@ -132,6 +132,6 @@ The `import-avro-files` command reuses Spark's support for reading Avro files. Y
 the [Spark Avro data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html) via the `-P` option
 to control how Avro content is read. These options are expressed as `-PoptionName=optionValue`.
 
-For the configuration options listed in the above Spark Avro guide, use the `-C` option instead. For example, 
-`-Cspark.sql.avro.filterPushdown.enabled=false` would configure Spark Avro to not push down filters.
+For the configuration options listed in the above Spark Avro guide, use the `--spark-conf` option instead. For example, 
+`--spark-conf spark.sql.avro.filterPushdown.enabled=false` would configure Spark Avro to not push down filters.
 

--- a/docs/import/import-files/orc.md
+++ b/docs/import/import-files/orc.md
@@ -132,5 +132,5 @@ The `import-orc-files` command reuses Spark's support for reading ORC files. You
 the [Spark ORC data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html) via the `-P` option
 to control how ORC content is read. These options are expressed as `-PoptionName=optionValue`.
 
-For the configuration options listed in the above Spark ORC guide, use the `-C` option instead. For example, 
-`-Cspark.sql.orc.filterPushdown=false` would configure Spark ORC to not push down filters.
+For the configuration options listed in the above Spark ORC guide, use the `--spark-conf` option instead. For example, 
+`--spark-conf spark.sql.orc.filterPushdown=false` would configure Spark ORC to not push down filters.

--- a/docs/import/import-files/parquet.md
+++ b/docs/import/import-files/parquet.md
@@ -132,5 +132,5 @@ The `import-parquet-files` command reuses Spark's support for reading Parquet fi
 the [Spark Parquet data source options](https://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html) via the `-P` option
 to control how Parquet content is read. These options are expressed as `-PoptionName=optionValue`.
 
-For the configuration options listed in the above Spark Parquet guide, use the `-C` option instead. For example,
-`-Cspark.sql.parquet.filterPushdown=false` would configure Spark Parquet to not push down filters.
+For the configuration options listed in the above Spark Parquet guide, use the `--spark-conf` option instead. For example,
+`--spark-conf spark.sql.parquet.filterPushdown=false` would configure Spark Parquet to not push down filters.

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/CommonParams.java
@@ -42,9 +42,9 @@ public class CommonParams {
     private String sparkMasterUrl;
 
     @CommandLine.Option(
-        names = "-C",
+        names = {"--spark-conf"},
         description = "Specify any key and value to be added to the Spark runtime configuration before a Spark session is built" +
-            "; %ne.g. -Cspark.logConf=true or -Cspark.io.encryption.enabled=true . "
+            "; %ne.g. --spark-conf spark.logConf=true or --spark-conf spark.io.encryption.enabled=true . "
     )
     private Map<String, String> sparkConfigurationProperties = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportAvroFilesCommand.java
@@ -57,7 +57,7 @@ public class ImportAvroFilesCommand extends AbstractImportFilesCommand<AvroFiles
             names = "-P",
             description = "Specify any Spark Avro data source option defined at " +
                 "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-avro.html; e.g. -PignoreExtension=true. " +
-                "Spark configuration options must be defined via '-C'."
+                "Spark configuration options must be defined via '--spark-conf'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportOrcFilesCommand.java
@@ -57,7 +57,7 @@ public class ImportOrcFilesCommand extends AbstractImportFilesCommand<OrcFilesIm
             names = "-P",
             description = "Specify any Spark ORC data source option defined at " +
                 "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-orc.html; e.g. -PmergeSchema=true. " +
-                "Spark configuration options must be defined via '-C'."
+                "Spark configuration options must be defined via '--spark-conf'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ImportParquetFilesCommand.java
@@ -57,7 +57,7 @@ public class ImportParquetFilesCommand extends AbstractImportFilesCommand<Parque
             names = "-P",
             description = "Specify any Spark Parquet data source option defined at " +
                 "%nhttps://spark.apache.org/docs/3.5.6/sql-data-sources-parquet.html; e.g. -PmergeSchema=true. " +
-                "Spark configuration options must be defined via '-C'."
+                "Spark configuration options must be defined via '--spark-conf'."
         )
         private Map<String, String> additionalOptions = new HashMap<>();
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/HandleErrorTest.java
@@ -46,8 +46,8 @@ class HandleErrorTest extends AbstractTest {
     @Test
     void badDynamicOption() {
         assertStderrContains(
-            "Value for option '-C' (<String=String>) should be in KEY=VALUE format but was noValue",
-            CommandLine.ExitCode.USAGE, "import-files", "-CnoValue"
+            "Value for option '--spark-conf' (<String=String>) should be in KEY=VALUE format but was noValue",
+            CommandLine.ExitCode.USAGE, "import-files", "--spark-conf", "noValue"
         );
     }
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/SetSparkConfigurationPropertiesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/SetSparkConfigurationPropertiesTest.java
@@ -15,7 +15,7 @@ class SetSparkConfigurationPropertiesTest extends AbstractTest {
     void validSparkConfProperty() {
         run(
             "import-files",
-            "-Cspark.io.encryption.enabled=true",
+            "--spark-conf", "spark.io.encryption.enabled=true",
             "--path", "src/test/resources/mixed-files/hello*",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
@@ -23,7 +23,7 @@ class SetSparkConfigurationPropertiesTest extends AbstractTest {
         );
 
         assertCollectionSize(
-            "The import should succeed because the -C option has a valid Spark configuration property.",
+            "The import should succeed because the --spark-conf option has a valid Spark configuration property.",
             "files", 4);
     }
 
@@ -32,7 +32,7 @@ class SetSparkConfigurationPropertiesTest extends AbstractTest {
         String stderr = runAndReturnStderr(
             CommandLine.ExitCode.SOFTWARE,
             "import-files",
-            "-Cspark.io.encryption.enabled=invalid",
+            "--spark-conf", "spark.io.encryption.enabled=invalid",
             "--path", "src/test/resources/mixed-files/hello*",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesOptionsTest.java
@@ -19,7 +19,7 @@ class ImportAvroFilesOptionsTest extends AbstractOptionsTest {
             "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
-            "-Cspark.sql.parquet.filterPushdown=false",
+            "--spark-conf", "spark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportAvroFilesTest.java
@@ -27,8 +27,8 @@ class ImportAvroFilesTest extends AbstractTest {
             "--batch-size", "1",
             "--log-progress", "2",
 
-            // Including this to ensure a valid -C option doesn't cause an error.
-            "-Cspark.sql.avro.filterPushdown.enabled=false"
+            // Including this to ensure a valid --spark-conf option doesn't cause an error.
+            "--spark-conf", "spark.sql.avro.filterPushdown.enabled=false"
         );
 
         assertCollectionSize("avro-test", 6);
@@ -123,7 +123,7 @@ class ImportAvroFilesTest extends AbstractTest {
             "--path", "src/test/resources/avro/*",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
-            "-Cspark.sql.parquet.filterPushdown=invalid-value"
+            "--spark-conf", "spark.sql.parquet.filterPushdown=invalid-value"
         );
 
         assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportFilesTest.java
@@ -179,6 +179,20 @@ class ImportFilesTest extends AbstractTest {
     }
 
     @Test
+    void zipTestWithOtherOption() {
+        run(
+            "import-files",
+            "--path", "src/test/resources/mixed-files/goodbye.zip",
+            "--connection-string", makeConnectionString(),
+            "--permissions", DEFAULT_PERMISSIONS,
+            "--collections", "-vfiles",
+            "--compression", "zip"
+        );
+
+        assertCollectionSize("-vfiles", 3);
+    }
+
+    @Test
     void zipTest() {
         run(
             "import-files",

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesOptionsTest.java
@@ -19,7 +19,7 @@ class ImportOrcFilesOptionsTest extends AbstractOptionsTest {
             "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PmergeSchema=true",
-            "-Cspark.sql.parquet.filterPushdown=false",
+            "--spark-conf", "spark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportOrcFilesTest.java
@@ -26,8 +26,8 @@ class ImportOrcFilesTest extends AbstractTest {
             "--batch-size", "5",
             "--log-progress", "5",
 
-            // Including this to ensure a valid -C option doesn't cause an error.
-            "-Cspark.sql.orc.filterPushdown=false"
+            // Including this to ensure a valid --spark-conf option doesn't cause an error.
+            "--spark-conf", "spark.sql.orc.filterPushdown=false"
         );
 
         getUrisInCollection("orcFile-test", 15).forEach(this::verifyDocContent);
@@ -116,7 +116,7 @@ class ImportOrcFilesTest extends AbstractTest {
             "--path", "src/test/resources/orc-files",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
-            "-Cspark.sql.parquet.filterPushdown=invalid-value"
+            "--spark-conf", "spark.sql.parquet.filterPushdown=invalid-value"
         );
 
         assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesOptionsTest.java
@@ -19,7 +19,7 @@ class ImportParquetFilesOptionsTest extends AbstractOptionsTest {
             "--connection-string", makeConnectionString(),
             "--path", "/doesnt/matter",
             "-PdatetimeRebaseMode=CORRECTED",
-            "-Cspark.sql.parquet.filterPushdown=false",
+            "--spark-conf", "spark.sql.parquet.filterPushdown=false",
             "--preview", "10"
         );
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ImportParquetFilesTest.java
@@ -28,8 +28,8 @@ class ImportParquetFilesTest extends AbstractTest {
             "--batch-size", "5",
             "--log-progress", "10",
 
-            // Including this to ensure a valid -C option doesn't cause an error.
-            "-Cspark.sql.parquet.filterPushdown=false"
+            // Including this to ensure a valid --spark-conf option doesn't cause an error.
+            "--spark-conf", "spark.sql.parquet.filterPushdown=false"
         );
 
         assertCollectionSize("parquet-test", 32);
@@ -165,7 +165,7 @@ class ImportParquetFilesTest extends AbstractTest {
             "--path", "src/test/resources/parquet/individual/cars.parquet",
             "--connection-string", makeConnectionString(),
             "--permissions", DEFAULT_PERMISSIONS,
-            "-Cspark.sql.parquet.filterPushdown=invalid-value"
+            "--spark-conf", "spark.sql.parquet.filterPushdown=invalid-value"
         );
 
         assertTrue(stderr.contains("INVALID_CONF_VALUE.TYPE_MISMATCH"),


### PR DESCRIPTION
First of a few PRs to get rid of single letter option names.
