### PR TITLE
MLE-31763 org.apache.thrift to 0.24.0 to match Spark Connector Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,9 @@ subprojects {
 
      if (details.requested.group.equals("org.apache.thrift") && details.requested.name.equals("libthrift")) {
        // This is being done solely for Black Duck's sake, as it seems to be having trouble recognizing that the
-       // internal snapshot build of the MarkLogic Spark connector is already using version 0.23.0.
-       details.useVersion "0.23.0"
-       details.because "Forces Spark 4.1.x to use the latest libthrift, which is needed to avoid CVEs."
+       // internal snapshot build of the MarkLogic Spark connector is already using version 0.24.0.
+       details.useVersion "0.24.0"
+       details.because "Forces Spark 4.2.x to use the latest libthrift, which is needed to avoid CVEs."
      }
 
      if (details.requested.group.equals("org.codehaus.janino")) {


### PR DESCRIPTION
Bump org.apache.thrift to 0.24.0 to match Spark Connector Version to avoid CVEs.

Jira Ticket: https://progresssoftware.atlassian.net/browse/MLE-31763
PR for the same bump in Spark Connector: https://github.com/marklogic/marklogic-spark-connector/pull/686