### PR TITLE
MLE-30316 Allow configurable socket timeout for classification requests in Flux

### DIFF
--- a/docs/import/classifier.md
+++ b/docs/import/classifier.md
@@ -41,7 +41,8 @@ The table below lists each of the options used to configure how the classifier i
 | `--classifier-api-key`     | Provide the API key for accessing the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-token-path`  | Specify the path to the token generator for the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-batch-size`  | Set the number of documents or text chunks to send in a single request to the classifier. Defaults to 20. |
-| `--classifier-timeout`     | Set the socket timeout in milliseconds for classification requests; must be > 0. Defaults to 10000 (10 seconds). |
+| `--classifier-socket-timeout`     | Set the socket timeout in seconds for classification requests. |
+| `--classifier-connection-timeout` | Set the connection timeout in seconds for classification requests. |
 | `--classifier-prop key=value` | Specify additional options for configuring the behavior of the classifier service. |
 
 As an example, the following options - applicable to any import command - would result in the text of each document

--- a/docs/import/classifier.md
+++ b/docs/import/classifier.md
@@ -23,27 +23,28 @@ This feature is particularly useful for organizations managing large-scale docum
 
 ## Configuring the classifier
 
-You can use the classifier options with any import command, as any document written to MarkLogic can have the text 
+You can use the classifier options with any import command, as any document written to MarkLogic can have the text
 within it classified. You can also use it when [copying documents](../copy.md) from one MarkLogic database to another.
 
-Use of a Semaphore classifier is enabled by including at least the `--classifier-host` option. When this option is 
+Use of a Semaphore classifier is enabled by including at least the `--classifier-host` option. When this option is
 included, along with any other options described in the below table, Flux will invoke the classifier for each document
-and will add the result to the corresponding document. 
+and will add the result to the corresponding document.
 
 The table below lists each of the options used to configure how the classifier is used by Flux:
- 
+
 | Option | Description |
 |---|---|
-| `--classifier-host`        | Specify the hostname of the classifier service.  | 
-| `--classifier-port`        | Specify the port number of the classifier service. | 
-| `--classifier-http`        | Use HTTP instead of HTTPS for the classifier service. | 
-| `--classifier-path`        | Specify the path of the classifier service. | 
-| `--classifier-api-key`     | Provide the API key for accessing the classifier service when hosted in Progress Data Cloud. | 
-| `--classifier-token-path`  | Specify the path to the token generator for the classifier service when hosted in Progress Data Cloud. | 
-| `--classifier-batch-size`  | Set the number of documents or text chunks to send in a single request to the classifier. Defaults to 20. | 
+| `--classifier-host`        | Specify the hostname of the classifier service.  |
+| `--classifier-port`        | Specify the port number of the classifier service. |
+| `--classifier-http`        | Use HTTP instead of HTTPS for the classifier service. |
+| `--classifier-path`        | Specify the path of the classifier service. |
+| `--classifier-api-key`     | Provide the API key for accessing the classifier service when hosted in Progress Data Cloud. |
+| `--classifier-token-path`  | Specify the path to the token generator for the classifier service when hosted in Progress Data Cloud. |
+| `--classifier-batch-size`  | Set the number of documents or text chunks to send in a single request to the classifier. Defaults to 20. |
+| `--classifier-timeout`     | Set the socket timeout in milliseconds for classification requests. Defaults to 10000 (10 seconds). |
 | `--classifier-prop key=value` | Specify additional options for configuring the behavior of the classifier service. |
 
-As an example, the following options - applicable to any import command - would result in the text of each document 
+As an example, the following options - applicable to any import command - would result in the text of each document
 to be written to MarkLogic having classification added to it, generated via Semaphore:
 
 {% tabs log %}
@@ -58,7 +59,7 @@ to be written to MarkLogic having classification added to it, generated via Sema
 ```
 --classifier-host example.org ^
 --classifier-port 443 ^
---classifier-path "/cls/dev/cs1/" 
+--classifier-path "/cls/dev/cs1/"
 ```
 {% endtab %}
 {% endtabs %}
