### PR TITLE
MLE-31399 update janino to 3.1.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ subprojects {
        details.useVersion "0.23.0"
        details.because "Forces Spark 4.1.x to use the latest libthrift, which is needed to avoid CVEs."
      }
+
+     if (details.requested.group.equals("org.codehaus.janino")) {
+       details.useVersion "${janinoVersion}"
+       details.because "Forces Janino to ${janinoVersion} to address CVE-2023-33546."
+     }
    }
  }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ jacksonVersion=2.21.5
 awssdkVersion=2.35.4
 
 nettyVersion=4.2.16.Final
+janinoVersion=3.1.12
 langchain4jVersion=1.17.2
 tikaVersion=3.3.1
 


### PR DESCRIPTION
Fixed BDSA-2023-1535 / CVE-2023-33546 in Janino v3.1.9 by forcing Janino to 3.1.12.