### PR TITLE
MLE-31204 Add Interactive Masked Input to Cloud Storage Secret CLI Options

### DIFF
--- a/docs/export/specifying-path.md
+++ b/docs/export/specifying-path.md
@@ -5,7 +5,7 @@ parent: Exporting Data
 nav_order: 1
 ---
 
-Each command for exporting data to files requires a path that defines the location of the exported data. 
+Each command for exporting data to files requires a path that defines the location of the exported data.
 This guide describes the different types of paths supported by Flux.
 
 ## Table of contents
@@ -16,11 +16,11 @@ This guide describes the different types of paths supported by Flux.
 
 ## Specifying a path
 
-Commands that export data to files require a single path specified via the `--path` option. 
-The value of the `--path` option can be any valid directory, S3 bucket, or Azure Storage container. 
+Commands that export data to files require a single path specified via the `--path` option.
+The value of the `--path` option can be any valid directory, S3 bucket, or Azure Storage container.
 
-> Note - MarkLogic allows for characters in document URIs that may not be supported in filenames for the target 
-> filesystem. For example, Azure Storage will not allow colons in a filename. If you run into issues with characters 
+> Note - MarkLogic allows for characters in document URIs that may not be supported in filenames for the target
+> filesystem. For example, Azure Storage will not allow colons in a filename. If you run into issues with characters
 > in the filename, consider exporting a zip file containing documents instead of exporting individual documents as files.
 
 ## Exporting to S3
@@ -54,30 +54,34 @@ bin\flux export-files ^
 {% endtab %}
 {% endtabs %}
 
-**Explicit credentials** - You can explicitly define your AWS credentials via `--s3-access-key-id` and 
-`--s3-secret-access-key`. To avoid typing these in plaintext, you may want to store these in a file and reference 
-the file via an options file. See the documentation on [Common Options](../common-options.md) for more information. 
-As of Flux 2.0.0, you may also specify an AWS session token via the `--s3-session-token` option. This token will be 
+**Explicit credentials** - You can explicitly define your AWS credentials via `--s3-access-key-id` and
+`--s3-secret-access-key`. To avoid typing these in plaintext, you may want to store these in a file and reference
+the file via an options file. See the documentation on [Common Options](../common-options.md) for more information.
+As of Flux 2.0.0, you may also specify an AWS session token via the `--s3-session-token` option. This token will be
 used with your access key ID and secret access key values when authenticating with S3.
 
