### PR TITLE
MLE-31394: [HIGH] BDSA-2026-3557 / CVE-2026-24281 in Apache ZooKeeper v3.9.4 (MarkLogic-DevExp-flux)[WIP]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,12 @@ subprojects {
        details.because "Forces Spark 4.1.x to use latest log4j 2.x to eliminate CVEs."
      }
 
+     if (details.requested.group.equals("org.apache.zookeeper") &&
+       (details.requested.name.equals("zookeeper") || details.requested.name.equals("zookeeper-jute"))) {
+       details.useVersion "${zookeeperVersion}"
+       details.because "Force Apache ZooKeeper to ${zookeeperVersion} to remediate CVE-2026-24281."
+     }
+
      if (details.requested.group.startsWith("com.fasterxml.jackson")) {
        if (details.requested.name == "jackson-annotations") {
          // This oddly does not have a 2.21.0 or 2.21.1 release, just 2.21.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ awssdkVersion=2.29.52
 nettyVersion=4.2.16.Final
 langchain4jVersion=1.17.2
 tikaVersion=3.3.1
+zookeeperVersion=3.9.5
 
 # Define these on the command line to publish to OSSRH
 # See https://central.sonatype.org/publish/publish-gradle/#credentials for more information


### PR DESCRIPTION
## Title
MLE-31394: Remediate CVE-2026-24281 by forcing Apache ZooKeeper 3.9.5

## Summary
This PR remediates BDSA-2026-3557 / CVE-2026-24281 (HIGH) in Apache ZooKeeper by forcing transitive ZooKeeper dependencies to the patched version, 3.9.5.

Spark 4.1.1 currently pulls ZooKeeper transitively (including 3.9.4). Since this vulnerability is in a transitive dependency path, the fix is applied centrally via Gradle resolution strategy so all subprojects inherit it.

## Changes
1. Added a shared ZooKeeper version property:
- gradle.properties

2. Added dependency resolution rules to force:
- org.apache.zookeeper:zookeeper -> 3.9.5
- org.apache.zookeeper:zookeeper-jute -> 3.9.5
- build.gradle

## Validation
Dependency resolution was verified with Gradle dependency insight on the Flux CLI runtime classpath:
1. org.apache.zookeeper:zookeeper resolves to 3.9.5
2. org.apache.zookeeper:zookeeper-jute resolves to 3.9.5
3. Selection reason shows the explicit remediation rule was applied

## Risk / Impact
1. Low-to-moderate change risk: dependency version override only, no application logic changes.
2. Broad coverage: applies across subprojects via shared root build configuration.
3. Expected benefit: removes vulnerable 3.9.4 resolution path flagged by BlackDuck.

## Notes
1. This is the most practical immediate remediation for a transitive vulnerability.
2. Long-term cleanup: remove the override once upstream dependencies (for example Spark/Curator) natively resolve to 3.9.5+.