### PR TITLE
MLE-12345 abort copy command only when --output-abort-on-write-failure option is specified

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/copy/CopyCommand.java
@@ -228,7 +228,7 @@ public class CopyCommand extends AbstractCommand<DocumentCopier> implements Docu
             }
 
             return OptionsUtil.addOptions(options,
-                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : null,
+                Options.WRITE_ABORT_ON_FAILURE, abortOnWriteFailure ? "true" : "false",
                 Options.WRITE_ARCHIVE_PATH_FOR_FAILED_DOCUMENTS, failedDocumentsPath,
                 Options.WRITE_BATCH_SIZE, OptionsUtil.intOption(batchSize),
                 Options.WRITE_PIPELINE_BATCH_SIZE, OptionsUtil.integerOption(pipelineBatchSize),

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl.copy;
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -10,6 +10,7 @@ import com.marklogic.client.query.QueryManager;
 import com.marklogic.client.query.StructuredQueryDefinition;
 import com.marklogic.flux.AbstractTest;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.util.List;
 
@@ -98,6 +99,44 @@ class CopyTest extends AbstractTest {
         assertCollectionSize("author", 15);
         assertCollectionSize("author-copies", 15);
         assertDirectoryCount("/copied/", 15);
+    }
+
+    @Test
+    void runsToCompletionWithBatchWriteFailuresAndAbortOnWriteFailureNotSpecified() {
+        run(CommandLine.ExitCode.OK,
+            "copy",
+            "--collections", "author",
+            "--partitions-per-forest", "1",
+            "--categories", "content,metadata",
+            "--connection-string", makeConnectionString(),
+            "--output-connection-string", makeConnectionString(),
+            // No need to specify permissions since they are included via "--categories".
+            "--output-collections", "author-copies",
+            "--output-uri-prefix", "/copied",
+            "--output-permissions", "invalid-roleZZ,read,rest-writer,update"
+            //^cause batch write err but don't specify --output-abort-on-write-failure
+        );
+
+    }
+
+    @Test
+    void abortsOnWriteFailureOnlyWhenAbortOnWriteFailureSpecified() {
+        assertStderrContains(
+            "Role does not exist: sec:role-name = invalid-roleZZZ",
+            CommandLine.ExitCode.SOFTWARE,
+            "copy",
+            "--collections", "author",
+            "--partitions-per-forest", "1",
+            "--categories", "content,metadata",
+            "--connection-string", makeConnectionString(),
+            "--output-connection-string", makeConnectionString(),
+            // No need to specify permissions since they are included via "--categories".
+            "--output-collections", "author-copies",
+            "--output-uri-prefix", "/copied",
+            "--output-permissions", "invalid-roleZZZ,read,rest-writer,update",
+            "--output-abort-on-write-failure",
+            "--stacktrace"
+        );
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -109,7 +109,7 @@ class CopyTest extends AbstractTest {
                 "--output-database", otherDatabaseName,
                 "--output-collections", "author-copies",
                 "--output-uri-prefix", "/copied",
-                "--output-permissions", "invalid-roleZZ,read,rest-writer,update"
+                "--output-permissions", "invalid-roleZZZ,read,rest-writer,update"
                 //^cause batch write err but don't specify --output-abort-on-write-failure
             );
             assertFalse(stdErr.contains("Role does not exist: sec:role-name = invalid-roleZZZ"));

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 import java.util.List;
+import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 class CopyTest extends AbstractTest {
 
@@ -42,27 +43,22 @@ class CopyTest extends AbstractTest {
 
     @Test
     void sameConnectionStringButDifferentOutputDatabase() {
-        final String otherTestDatabase = "flux-other-test-content";
-
-        try (DatabaseClient otherTestClient = newDatabaseClient(otherTestDatabase)) {
-            // Clear out the other test database first in case anything is hanging around in there.
-            otherTestClient.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").evalAs(String.class);
-
+        runCopyToOtherDatabase(otherDbName -> {
             run(
                 "copy",
                 "--collections", "author",
                 "--connection-string", makeConnectionString(),
-                "--output-database", otherTestDatabase
+                "--output-database", otherDbName
             );
-
+        }, otherDbTestClient -> {
             final List<String> originalAuthorUris = getUrisInCollection("author", 15);
 
-            List<String> otherAuthorUris = new ClientHelper(otherTestClient).getUrisInCollection("author", 15);
+            List<String> otherAuthorUris = new ClientHelper(otherDbTestClient).getUrisInCollection("author", 15);
             for (String authorUri : originalAuthorUris) {
                 assertTrue(otherAuthorUris.contains(authorUri),
                     "Did not find expected author URI in other test database: " + authorUri);
             }
-        }
+        });
     }
 
     @Test
@@ -103,20 +99,23 @@ class CopyTest extends AbstractTest {
 
     @Test
     void runsToCompletionWithBatchWriteFailuresAndAbortOnWriteFailureNotSpecified() {
-        run(CommandLine.ExitCode.OK,
-            "copy",
-            "--collections", "author",
-            "--partitions-per-forest", "1",
-            "--categories", "content,metadata",
-            "--connection-string", makeConnectionString(),
-            "--output-connection-string", makeConnectionString(),
-            // No need to specify permissions since they are included via "--categories".
-            "--output-collections", "author-copies",
-            "--output-uri-prefix", "/copied",
-            "--output-permissions", "invalid-roleZZ,read,rest-writer,update"
-            //^cause batch write err but don't specify --output-abort-on-write-failure
-        );
-
+        runCopyToOtherDatabase(otherDatabaseName -> {
+            String stdErr = runAndReturnStderr(CommandLine.ExitCode.OK,
+                "copy",
+                "--collections", "author",
+                "--partitions-per-forest", "1",
+                "--categories", "content,metadata",
+                "--connection-string", makeConnectionString(),
+                "--output-database", otherDatabaseName,
+                "--output-collections", "author-copies",
+                "--output-uri-prefix", "/copied",
+                "--output-permissions", "invalid-roleZZ,read,rest-writer,update"
+                //^cause batch write err but don't specify --output-abort-on-write-failure
+            );
+            assertFalse(stdErr.contains("Role does not exist: sec:role-name = invalid-roleZZZ"));
+        }, otherDbClient -> {
+            assertEquals(0, (new ClientHelper(otherDbClient)).getCollectionSize("author-copies"));
+        });
     }
 
     @Test
@@ -130,7 +129,6 @@ class CopyTest extends AbstractTest {
             "--categories", "content,metadata",
             "--connection-string", makeConnectionString(),
             "--output-connection-string", makeConnectionString(),
-            // No need to specify permissions since they are included via "--categories".
             "--output-collections", "author-copies",
             "--output-uri-prefix", "/copied",
             "--output-permissions", "invalid-roleZZZ,read,rest-writer,update",
@@ -204,4 +202,17 @@ class CopyTest extends AbstractTest {
         SearchHandle results = queryManager.search(query, new SearchHandle());
         assertEquals(expectedCount, results.getTotalResults());
     }
+
+    private void runCopyToOtherDatabase(Consumer<String> copyCommand, Consumer<DatabaseClient> copyAssertions) {
+        final String otherTestDatabase = "flux-other-test-content";
+
+        try (DatabaseClient otherTestClient = newDatabaseClient(otherTestDatabase)) {
+            // Clear out the other test database first in case anything is hanging around in there.
+            otherTestClient.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").evalAs(String.class);
+
+            copyCommand.accept(otherTestDatabase);
+            copyAssertions.accept(otherTestClient);
+        }
+    }
 }
+

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -129,12 +129,13 @@ class CopyTest extends AbstractTest {
             "--categories", "content,metadata",
             "--connection-string", makeConnectionString(),
             "--output-connection-string", makeConnectionString(),
-            "--output-collections", "author-copies",
+            "--output-collections", "author-copiesZ", //different coll name so it does not interfere with other tests
             "--output-uri-prefix", "/copied",
             "--output-permissions", "invalid-roleZZZ,read,rest-writer,update",
-            "--output-abort-on-write-failure",
-            "--stacktrace"
+            "--output-abort-on-write-failure"
         );
+
+        assertCollectionSize("author-copiesZ", 0);
     }
 
     @Test

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyTest.java
@@ -120,6 +120,7 @@ class CopyTest extends AbstractTest {
 
     @Test
     void abortsOnWriteFailureOnlyWhenAbortOnWriteFailureSpecified() {
+        String outputCollName = "author-copiesZ"; //different coll name so it does not interfere with other tests
         assertStderrContains(
             "Role does not exist: sec:role-name = invalid-roleZZZ",
             CommandLine.ExitCode.SOFTWARE,
@@ -129,13 +130,13 @@ class CopyTest extends AbstractTest {
             "--categories", "content,metadata",
             "--connection-string", makeConnectionString(),
             "--output-connection-string", makeConnectionString(),
-            "--output-collections", "author-copiesZ", //different coll name so it does not interfere with other tests
+            "--output-collections", outputCollName,
             "--output-uri-prefix", "/copied",
             "--output-permissions", "invalid-roleZZZ,read,rest-writer,update",
             "--output-abort-on-write-failure"
         );
 
-        assertCollectionSize("author-copiesZ", 0);
+        assertCollectionSize(outputCollName, 0);
     }
 
     @Test


### PR DESCRIPTION
This supercedes #629 