### PR TITLE
don't abort on batch write failures if flag is not specified for copy command

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -228,7 +228,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             }
 
             return OptionsUtil.addOptions(options,
-                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : null,
+                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
                 Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
                 Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
                 Options.WRITE_PIPELINE_BATCH_SIZE, OptionsUtil.integerOption(pipelineBatchSize),

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -10,6 +10,7 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.flux.AbstractTest;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.util.List;
 
@@ -98,6 +99,44 @@ class CopyTest extends AbstractTest {
         assertCollectionSize("author", 15);
         assertCollectionSize("author-copies", 15);
         assertDirectoryCount("/copied/", 15);
+    }
+
+    @Test
+    void runsToCompletionWithBatchWriteFailuresAndAbortOnWriteFailureNotSpecified() {
+        run(CommandLine.ExitCode.OK,
+            "copy",
+            "--collections", "author",
+            "--partitions-per-forest", "1",
+            "--categories", "content,metadata",
+            "--connection-string", makeConnectionString(),
+            "--output-connection-string", makeConnectionString(),
+            // No need to specify permissions since they are included via "--categories".
+            "--output-collections", "author-copies",
+            "--output-uri-prefix", "/copied",
+            "--output-permissions", "invalid-roleZZ,read,rest-writer,update"
+            //^cause batch write err but don't specify --output-abort-on-write-failure
+        );
+
+    }
+
+    @Test
+    void abortsOnWriteFailureOnlyWhenAbortOnWriteFailureSpecified() {
+        assertStderrContains(
+            "Role does not exist: sec:role-name = invalid-roleZZZ",
+            CommandLine.ExitCode.SOFTWARE,
+            "copy",
+            "--collections", "author",
+            "--partitions-per-forest", "1",
+            "--categories", "content,metadata",
+            "--connection-string", makeConnectionString(),
+            "--output-connection-string", makeConnectionString(),
+            // No need to specify permissions since they are included via "--categories".
+            "--output-collections", "author-copies",
+            "--output-uri-prefix", "/copied",
+            "--output-permissions", "invalid-roleZZZ,read,rest-writer,update",
+            "--output-abort-on-write-failure",
+            "--stacktrace"
+        );
     }
 
     @Test


### PR DESCRIPTION
this addresses issue #628  