@@ -66,18 +67,18 @@ to be written to MarkLogic having classification added to it, generated via Sema
 ## Configuring batch processing
 
 The performance of the Semaphore classifier is typically improved by having Flux send more than one document at a time
-to the classifier. Flux defaults to sending the text of up to 20 documents in each request to the classifier. You 
-can control this via the `--classifier-batch-size` option. 
+to the classifier. Flux defaults to sending the text of up to 20 documents in each request to the classifier. You
+can control this via the `--classifier-batch-size` option.
 
 The appropriate value for this option will depend on the size of your documents and the performance characteristics of
-your Semaphore instance. For small documents, you may find improved performance by increasing the batch size to a 
+your Semaphore instance. For small documents, you may find improved performance by increasing the batch size to a
 higher number, and vice versa for larger documents.
 
 ## Configuring the behavior of the classifier service
 
 The `--classifier-prop` option allows for passing options that affect the behavior of the classifier service. The
-[Semaphore documentation](https://portal.smartlogic.com/docs/5.6/classification_server_-_developers_guide/calling_classification_server), 
-which requires logging in to the Semaphore portal, provides a list of the options that you can pass. 
+[Semaphore documentation](https://portal.smartlogic.com/docs/5.6/classification_server_-_developers_guide/calling_classification_server),
+which requires logging in to the Semaphore portal, provides a list of the options that you can pass.
 
-As Flux uses the "multi-article" support for configuring batch processing, you should not set either the 
-`singlearticle` or `multiarticle` options. 
+As Flux uses the "multi-article" support for configuring batch processing, you should not set either the
+`singlearticle` or `multiarticle` options.

--- a/docs/import/classifier.md
+++ b/docs/import/classifier.md
@@ -41,8 +41,8 @@ The table below lists each of the options used to configure how the classifier i
 | `--classifier-api-key`     | Provide the API key for accessing the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-token-path`  | Specify the path to the token generator for the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-batch-size`  | Set the number of documents or text chunks to send in a single request to the classifier. Defaults to 20. |
-| `--classifier-socket-timeout`     | Set the socket timeout in seconds for classification requests. |
-| `--classifier-connection-timeout` | Set the connection timeout in seconds for classification requests. |
+| `--classifier-socket-timeout`     | Set the socket timeout in seconds for classification requests. Defaults to 10. |
+| `--classifier-connection-timeout` | Set the connection timeout in seconds for classification requests. Defaults to 10. |
 | `--classifier-prop key=value` | Specify additional options for configuring the behavior of the classifier service. |
 
 As an example, the following options - applicable to any import command - would result in the text of each document

--- a/docs/import/classifier.md
+++ b/docs/import/classifier.md
@@ -41,7 +41,7 @@ The table below lists each of the options used to configure how the classifier i
 | `--classifier-api-key`     | Provide the API key for accessing the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-token-path`  | Specify the path to the token generator for the classifier service when hosted in Progress Data Cloud. |
 | `--classifier-batch-size`  | Set the number of documents or text chunks to send in a single request to the classifier. Defaults to 20. |
-| `--classifier-timeout`     | Set the socket timeout in milliseconds for classification requests. Defaults to 10000 (10 seconds). |
+| `--classifier-timeout`     | Set the socket timeout in milliseconds for classification requests; must be > 0. Defaults to 10000 (10 seconds). |
 | `--classifier-prop key=value` | Specify additional options for configuring the behavior of the classifier service. |
 
 As an example, the following options - applicable to any import command - would result in the text of each document

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.api;
 
@@ -44,6 +44,13 @@ public interface ClassifierOptions {
      * @param batchSize Number of documents and/or chunks of text to send to the classifier service in a single request.
      */
     ClassifierOptions batchSize(int batchSize);
+
+    /**
+     * @param socketTimeoutMs Socket timeout in milliseconds for classification requests.
+     *                        Defaults to 10000 (10 seconds) when not specified.
+     * @since 2.1.2
+     */
+    ClassifierOptions socketTimeout(int socketTimeoutMs);
 
     /**
      * @param additionalOptions Additional options for configuring the behavior of the classifier service.

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
@@ -46,11 +46,16 @@ public interface ClassifierOptions {
     ClassifierOptions batchSize(int batchSize);
 
     /**
-     * @param socketTimeoutMs Socket timeout in milliseconds for classification requests; must be > 0.
-     *                        Defaults to 10000 (10 seconds) when not specified.
+     * @param socketTimeoutSeconds Socket timeout in seconds for classification requests.
      * @since 2.1.2
      */
-    ClassifierOptions socketTimeout(int socketTimeoutMs);
+    ClassifierOptions socketTimeout(int socketTimeoutSeconds);
+
+    /**
+     * @param connectionTimeoutSeconds Connection timeout in seconds for classification requests.
+     * @since 2.1.2
+     */
+    ClassifierOptions connectionTimeout(int connectionTimeoutSeconds);
 
     /**
      * @param additionalOptions Additional options for configuring the behavior of the classifier service.

--- a/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/api/ClassifierOptions.java
@@ -46,7 +46,7 @@ public interface ClassifierOptions {
     ClassifierOptions batchSize(int batchSize);
 
     /**
-     * @param socketTimeoutMs Socket timeout in milliseconds for classification requests.
+     * @param socketTimeoutMs Socket timeout in milliseconds for classification requests; must be > 0.
      *                        Defaults to 10000 (10 seconds) when not specified.
      * @since 2.1.2
      */

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
@@ -56,10 +56,16 @@ public class ClassifierParams implements ClassifierOptions {
     private Integer batchSize = 20;
 
     @CommandLine.Option(
-        names = "--classifier-timeout",
-        description = "Socket timeout in milliseconds for classification requests. Must be > 0. Defaults to 10000 (10 seconds) when not specified."
+        names = "--classifier-socket-timeout",
+        description = "Socket timeout in seconds for classification requests."
     )
-    private Integer socketTimeoutMs;
+    private Integer socketTimeoutSeconds;
+
+    @CommandLine.Option(
+        names = "--classifier-connection-timeout",
+        description = "Connection timeout in seconds for classification requests."
+    )
+    private Integer connectionTimeoutSeconds;
 
     @CommandLine.Option(
         names = "--classifier-prop",
@@ -78,7 +84,8 @@ public class ClassifierParams implements ClassifierOptions {
                 Options.WRITE_CLASSIFIER_APIKEY, apikey,
                 Options.WRITE_CLASSIFIER_TOKEN_PATH, tokenPath,
                 Options.WRITE_CLASSIFIER_BATCH_SIZE, OptionsUtil.integerOption(batchSize),
-                Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, OptionsUtil.integerOption(socketTimeoutMs)
+                Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, OptionsUtil.integerOption(socketTimeoutSeconds),
+                Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, OptionsUtil.integerOption(connectionTimeoutSeconds)
             );
             if (additionalOptions != null) {
                 additionalOptions.entrySet().forEach(entry -> options.put(
@@ -131,8 +138,14 @@ public class ClassifierParams implements ClassifierOptions {
     }
 
     @Override
-    public ClassifierOptions socketTimeout(int socketTimeoutMs) {
-        this.socketTimeoutMs = socketTimeoutMs;
+    public ClassifierOptions socketTimeout(int socketTimeoutSeconds) {
+        this.socketTimeoutSeconds = socketTimeoutSeconds;
+        return this;
+    }
+
+    @Override
+    public ClassifierOptions connectionTimeout(int connectionTimeoutSeconds) {
+        this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         return this;
     }
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
@@ -57,7 +57,7 @@ public class ClassifierParams implements ClassifierOptions {
 
     @CommandLine.Option(
         names = "--classifier-timeout",
-        description = "Socket timeout in milliseconds for classification requests. Defaults to 10000 (10 seconds)."
+        description = "Socket timeout in milliseconds for classification requests. Must be > 0. Defaults to 10000 (10 seconds) when not specified."
     )
     private Integer socketTimeoutMs;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/importdata/ClassifierParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl.importdata;
 
@@ -56,6 +56,12 @@ public class ClassifierParams implements ClassifierOptions {
     private Integer batchSize = 20;
 
     @CommandLine.Option(
+        names = "--classifier-timeout",
+        description = "Socket timeout in milliseconds for classification requests. Defaults to 10000 (10 seconds)."
+    )
+    private Integer socketTimeoutMs;
+
+    @CommandLine.Option(
         names = "--classifier-prop",
         description = "Specify additional options for configuring the behavior of the classifier service."
     )
@@ -71,7 +77,8 @@ public class ClassifierParams implements ClassifierOptions {
                 Options.WRITE_CLASSIFIER_PATH, path,
                 Options.WRITE_CLASSIFIER_APIKEY, apikey,
                 Options.WRITE_CLASSIFIER_TOKEN_PATH, tokenPath,
-                Options.WRITE_CLASSIFIER_BATCH_SIZE, OptionsUtil.integerOption(batchSize)
+                Options.WRITE_CLASSIFIER_BATCH_SIZE, OptionsUtil.integerOption(batchSize),
+                Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, OptionsUtil.integerOption(socketTimeoutMs)
             );
             if (additionalOptions != null) {
                 additionalOptions.entrySet().forEach(entry -> options.put(
@@ -120,6 +127,12 @@ public class ClassifierParams implements ClassifierOptions {
     @Override
     public ClassifierOptions batchSize(int batchSize) {
         this.batchSize = batchSize;
+        return this;
+    }
+
+    @Override
+    public ClassifierOptions socketTimeout(int socketTimeoutMs) {
+        this.socketTimeoutMs = socketTimeoutMs;
         return this;
     }
 

--- a/flux-cli/src/main/resources/marklogic-spark-messages_en.properties
+++ b/flux-cli/src/main/resources/marklogic-spark-messages_en.properties
@@ -24,3 +24,5 @@ spark.marklogic.write.splitter.sidecar.maxChunks=--splitter-sidecar-max-chunks
 spark.marklogic.write.embedder.chunks.jsonPointer=--embedder-chunks-json-pointer
 spark.marklogic.write.embedder.chunks.xpath=--embedder-chunks-xpath
 spark.marklogic.write.embedder.batchSize=--embedder-batch-size
+spark.marklogic.write.classifier.socketTimeout=--classifier-socket-timeout
+spark.marklogic.write.classifier.connectionTimeout=--classifier-connection-timeout

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl;
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/ErrorMessagesTest.java
@@ -15,8 +15,8 @@ class ErrorMessagesTest {
     @Test
     void verifyEachKeyIsOverridden() {
         ResourceBundle bundle = ResourceBundle.getBundle("marklogic-spark-messages");
-        assertEquals(21, bundle.keySet().size(),
-            "Expecting 21 keys as of the upcoming 2.0.0 release. Bump this up as more keys are added. Each key should " +
+        assertEquals(23, bundle.keySet().size(),
+            "Expecting 23 keys as of the upcoming 2.0.0 release. Bump this up as more keys are added. Each key should " +
                 "also be verified in an assertion below.");
 
         assertEquals("--connection-string", bundle.getString(Options.CLIENT_URI));
@@ -40,5 +40,7 @@ class ErrorMessagesTest {
         assertEquals("--embedder-chunks-json-pointer", bundle.getString(Options.WRITE_EMBEDDER_CHUNKS_JSON_POINTER));
         assertEquals("--embedder-chunks-xpath", bundle.getString(Options.WRITE_EMBEDDER_CHUNKS_XPATH));
         assertEquals("--embedder-batch-size", bundle.getString(Options.WRITE_EMBEDDER_BATCH_SIZE));
+        assertEquals("--classifier-socket-timeout", bundle.getString(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT));
+        assertEquals("--classifier-connection-timeout", bundle.getString(Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT));
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
@@ -99,6 +99,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
             "--classifier-api-key", "apikey",
             "--classifier-token-path", "/token/path",
             "--classifier-batch-size", "50",
+            "--classifier-timeout", "60000",
             "--classifier-prop", "key1=value1"
         );
 
@@ -136,6 +137,7 @@ class CopyOptionsTest extends AbstractOptionsTest {
             Options.WRITE_CLASSIFIER_APIKEY, "apikey",
             Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token/path",
             Options.WRITE_CLASSIFIER_BATCH_SIZE, "50",
+            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "60000",
             Options.WRITE_CLASSIFIER_OPTION_PREFIX + "key1", "value1"
         );
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/copy/CopyOptionsTest.java
@@ -99,7 +99,8 @@ class CopyOptionsTest extends AbstractOptionsTest {
             "--classifier-api-key", "apikey",
             "--classifier-token-path", "/token/path",
             "--classifier-batch-size", "50",
-            "--classifier-timeout", "60000",
+            "--classifier-socket-timeout", "60",
+            "--classifier-connection-timeout", "30",
             "--classifier-prop", "key1=value1"
         );
 
@@ -137,7 +138,8 @@ class CopyOptionsTest extends AbstractOptionsTest {
             Options.WRITE_CLASSIFIER_APIKEY, "apikey",
             Options.WRITE_CLASSIFIER_TOKEN_PATH, "/token/path",
             Options.WRITE_CLASSIFIER_BATCH_SIZE, "50",
-            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "60000",
+            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "60",
+            Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, "30",
             Options.WRITE_CLASSIFIER_OPTION_PREFIX + "key1", "value1"
         );
     }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ClassifierOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ClassifierOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl.importdata;
 
@@ -10,6 +10,8 @@ import com.marklogic.spark.Options;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ClassifierOptionsTest extends AbstractOptionsTest {
 
@@ -26,7 +28,8 @@ class ClassifierOptionsTest extends AbstractOptionsTest {
                     .path("/cls/endpoint")
                     .apiKey("MyApiKey")
                     .tokenPath("token/endpoint")
-                    .batchSize(30);
+                    .batchSize(30)
+                    .socketTimeout(30000);
                 reference.set(classifierOptions);
             }));
 
@@ -38,7 +41,23 @@ class ClassifierOptionsTest extends AbstractOptionsTest {
             Options.WRITE_CLASSIFIER_PATH, "/cls/endpoint",
             Options.WRITE_CLASSIFIER_APIKEY, "MyApiKey",
             Options.WRITE_CLASSIFIER_TOKEN_PATH, "token/endpoint",
-            Options.WRITE_CLASSIFIER_BATCH_SIZE, "30"
+            Options.WRITE_CLASSIFIER_BATCH_SIZE, "30",
+            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30000"
         );
+    }
+
+    @Test
+    void defaultTimeoutNotIncludedWhenNotSet() {
+        AtomicReference<ClassifierOptions> reference = new AtomicReference<>();
+
+        Flux.importGenericFiles()
+            .to(options -> options.classifier(classifierOptions -> {
+                classifierOptions.host("h");
+                reference.set(classifierOptions);
+            }));
+
+        ClassifierParams params = (ClassifierParams) reference.get();
+        assertFalse(params.makeOptions().containsKey(Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT),
+            "When no socket timeout is configured, the option key should be absent so the Spark connector uses its default.");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ClassifierOptionsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ClassifierOptionsTest.java
@@ -29,7 +29,8 @@ class ClassifierOptionsTest extends AbstractOptionsTest {
                     .apiKey("MyApiKey")
                     .tokenPath("token/endpoint")
                     .batchSize(30)
-                    .socketTimeout(30000);
+                    .socketTimeout(30)
+                    .connectionTimeout(15);
                 reference.set(classifierOptions);
             }));
 
@@ -42,8 +43,24 @@ class ClassifierOptionsTest extends AbstractOptionsTest {
             Options.WRITE_CLASSIFIER_APIKEY, "MyApiKey",
             Options.WRITE_CLASSIFIER_TOKEN_PATH, "token/endpoint",
             Options.WRITE_CLASSIFIER_BATCH_SIZE, "30",
-            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30000"
+            Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT, "30",
+            Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT, "15"
         );
+    }
+
+    @Test
+    void defaultConnectionTimeoutNotIncludedWhenNotSet() {
+        AtomicReference<ClassifierOptions> reference = new AtomicReference<>();
+
+        Flux.importGenericFiles()
+            .to(options -> options.classifier(classifierOptions -> {
+                classifierOptions.host("h");
+                reference.set(classifierOptions);
+            }));
+
+        ClassifierParams params = (ClassifierParams) reference.get();
+        assertFalse(params.makeOptions().containsKey(Options.WRITE_CLASSIFIER_CONNECTION_TIMEOUT),
+            "When no connection timeout is configured, the option key should be absent so the Spark connector uses its default.");
     }
 
     @Test


### PR DESCRIPTION
### Problem

The Semaphore classifier client had a hardcoded 10-second socket timeout with no way to override it. Classifying large or complex documents (e.g., PDFs with forced language settings) can exceed this limit, and there was no CLI option or Java API method available to raise it.

### Solution

Added `--classifier-timeout` as a new CLI option and `socketTimeout(int)` as a new method on the `ClassifierOptions` Java API. The value is passed through to the Spark Connector as `spark.marklogic.write.classifier.socketTimeout`, where it is applied to the Semaphore `ClassificationConfiguration`.

When the option is not set, no value is forwarded to the connector and the Semaphore library's default of 10,000 ms is preserved — no behavior change for existing users.

### Changes

**ClassifierOptions.java** (public API)
- Added `socketTimeout(int socketTimeoutMs)` method (`@since 2.1.2`).

**ClassifierParams.java**
- Added `--classifier-timeout` picocli option (`Integer socketTimeoutMs`, defaults to `null` so no entry is added to the options map when not specified).
- Wired `Options.WRITE_CLASSIFIER_SOCKET_TIMEOUT` into `makeOptions()` via `OptionsUtil.integerOption()`.
- Implemented `socketTimeout(int)` from the `ClassifierOptions` interface.

**ClassifierOptionsTest.java**
- `testOptions()` — updated to assert `WRITE_CLASSIFIER_SOCKET_TIMEOUT` is correctly mapped when `socketTimeout(30000)` is called.
- `defaultTimeoutNotIncludedWhenNotSet()` — new test verifying the option key is absent from the options map when `socketTimeout` is never called.

**CopyOptionsTest.java**
- Added `--classifier-timeout 60000` to the copy command classifier options test and the corresponding `assertOptions()` assertion.

**classifier.md**
- Added `--classifier-timeout` row to the options table.

### Testing

Unit tests only — no MarkLogic instance required.

```
./gradlew :flux-cli:test --tests com.marklogic.flux.impl.importdata.ClassifierOptionsTest
./gradlew :flux-cli:test --tests com.marklogic.flux.impl.copy.CopyOptionsTest
```

All tests pass.

### Notes

- The `ClassifierOptions` interface change is purely additive — no breaking change to the public API.
- This PR depends on the companion Spark Connector PR being merged and released first so that `WRITE_CLASSIFIER_SOCKET_TIMEOUT` is available at compile time.  https://github.com/marklogic/marklogic-spark-connector/pull/666

Jira Story: https://progresssoftware.atlassian.net/browse/MLE-30316

