### PR TITLE
MLE-28702 Using bucket-scoped keys for S3

### DIFF
--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AbstractCommand.java
@@ -256,7 +256,8 @@ public abstract class AbstractCommand<T extends Executor> implements Command, Ex
      * each path if necessary based on the Azure Storage parameters.
      */
     protected final List<String> applyCloudStorageParams(Configuration conf, CloudStorageParams params, List<String> paths) {
-        applyCloudStorageParams(conf, params);
+        params.getS3Params().addToHadoopConfiguration(conf, paths);
+        params.getAzureStorageParams().addToHadoopConfiguration(conf);
         List<String> transformedPaths = params.getAzureStorageParams().transformPathsIfNecessary(paths);
         if (logger.isInfoEnabled()) {
             if (transformedPaths.size() == 1) {

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/S3Params.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/S3Params.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl;
 
@@ -8,13 +8,15 @@ import picocli.CommandLine;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
 /**
  * Intended to be a delegate in any command that can access S3.
  */
 public class S3Params {
 
-    private static final String S3A_ACCESS_KEY = "fs.s3a.access.key";
-    private static final String S3A_SECRET_KEY = "fs.s3a.secret.key";
     private static final String S3A_CREDENTIALS_PROVIDER = "fs.s3a.aws.credentials.provider";
 
     @CommandLine.Option(
@@ -67,38 +69,95 @@ public class S3Params {
      * @param config the Spark runtime configuration object
      */
     public void addToHadoopConfiguration(Configuration config) {
+        addToHadoopConfiguration(config, (String) null);
+    }
+
+    /**
+     * Extracts the bucket from the first S3 path in the list and delegates to
+     * {@link #addToHadoopConfiguration(Configuration, String)} so that callers do not need to know about
+     * bucket extraction.
+     *
+     * @param config the Hadoop configuration to modify
+     * @param paths  the list of input/output paths; the first S3/S3A/S3N URI in the list is used to determine the bucket
+     */
+    public void addToHadoopConfiguration(Configuration config, List<String> paths) {
+        String bucket = null;
+        if (paths != null) {
+            for (String path : paths) {
+                bucket = extractBucket(path);
+                if (bucket != null) {
+                    break;
+                }
+            }
+        }
+        addToHadoopConfiguration(config, bucket);
+    }
+
+    /**
+     * Adds S3 credentials and options to the Hadoop configuration. When a bucket name is provided, bucket-scoped
+     * keys are used (e.g. {@code fs.s3a.bucket.<name>.access.key}) so that concurrent jobs targeting different
+     * buckets do not interfere with each other. When bucket is null, global keys are used as a fallback.
+     *
+     * @param config the Hadoop configuration to modify
+     * @param bucket the S3 bucket name, or null to set global keys
+     */
+    public void addToHadoopConfiguration(Configuration config, String bucket) {
+        // useProfile has no bucket-scoped equivalent — always set globally.
+        if (useProfile) {
+            config.set(S3A_CREDENTIALS_PROVIDER, "software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider");
+        }
+
+        String prefix = (bucket != null && !bucket.isEmpty()) ? "fs.s3a.bucket." + bucket + "." : "fs.s3a.";
+
+        if (addCredentials) {
+            try (DefaultCredentialsProvider provider = DefaultCredentialsProvider.create()) {
+                AwsCredentials credentials = provider.resolveCredentials();
+                config.set(prefix + "access.key", credentials.accessKeyId());
+                config.set(prefix + "secret.key", credentials.secretAccessKey());
+            }
+        }
+
         // See https://sparkbyexamples.com/amazon-aws/write-read-csv-file-from-s3-into-dataframe/ for more
         // information on the keys used below.
 
         // See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-providers.html for
         // an explanation of how this provider works. The main use case is for enabling SSO auth.
-        if (useProfile) {
-            config.set(S3A_CREDENTIALS_PROVIDER, "software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider");
-        }
-
-        if (addCredentials) {
-            try (DefaultCredentialsProvider provider = DefaultCredentialsProvider.create()) {
-                AwsCredentials credentials = provider.resolveCredentials();
-                config.set(S3A_ACCESS_KEY, credentials.accessKeyId());
-                config.set(S3A_SECRET_KEY, credentials.secretAccessKey());
-            }
-        }
 
         if (hasText(accessKeyId)) {
-            config.set(S3A_ACCESS_KEY, accessKeyId);
+            config.set(prefix + "access.key", accessKeyId);
         }
         if (hasText(secretAccessKey)) {
-            config.set(S3A_SECRET_KEY, secretAccessKey);
+            config.set(prefix + "secret.key", secretAccessKey);
         }
         if (hasText(sessionToken)) {
-            config.set("fs.s3a.session.token", sessionToken);
+            config.set(prefix + "session.token", sessionToken);
         }
         if (hasText(endpoint)) {
-            config.set("fs.s3a.endpoint", endpoint);
+            config.set(prefix + "endpoint", endpoint);
         }
         if (hasText(region)) {
-            config.set("fs.s3a.endpoint.region", region);
+            config.set(prefix + "endpoint.region", region);
         }
+    }
+
+    /**
+     * Extracts the bucket name from an S3 path of the form {@code s3a://bucket/...} or {@code s3://bucket/...}.
+     * Returns null if the path is not an S3 URI or the bucket cannot be determined.
+     */
+    protected static String extractBucket(String path) {
+        if (path == null) {
+            return null;
+        }
+        try {
+            URI uri = new URI(path);
+            String scheme = uri.getScheme();
+            if ("s3a".equals(scheme) || "s3".equals(scheme) || "s3n".equals(scheme)) {
+                return uri.getHost();
+            }
+        } catch (URISyntaxException e) {
+            // Not a valid URI — fall through to return null
+        }
+        return null;
     }
 
     private boolean hasText(String value) {

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/S3ParamsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/S3ParamsTest.java
@@ -6,7 +6,9 @@ package com.marklogic.flux.impl;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple unit tests for verifying the S3 options. Minio was tried for integration tests, but it didn't work when the
@@ -76,6 +78,94 @@ class S3ParamsTest {
         assertEquals("my-session-token", config.get("fs.s3a.session.token"));
         assertEquals("https://s3.us-west-2.amazonaws.com", config.get("fs.s3a.endpoint"));
         assertEquals("us-west-2", config.get("fs.s3a.endpoint.region"));
+    }
+
+    @Test
+    void bucketScopedAccessKey() {
+        params.setAccessKeyId("my-access-key");
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config, "my-bucket");
+        assertEquals("my-access-key", config.get("fs.s3a.bucket.my-bucket.access.key"));
+        assertNull(config.get("fs.s3a.access.key"), "Global key should not be set when bucket is provided");
+    }
+
+    @Test
+    void bucketScopedAllCredentials() {
+        params.setAccessKeyId("key");
+        params.setSecretAccessKey("secret");
+        params.setSessionToken("token");
+        params.setEndpoint("http://localhost:9000");
+        params.setRegion("us-east-1");
+
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config, "test-bucket");
+
+        assertEquals("key", config.get("fs.s3a.bucket.test-bucket.access.key"));
+        assertEquals("secret", config.get("fs.s3a.bucket.test-bucket.secret.key"));
+        assertEquals("token", config.get("fs.s3a.bucket.test-bucket.session.token"));
+        assertEquals("http://localhost:9000", config.get("fs.s3a.bucket.test-bucket.endpoint"));
+        assertEquals("us-east-1", config.get("fs.s3a.bucket.test-bucket.endpoint.region"));
+    }
+
+    @Test
+    void useProfileIsAlwaysGlobalEvenWithBucket() {
+        params.setUseProfile(true);
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config, "my-bucket");
+        assertEquals(
+            "software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider",
+            config.get("fs.s3a.aws.credentials.provider")
+        );
+    }
+
+    @Test
+    void extractBucketFromS3aUri() {
+        assertEquals("my-bucket", S3Params.extractBucket("s3a://my-bucket/some/prefix/"));
+    }
+
+    @Test
+    void extractBucketFromS3Uri() {
+        assertEquals("my-bucket", S3Params.extractBucket("s3://my-bucket/file.csv"));
+    }
+
+    @Test
+    void extractBucketFromNonS3Path() {
+        assertNull(S3Params.extractBucket("/local/path/file.csv"));
+        assertNull(S3Params.extractBucket("abfss://container@account.dfs.core.windows.net/path"));
+        assertNull(S3Params.extractBucket(null));
+    }
+
+    @Test
+    void bucketExtractedFromFirstS3PathInMixedList() {
+        params.setAccessKeyId("key");
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config, List.of(
+            "/local/path/file1.csv",
+            "abfss://container@account.dfs.core.windows.net/path",
+            "s3a://my-bucket/data/"
+        ));
+        assertEquals("key", config.get("fs.s3a.bucket.my-bucket.access.key"));
+        assertNull(config.get("fs.s3a.access.key"), "Global key should not be set when an S3 path is present");
+    }
+
+    @Test
+    void addCredentialsWithBucketUsesBucketScopedKeys() {
+        params.setAddCredentials(true);
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config, "my-bucket");
+        assertNull(config.get("fs.s3a.access.key"), "Global access key should not be set when bucket is provided");
+        assertNull(config.get("fs.s3a.secret.key"), "Global secret key should not be set when bucket is provided");
+        assertNotNull(config.get("fs.s3a.bucket.my-bucket.access.key"), "Bucket-scoped access key should be set");
+        assertNotNull(config.get("fs.s3a.bucket.my-bucket.secret.key"), "Bucket-scoped secret key should be set");
+    }
+
+    @Test
+    void addCredentialsWithoutBucketUsesGlobalKeys() {
+        params.setAddCredentials(true);
+        Configuration config = new Configuration();
+        params.addToHadoopConfiguration(config);
+        assertNotNull(config.get("fs.s3a.access.key"), "Global access key should be set when no bucket");
+        assertNotNull(config.get("fs.s3a.secret.key"), "Global secret key should be set when no bucket");
     }
 
     private String getConfigValue(String key) {


### PR DESCRIPTION
No downside to this, and it allows for multiple concurrent jobs using S3 in the same Spark context.