-**Profile-based authentication** - As of Flux 2.0.0, you can use `--s3-use-profile` to authenticate with AWS profile 
-credentials from `~/.aws/config` and `~/.aws/credentials`. This supports SSO profiles (configured via `aws sso login`), 
-standard profiles with access keys, and any other profile types. By default, the `[default]` profile is used, or you 
-can specify a profile via the `AWS_PROFILE` environment variable. See the 
-[AWS documentation on configuration and credential files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) 
+As of Flux 2.1.2, `--s3-secret-access-key` and `--s3-session-token` support masked interactive input: specify
+the option name without a value and Flux will prompt you to enter the value with no-echo input, keeping the
+credential out of your shell history and process listings.
+
+**Profile-based authentication** - As of Flux 2.0.0, you can use `--s3-use-profile` to authenticate with AWS profile
+credentials from `~/.aws/config` and `~/.aws/credentials`. This supports SSO profiles (configured via `aws sso login`),
+standard profiles with access keys, and any other profile types. By default, the `[default]` profile is used, or you
+can specify a profile via the `AWS_PROFILE` environment variable. See the
+[AWS documentation on configuration and credential files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 for more information.
 
-**Anonymous authentication** - As of Flux 2.1.1, you can use `--s3-anonymous` to access public S3 buckets that do not 
+**Anonymous authentication** - As of Flux 2.1.1, you can use `--s3-anonymous` to access public S3 buckets that do not
 require authentication.
 
 ### Configuring the S3 connection
 
-When running Flux within AWS and accessing an S3 bucket in a different region, you may need to configure the S3 
-connection explicitly. Use `--s3-endpoint` to specify the S3 endpoint URL, and as of Flux 2.0.0, use `--s3-region` 
+When running Flux within AWS and accessing an S3 bucket in a different region, you may need to configure the S3
+connection explicitly. Use `--s3-endpoint` to specify the S3 endpoint URL, and as of Flux 2.0.0, use `--s3-region`
 to specify the AWS region of the S3 bucket to access.
 
-For advanced S3 configuration, you can use `--spark-conf` to set 
-[Hadoop S3 properties](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#General_S3A_Client_configuration). 
+For advanced S3 configuration, you can use `--spark-conf` to set
+[Hadoop S3 properties](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#General_S3A_Client_configuration).
 For example, the following sets the connection timeout:
 
 `--spark-conf spark.hadoop.fs.s3a.connection.timeout=300000`
@@ -86,13 +90,13 @@ See [Common Options](../common-options.md) for more information on using `--spar
 
 ## Exporting to Azure Storage
 
-Flux can export files to [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-introduction) using either [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) or [Azure Data Lake Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction). 
+Flux can export files to [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-introduction) using either [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) or [Azure Data Lake Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction).
 
 The examples below use notional values for options that contain credentials. To avoid typing credentials in plaintext,
 consider storing them in [an options file](../../common-options.md).
 
-> When exporting to Azure Blob Storage, you may notice that folders appear as both a folder structure and 
-> a blob with the same name. This is normal behavior - Azure Blob Storage uses special marker blobs to represent 
+> When exporting to Azure Blob Storage, you may notice that folders appear as both a folder structure and
+> a blob with the same name. This is normal behavior - Azure Blob Storage uses special marker blobs to represent
 > folder structures, and these are automatically created by the underlying storage libraries.
 
 ### Azure Blob Storage Authentication
@@ -102,7 +106,9 @@ Azure Blob Storage supports two authentication methods:
 **Access Key Authentication**
 
 If you are using [access key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage),
-you can define a key via the `--azure-access-key` option:
+you can define a key via the `--azure-access-key` option. As of Flux 2.1.2, `--azure-access-key` supports masked
+interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -112,7 +118,7 @@ you can define a key via the `--azure-access-key` option:
     --azure-storage-account "mystorage" \
     --azure-container-name "exports" \
     --azure-access-key "your-access-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -122,7 +128,7 @@ bin\flux export-files ^
     --azure-storage-account "mystorage" ^
     --azure-container-name "exports" ^
     --azure-access-key "your-access-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
@@ -130,7 +136,9 @@ bin\flux export-files ^
 **SAS Token Authentication**
 
 If you are using [SAS (Shared Access Signature) tokens](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview),
-you can define a token via the `--azure-sas-token` option:
+you can define a token via the `--azure-sas-token` option. As of Flux 2.1.2, `--azure-sas-token` supports masked
+interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -140,7 +148,7 @@ you can define a token via the `--azure-sas-token` option:
     --azure-storage-account "mystorage" \
     --azure-container-name "exports" \
     --azure-sas-token "your-sas-token" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -150,7 +158,7 @@ bin\flux export-files ^
     --azure-storage-account "mystorage" ^
     --azure-container-name "exports" ^
     --azure-sas-token "your-sas-token" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
@@ -160,8 +168,10 @@ bin\flux export-files ^
 ### Azure Data Lake Storage Authentication
 
 Azure Data Lake Storage uses [shared key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage).
-You can define a shared key via the `--azure-shared-key` option. You must also include `--azure-storage-type DATA_LAKE`
-to indicate that you are using Data Lake Storage instead of Blob Storage:
+You can define a shared key via the `--azure-shared-key` option, and must also include `--azure-storage-type DATA_LAKE`
+to indicate that you are using Data Lake Storage instead of Blob Storage. As of Flux 2.1.2, `--azure-shared-key` supports
+masked interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -172,7 +182,7 @@ to indicate that you are using Data Lake Storage instead of Blob Storage:
     --azure-container-name "exports" \
     --azure-storage-type "DATA_LAKE" \
     --azure-shared-key "your-shared-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -183,7 +193,7 @@ bin\flux export-files ^
     --azure-container-name "exports" ^
     --azure-storage-type "DATA_LAKE" ^
     --azure-shared-key "your-shared-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
@@ -209,7 +219,7 @@ Alternatively, you can provide the complete storage URL yourself:
     --path "wasbs://exports@mystorage.blob.core.windows.net/reports/" \
     --azure-storage-account "mystorage" \
     --azure-access-key "your-access-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -218,7 +228,7 @@ bin\flux export-files ^
     --path "wasbs://exports@mystorage.blob.core.windows.net/reports/" ^
     --azure-storage-account "mystorage" ^
     --azure-access-key "your-access-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}

--- a/docs/import/import-files/selecting-files.md
+++ b/docs/import/import-files/selecting-files.md
@@ -86,27 +86,27 @@ You can restrict which files are read from a directory by specifying a standard
 
 
 Depending on your shell environment, you may need to include the value of `--filter` in double quotes as shown above to
-ensure that each asterisk is interpreted correctly. However, if you include `--filter` in an options file as 
-described in [Common Options](../../common-options.md), you do not need double quotes around the value. 
+ensure that each asterisk is interpreted correctly. However, if you include `--filter` in an options file as
+described in [Common Options](../../common-options.md), you do not need double quotes around the value.
 
 ## Working with large numbers of files
 
-In general, Flux performs better with smaller numbers of large files versus large numbers of small files. Having a 
-large number of small files in a directory, such as 1 million or more files, is a pattern that causes performance 
+In general, Flux performs better with smaller numbers of large files versus large numbers of small files. Having a
+large number of small files in a directory, such as 1 million or more files, is a pattern that causes performance
 issues across many systems. With Flux, you may encounter out-of-memory errors in this scenario due to the need to
-create a list of all file paths. 
+create a list of all file paths.
 
 If you have large numbers of files to import, consider one of the following approaches:
 
-- **Combine files into archives**: Zip your files into larger archive files before importing. This significantly 
-  reduces the number of file handles that need to be managed. Use the `--compression zip` option when importing zip files.  
-- **Use JSON Lines format**: If your files contain structured data, combine them into one or more 
-  [JSON Lines](https://jsonlines.org/) files where each line is a separate JSON document. Flux can efficiently process 
+- **Combine files into archives**: Zip your files into larger archive files before importing. This significantly
+  reduces the number of file handles that need to be managed. Use the `--compression zip` option when importing zip files.
+- **Use JSON Lines format**: If your files contain structured data, combine them into one or more
+  [JSON Lines](https://jsonlines.org/) files where each line is a separate JSON document. Flux can efficiently process
   JSON Lines files of any size via the `import-aggregate-json-files` command.
 - **Process in batches**: Break your import into multiple smaller operations, each processing a manageable subset of files.
 
-Additionally, for commands that support the `--partitions` option, specify a value such as `--partitions 10` to 
-limit the number of partitions created by Flux. This addresses a bug that will be fixed in Flux 2.0. Without this, 
+Additionally, for commands that support the `--partitions` option, specify a value such as `--partitions 10` to
+limit the number of partitions created by Flux. This addresses a bug that will be fixed in Flux 2.0. Without this,
 the import command will succeed but will perform much worse than with a fixed, small number of partitions.
 
 ## Ignoring child directories
@@ -124,8 +124,8 @@ Flux can read files from S3 via a path expression of the form `s3a://bucket-name
 
 In most cases, Flux must use your AWS credentials to access an S3 bucket. Flux supports several authentication methods:
 
-**Automatic credential retrieval** - Flux uses the AWS SDK to fetch credentials from 
-[locations supported by the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-short-term.html). 
+**Automatic credential retrieval** - Flux uses the AWS SDK to fetch credentials from
+[locations supported by the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-short-term.html).
 To enable this, include the `--s3-add-credentials` option:
 
 {% tabs log %}
@@ -134,7 +134,7 @@ To enable this, include the `--s3-add-credentials` option:
 ./bin/flux import-files \
     --path "s3a://my-bucket/some/path" \
     --s3-add-credentials \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -142,22 +142,26 @@ To enable this, include the `--s3-add-credentials` option:
 bin\flux import-files ^
     --path "s3a://my-bucket/some/path" ^
     --s3-add-credentials ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
 
-**Explicit credentials** - You can explicitly define your AWS credentials via `--s3-access-key-id` and 
-`--s3-secret-access-key`. To avoid typing these in plaintext, you may want to store these in a file and reference 
-the file via an options file. See [Common Options](../../common-options.md) for more information on how to use 
-options files. As of Flux 2.0.0, you may also specify an AWS session token via the `--s3-session-token` option. 
+**Explicit credentials** - You can explicitly define your AWS credentials via `--s3-access-key-id` and
+`--s3-secret-access-key`. To avoid typing these in plaintext, you may want to store these in a file and reference
+the file via an options file. See [Common Options](../../common-options.md) for more information on how to use
+options files. As of Flux 2.0.0, you may also specify an AWS session token via the `--s3-session-token` option.
 This token will be used with your access key ID and secret access key values when authenticating with S3.
 
-**Profile-based authentication** - As of Flux 2.0.0, you can use `--s3-use-profile` to authenticate with AWS profile 
-credentials from `~/.aws/config` and `~/.aws/credentials`. This supports SSO profiles (configured via `aws sso login`), 
-standard profiles with access keys, and any other profile types. By default, the `[default]` profile is used, or you 
-can specify a profile via the `AWS_PROFILE` environment variable. See the 
-[AWS documentation on configuration and credential files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) 
+As of Flux 2.1.2, `--s3-secret-access-key` and `--s3-session-token` support masked interactive input: specify
+the option name without a value and Flux will prompt you to enter the value with no-echo input, keeping the
+credential out of your shell history and process listings.
+
+**Profile-based authentication** - As of Flux 2.0.0, you can use `--s3-use-profile` to authenticate with AWS profile
+credentials from `~/.aws/config` and `~/.aws/credentials`. This supports SSO profiles (configured via `aws sso login`),
+standard profiles with access keys, and any other profile types. By default, the `[default]` profile is used, or you
+can specify a profile via the `AWS_PROFILE` environment variable. See the
+[AWS documentation on configuration and credential files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 for more information.
 
 **Anonymous authentication** - As of Flux 2.1.1, you can use `--s3-anonymous` to access public S3 buckets that do not
@@ -165,12 +169,12 @@ require authentication.
 
 ### Configuring the S3 connection
 
-When running Flux within AWS and accessing an S3 bucket in a different region, you may need to configure the S3 
-connection explicitly. Use `--s3-endpoint` to specify the S3 endpoint URL, and as of Flux 2.0.0, use `--s3-region` 
+When running Flux within AWS and accessing an S3 bucket in a different region, you may need to configure the S3
+connection explicitly. Use `--s3-endpoint` to specify the S3 endpoint URL, and as of Flux 2.0.0, use `--s3-region`
 to specify the AWS region of the S3 bucket to access.
 
-For advanced S3 configuration, you can use `--spark-conf` to set 
-[Hadoop S3 properties](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#General_S3A_Client_configuration). 
+For advanced S3 configuration, you can use `--spark-conf` to set
+[Hadoop S3 properties](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#General_S3A_Client_configuration).
 For example, the following sets the connection timeout:
 
 `--spark-conf spark.hadoop.fs.s3a.connection.timeout=300000`
@@ -179,13 +183,13 @@ See [Common Options](../common-options.md) for more information on using `--spar
 
 ## Importing from Azure Storage
 
-Flux can read files from [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-introduction) using either [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) or [Azure Data Lake Storage Gen2](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction).  
+Flux can read files from [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-introduction) using either [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction) or [Azure Data Lake Storage Gen2](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction).
 
-The first step is configuring authentication to your Azure Storage account. Once authenticated, you can use simple 
+The first step is configuring authentication to your Azure Storage account. Once authenticated, you can use simple
 relative file paths and Flux will automatically construct the full Azure Storage URLs for you.
 
-The examples below use notional values for options that contain credentials. To avoid typing credentials in plaintext, 
-consider storing them in [an options file](../../common-options.md). 
+The examples below use notional values for options that contain credentials. To avoid typing credentials in plaintext,
+consider storing them in [an options file](../../common-options.md).
 
 ### Blob Storage Authentication
 
@@ -193,8 +197,10 @@ Azure Blob Storage supports two authentication methods:
 
 **Access Key Authentication**
 
-If you are using [access key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage), 
-you can define a key via the `--azure-access-key` option:
+If you are using [access key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage),
+you can define a key via the `--azure-access-key` option. As of Flux 2.1.2, `--azure-access-key` supports masked
+interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -204,7 +210,7 @@ you can define a key via the `--azure-access-key` option:
     --azure-storage-account "mystorage" \
     --azure-container-name "mycontainer" \
     --azure-access-key "your-access-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -214,15 +220,17 @@ bin\flux import-files ^
     --azure-storage-account "mystorage" ^
     --azure-container-name "mycontainer" ^
     --azure-access-key "your-access-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
 
 **SAS Token Authentication**
 
-If you are using [SAS (Shared Access Signature) tokens](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview), 
-you can define a token via the `--azure-sas-token` option:
+If you are using [SAS (Shared Access Signature) tokens](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview),
+you can define a token via the `--azure-sas-token` option. As of Flux 2.1.2, `--azure-sas-token` supports masked
+interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -232,7 +240,7 @@ you can define a token via the `--azure-sas-token` option:
     --azure-storage-account "mystorage" \
     --azure-container-name "mycontainer" \
     --azure-sas-token "your-sas-token" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -242,7 +250,7 @@ bin\flux import-files ^
     --azure-storage-account "mystorage" ^
     --azure-container-name "mycontainer" ^
     --azure-sas-token "your-sas-token" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
@@ -251,9 +259,11 @@ bin\flux import-files ^
 
 ### Data Lake Storage Authentication
 
-Azure Data Lake Storage uses [shared key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage). 
-You can define a shared key via the `--azure-shared-key` option. You must also include `--azure-storage-type DATA_LAKE`
-to indicate that you are using Data Lake Storage instead of Blob Storage:
+Azure Data Lake Storage uses [shared key authentication](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage).
+You can define a shared key via the `--azure-shared-key` option, and must also include `--azure-storage-type DATA_LAKE`
+to indicate that you are using Data Lake Storage instead of Blob Storage. As of Flux 2.1.2, `--azure-shared-key` supports
+masked interactive input: specify the option name without a value and Flux will prompt you to enter the value with
+no-echo input.
 
 {% tabs log %}
 {% tab log Unix %}
@@ -264,7 +274,7 @@ to indicate that you are using Data Lake Storage instead of Blob Storage:
     --azure-container-name "analytics" \
     --azure-storage-type "DATA_LAKE" \
     --azure-shared-key "your-shared-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -275,7 +285,7 @@ bin\flux import-files ^
     --azure-container-name "analytics" ^
     --azure-storage-type "DATA_LAKE" ^
     --azure-shared-key "your-shared-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}
@@ -284,7 +294,7 @@ bin\flux import-files ^
 
 Flux provides two ways to specify file paths. First, when both `--azure-storage-account` and `--azure-container-name`
 are specified and the path is relative - i.e. it does not contain a protocol like `wasbs://` or `abfss://` - Flux will
-construct the full Azure Storage URL for you. This is the most convenient way to work with Azure Storage, as it hides 
+construct the full Azure Storage URL for you. This is the most convenient way to work with Azure Storage, as it hides
 the underlying Azure protocols from you.
 
 For example:
@@ -292,7 +302,7 @@ For example:
 - `"data/myfile.csv"` becomes `"wasbs://mycontainer@mystorage.blob.core.windows.net/data/myfile.csv"` (for Blob Storage).
 - `"analytics/sales-data.orc"` becomes `"abfss://analytics@mydatalake.dfs.core.windows.net/analytics/sales-data.orc"` (for Data Lake Storage Gen2).
 
-If you instead need to mix Azure Storage paths with other types of paths (such as S3 or local file paths), you must 
+If you instead need to mix Azure Storage paths with other types of paths (such as S3 or local file paths), you must
 provide the complete Azure Storage URLs yourself. In this case, Flux will not perform any path transformation:
 
 {% tabs log %}
@@ -304,7 +314,7 @@ provide the complete Azure Storage URLs yourself. In this case, Flux will not pe
     --path "/local/file/path" \
     --azure-storage-account "mystorage" \
     --azure-access-key "your-access-key" \
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% tab log Windows %}
@@ -315,7 +325,7 @@ bin\flux import-files ^
     --path "C:\local\file\path" ^
     --azure-storage-account "mystorage" ^
     --azure-access-key "your-access-key" ^
-    --connection-string etc... 
+    --connection-string etc...
 ```
 {% endtab %}
 {% endtabs %}

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AzureStorageParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AzureStorageParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/AzureStorageParams.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/AzureStorageParams.java
@@ -27,19 +27,25 @@ public class AzureStorageParams implements AzureStorageOptions {
 
     @CommandLine.Option(
         names = "--azure-access-key",
-        description = "Access key for Blob Storage authentication."
+        description = "Access key for Blob Storage authentication.",
+        interactive = true,
+        arity = "0..1"
     )
     private String accessKey;
 
     @CommandLine.Option(
         names = "--azure-sas-token",
-        description = "Azure SAS token for Blob Storage authentication."
+        description = "Azure SAS token for Blob Storage authentication.",
+        interactive = true,
+        arity = "0..1"
     )
     private String sasToken;
 
     @CommandLine.Option(
         names = "--azure-shared-key",
-        description = "Azure shared key for Data Lake Storage authentication."
+        description = "Azure shared key for Data Lake Storage authentication.",
+        interactive = true,
+        arity = "0..1"
     )
     private String sharedKey;
 

--- a/flux-cli/src/main/java/com/marklogic/flux/impl/S3Params.java
+++ b/flux-cli/src/main/java/com/marklogic/flux/impl/S3Params.java
@@ -48,13 +48,17 @@ public class S3Params {
 
     @CommandLine.Option(
         names = "--s3-secret-access-key",
-        description = "Specifies the AWS secret key to use for accessing S3 paths."
+        description = "Specifies the AWS secret key to use for accessing S3 paths.",
+        interactive = true,
+        arity = "0..1"
     )
     private String secretAccessKey;
 
     @CommandLine.Option(
         names = "--s3-session-token",
-        description = "Specifies the AWS session token to use, along with the access key ID and secret access key, for accessing S3 paths."
+        description = "Specifies the AWS session token to use, along with the access key ID and secret access key, for accessing S3 paths.",
+        interactive = true,
+        arity = "0..1"
     )
     private String sessionToken;
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/AzureStorageParamsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/AzureStorageParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl;
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/AzureStorageParamsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/AzureStorageParamsTest.java
@@ -9,6 +9,7 @@ import com.marklogic.flux.impl.importdata.ReadFilesParams;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.util.Arrays;
 import java.util.List;
@@ -571,5 +572,32 @@ class AzureStorageParamsTest {
         assertEquals(2, result.size());
         assertEquals("data/big-file.parquet", result.get(0));  // NOT transformed
         assertEquals("abfss://other@different.dfs.core.windows.net/existing.parquet", result.get(1));
+    }
+
+    @Test
+    void accessKeyIsInteractive() throws NoSuchFieldException {
+        CommandLine.Option ann = AzureStorageParams.class
+            .getDeclaredField("accessKey")
+            .getAnnotation(CommandLine.Option.class);
+        assertTrue(ann.interactive(), "--azure-access-key must have interactive = true");
+        assertEquals("0..1", ann.arity(), "--azure-access-key must have arity = \"0..1\"");
+    }
+
+    @Test
+    void sasTokenIsInteractive() throws NoSuchFieldException {
+        CommandLine.Option ann = AzureStorageParams.class
+            .getDeclaredField("sasToken")
+            .getAnnotation(CommandLine.Option.class);
+        assertTrue(ann.interactive(), "--azure-sas-token must have interactive = true");
+        assertEquals("0..1", ann.arity(), "--azure-sas-token must have arity = \"0..1\"");
+    }
+
+    @Test
+    void sharedKeyIsInteractive() throws NoSuchFieldException {
+        CommandLine.Option ann = AzureStorageParams.class
+            .getDeclaredField("sharedKey")
+            .getAnnotation(CommandLine.Option.class);
+        assertTrue(ann.interactive(), "--azure-shared-key must have interactive = true");
+        assertEquals("0..1", ann.arity(), "--azure-shared-key must have arity = \"0..1\"");
     }
 }

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/S3ParamsTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/S3ParamsTest.java
@@ -7,6 +7,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.util.List;
 
@@ -211,6 +212,24 @@ class S3ParamsTest {
         params.addToHadoopConfiguration(config);
         assertNotNull(config.get("fs.s3a.access.key"), "Global access key should be set when no bucket");
         assertNotNull(config.get("fs.s3a.secret.key"), "Global secret key should be set when no bucket");
+    }
+
+    @Test
+    void secretAccessKeyIsInteractive() throws NoSuchFieldException {
+        CommandLine.Option ann = S3Params.class
+            .getDeclaredField("secretAccessKey")
+            .getAnnotation(CommandLine.Option.class);
+        assertTrue(ann.interactive(), "--s3-secret-access-key must have interactive = true");
+        assertEquals("0..1", ann.arity(), "--s3-secret-access-key must have arity = \"0..1\"");
+    }
+
+    @Test
+    void sessionTokenIsInteractive() throws NoSuchFieldException {
+        CommandLine.Option ann = S3Params.class
+            .getDeclaredField("sessionToken")
+            .getAnnotation(CommandLine.Option.class);
+        assertTrue(ann.interactive(), "--s3-session-token must have interactive = true");
+        assertEquals("0..1", ann.arity(), "--s3-session-token must have arity = \"0..1\"");
     }
 
     private String getConfigValue(String key) {


### PR DESCRIPTION

## Summary

Addresses security finding FIND-001 from the Flux Security Findings Report (CVSS 7.1 High — CWE-214/CWE-312). Five cloud storage credential options previously required their values to be supplied inline on the command line, exposing secrets in shell history, `ps aux` output, and CI logs.

This PR adds `interactive = true` and `arity = "0..1"` to the five affected picocli options so that omitting the value triggers a masked (no-echo) prompt. The behavior is backward-compatible: callers that supply values inline continue to work unchanged.

## Affected Options

| Option | File |
|--------|------|
| `--s3-secret-access-key` | S3Params.java |
| `--s3-session-token` | S3Params.java |
| `--azure-access-key` | AzureStorageParams.java |
| `--azure-sas-token` | AzureStorageParams.java |
| `--azure-shared-key` | AzureStorageParams.java |

## Changes

**Production code** — 2 files, annotation-only changes:
- S3Params.java — `interactive = true, arity = "0..1"` added to `--s3-secret-access-key` and `--s3-session-token`
- AzureStorageParams.java — same added to `--azure-access-key`, `--azure-sas-token`, and `--azure-shared-key`

**Tests** — 2 files, 5 new unit test methods:
- S3ParamsTest.java — reflection-based tests verifying `interactive = true` and `arity = "0..1"` on both S3 secret fields
- AzureStorageParamsTest.java — same for all three Azure secret fields

**Documentation** — 2 files:
- selecting-files.md — added masked-prompt notes to S3 explicit credentials, Azure Blob access key, Azure Blob SAS token, and Azure Data Lake shared key sections
- specifying-path.md — same updates mirrored on the export side

## Testing

The five new reflection tests and all pre-existing tests in both classes pass. End-to-end verification of the actual masked prompt requires a manual smoke test (see story notes — picocli blocks on `System.in` at execution time and cannot be driven from the automated test suite without additional infrastructure).

---

**Running the new unit tests:**

```
.\gradlew :flux-cli:test --tests "com.marklogic.flux.impl.S3ParamsTest" --tests "com.marklogic.flux.impl.AzureStorageParamsTest"
```

These are pure unit tests — no MarkLogic server, no Docker, no additional setup required. 


- Jira Story: [MLE-31204](https://progresssoftware.atlassian.net/browse/MLE-31204)


[MLE-31204]: https://progresssoftware.atlassian.net/browse/MLE-31204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