### PR TITLE
MLE-31502 Fixed filtering-data.md ToC

### DIFF
--- a/docs/import/structured-data/filtering-data.md
+++ b/docs/import/structured-data/filtering-data.md
@@ -13,7 +13,7 @@ use `--where` to filter rows, and `--drop` to exclude columns.
 {: .no_toc .text-delta }
 
 - TOC
-  {:toc}
+{:toc}
 
 ## Supported commands
 


### PR DESCRIPTION
Fixed the rendering for the table of contents in the filtering-data.md file.

Locally verified using Ruby 3.2.11 running the command `bundle exec jekyll serve`

Jira Ticket: https://progresssoftware.atlassian.net/browse/MLE-31502