### PR TITLE
MLE-31396 update tika to 3.3.2

### DIFF
--- a/docs/import/import-files/generic-files.md
+++ b/docs/import/import-files/generic-files.md
@@ -131,6 +131,17 @@ As of Flux 1.3.0, text can be extracted from files via [Apache Tika](https://tik
 documents in MarkLogic. This is typically useful when importing binary content such as PDF and Word files, where both
 the binary file and extracted text can be stored in MarkLogic.
 
+### Behavior change in Flux 2.1.2: Microsoft Office file extraction
+
+Flux 2.1.2 upgrades Apache Tika from 3.3.1 to 3.3.2. Tika 3.3.2 changes the default parser for Microsoft Office OOXML
+files (`.docx`, `.pptx`, `.xlsx`, `.vsdx`) from a DOM-based extractor to a SAX-based extractor. The SAX parser is
+faster and more memory-efficient, but may produce slightly different whitespace in extracted text compared to previous
+Flux versions — for example, paragraph separators may differ.
+
+If your application depends on the exact text output from Office files and you need the previous DOM-based behavior,
+you can restore it by providing a [Tika configuration file](https://tika.apache.org/3.3.2/configuring.html) that
+sets `useSAXDocxExtractor` and/or `useSAXPptxExtractor` to `false` on the `OfficeParserConfig`.
+
 Text extraction is enabled by including the following option when executing the `import-files` command:
 
     --extract-text

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ExtractTextTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ExtractTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2024-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.flux.impl.importdata;
 

--- a/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ExtractTextTest.java
+++ b/flux-cli/src/test/java/com/marklogic/flux/impl/importdata/ExtractTextTest.java
@@ -55,7 +55,7 @@ class ExtractTextTest extends AbstractTest {
         assertCollectionSize(collection, 2);
         JsonNode doc = readJsonDocument("/extraction-files/hello-world.docx-extracted-text.json", collection);
         assertEquals("/extraction-files/hello-world.docx", doc.get("source-uri").asText());
-        assertEquals("Hello world.\n\nThis file is used for testing text extraction.\n", doc.get("content").asText());
+        assertEquals("Hello world.\nThis file is used for testing text extraction.\n", doc.get("content").asText());
         assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             doc.get("extracted-metadata").get("Content-Type").asText());
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ awssdkVersion=2.35.4
 nettyVersion=4.2.16.Final
 janinoVersion=3.1.12
 langchain4jVersion=1.17.2
-tikaVersion=3.3.1
+tikaVersion=3.3.2
 
 # Define these on the command line to publish to OSSRH
 # See https://central.sonatype.org/publish/publish-gradle/#credentials for more information


### PR DESCRIPTION
Fixed BDSA-2026-3678 / CVE-2026-23907 in Apache PDFBox v3.0.7 by upgrading Tika to 3.3.2 since tika-parser-pdf-module:3.3.2 already depends on pdfbox:3.0.8 and pdfbox-tools:3.0.8 directly. 