### PR TITLE
MLE-30127 Expand Azure OpenAI Token Credential Support

### DIFF
--- a/docs/import/embedder/embedder.md
+++ b/docs/import/embedder/embedder.md
@@ -80,14 +80,15 @@ supports the following options:
 
 | Option | Description | 
 | --- | --- |
-| api-key | Required, unless using `non-azure-api-key`; used to authenticate with Azure OpenAI. |
+| api-key | Used to authenticate with Azure OpenAI. Mutually exclusive with `non-azure-api-key` and `token`; exactly one must be provided. |
 | deployment-name | Required; the name of the Azure OpenAI deployment to use for embeddings. |
-| endpoint | Required, unless using `non-azure-api-key`; the Azure OpenAI endpoint in the format: `https://{resource}.openai.azure.com/`. |
+| endpoint | Required when using `api-key` or `token`; the Azure OpenAI endpoint in the format: `https://{resource}.openai.azure.com/`. |
 | dimensions | The number of dimensions in a generated embedding. |
 | duration | Maximum duration, in seconds, of a request before timing out. |
 | log-requests-and-responses | If set to `true`, enables logging of requests and responses. |
 | max-retries | The number of retries to attempt when generating an embedding fails. |
-| non-azure-api-key | Used to authenticate with the OpenAI service instead of Azure OpenAI. If set, the endpoint is automatically set to `https://api.openai.com/v1`. |
+| non-azure-api-key | Used to authenticate with the OpenAI service instead of Azure OpenAI. If set, the endpoint is automatically set to `https://api.openai.com/v1`. Mutually exclusive with `api-key` and `token`. |
+| token | An OAuth2 bearer token used to authenticate via Azure Active Directory / Entra ID. If set, `api-key` must not be provided and the `endpoint` must be specified. Mutually exclusive with `api-key` and `non-azure-api-key`. |
 
 The following shows an example of configuring the Azure OpenAI embedding model with what are likely the most common
 options to be used (the deployment names and endpoints are notional):

--- a/flux-embedding-model-azure-open-ai/src/main/java/com/marklogic/flux/langchain4j/embedding/AzureOpenAiEmbeddingModelFunction.java
+++ b/flux-embedding-model-azure-open-ai/src/main/java/com/marklogic/flux/langchain4j/embedding/AzureOpenAiEmbeddingModelFunction.java
@@ -1,14 +1,19 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.langchain4j.embedding;
 
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenCredential;
 import dev.langchain4j.model.azure.AzureOpenAiEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import reactor.core.publisher.Mono;
 
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class AzureOpenAiEmbeddingModelFunction implements Function<Map<String, String>, EmbeddingModel> {
 
@@ -17,8 +22,12 @@ public class AzureOpenAiEmbeddingModelFunction implements Function<Map<String, S
         // See https://docs.langchain4j.dev/integrations/embedding-models/azure-open-ai/#spring-boot-1 for reference
         // of all properties that should be configurable.
         final String nonAzureKey = "non-azure-api-key";
-        if (!options.containsKey("api-key") && !options.containsKey(nonAzureKey)) {
-            throw new IllegalArgumentException(String.format("Must specify either api-key or %s.", nonAzureKey));
+        final String tokenKey = "token";
+        long authCount = Stream.of("api-key", nonAzureKey, tokenKey)
+            .filter(options::containsKey)
+            .count();
+        if (authCount != 1) {
+            throw new IllegalArgumentException("Must specify exactly one of: api-key, non-azure-api-key, or token.");
         }
 
         final String deploymentName = options.get("deployment-name");
@@ -35,6 +44,12 @@ public class AzureOpenAiEmbeddingModelFunction implements Function<Map<String, S
 
         if (options.containsKey(nonAzureKey)) {
             builder.nonAzureApiKey(options.get(nonAzureKey));
+        }
+
+        if (options.containsKey(tokenKey)) {
+            final String token = options.get(tokenKey);
+            TokenCredential credential = request -> Mono.just(new AccessToken(token, OffsetDateTime.MAX));
+            builder.tokenCredential(credential);
         }
 
         if (options.containsKey("log-requests-and-responses")) {

--- a/flux-embedding-model-azure-open-ai/src/test/java/com/marklogic/flux/langchain4j/embedding/ConfigTest.java
+++ b/flux-embedding-model-azure-open-ai/src/test/java/com/marklogic/flux/langchain4j/embedding/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.langchain4j.embedding;
 
@@ -48,6 +48,15 @@ class ConfigTest {
     }
 
     @Test
+    void tokenWithMissingEndpoint() {
+        expectError(
+            "endpoint cannot be null or blank",
+            "token", "my-oauth2-bearer-token",
+            "deployment-name", "anything"
+        );
+    }
+
+    @Test
     void missingDeploymentName() {
         expectError(
             // We have to translate the internal Azure error, as it will say "deploymentName" instead of "deployment-name".
@@ -70,8 +79,50 @@ class ConfigTest {
     @Test
     void endpointAndNoApiKey() {
         expectError(
-            "Must specify either api-key or non-azure-api-key.",
+            "Must specify exactly one of: api-key, non-azure-api-key, or token.",
             "endpoint", "https://gpt-testing-custom-data1.openai.azure.com"
+        );
+    }
+
+    @Test
+    void tokenCredential() {
+        EmbeddingModel model = apply(
+            "token", "my-oauth2-bearer-token",
+            "endpoint", "https://gpt-testing-custom-data1.openai.azure.com",
+            "deployment-name", "anything"
+        );
+        assertNotNull(model);
+    }
+
+    @Test
+    void tokenConflictsWithApiKey() {
+        expectError(
+            "Must specify exactly one of: api-key, non-azure-api-key, or token.",
+            "token", "my-oauth2-bearer-token",
+            "api-key", "abc123",
+            "endpoint", "https://gpt-testing-custom-data1.openai.azure.com",
+            "deployment-name", "anything"
+        );
+    }
+
+    @Test
+    void tokenConflictsWithNonAzureApiKey() {
+        expectError(
+            "Must specify exactly one of: api-key, non-azure-api-key, or token.",
+            "token", "my-oauth2-bearer-token",
+            "non-azure-api-key", "abc123",
+            "deployment-name", "anything"
+        );
+    }
+
+    @Test
+    void allThreeAuthOptionsConflict() {
+        expectError(
+            "Must specify exactly one of: api-key, non-azure-api-key, or token.",
+            "api-key", "abc123",
+            "non-azure-api-key", "def456",
+            "token", "my-oauth2-bearer-token",
+            "deployment-name", "anything"
         );
     }
 


### PR DESCRIPTION
Adds a new token option to AzureOpenAiEmbeddingModelFunction that wraps a raw OAuth2 bearer token string in a TokenCredential adapter and passes it to AzureOpenAiEmbeddingModel.Builder.tokenCredential() and changes auth validation to allow 3 different mutually exclusive options. It also updates tests and docs.